### PR TITLE
[test] Update references

### DIFF
--- a/cscs-checks/apps/cp2k/cp2k_check.py
+++ b/cscs-checks/apps/cp2k/cp2k_check.py
@@ -56,13 +56,13 @@ class Cp2kCpuCheck(Cp2kCheck):
     valid_systems = ['daint:mc', 'eiger:mc', 'pilatus:mc']
     refs_by_scale = {
         'small': {
-            'dom:mc': {'time': (164, None, 0.07, 's')},
-            'daint:mc': {'time': (164, None, 0.07, 's')},
+            'dom:mc': {'time': (157.0, None, 0.05, 's')},
+            'daint:mc': {'time': (157.0, None, 0.10, 's')},
             'eiger:mc': {'time': (70.0, None, 0.08, 's')},
             'pilatus:mc': {'time': (70.0, None, 0.08, 's')}
         },
         'large': {
-            'daint:mc': {'time': (120, None, 0.15, 's')},
+            'daint:mc': {'time': (122.0, None, 0.10, 's')},
             'eiger:mc': {'time': (46.0, None, 0.05, 's')},
             'pilatus:mc': {'time': (46.0, None, 0.05, 's')}
         }
@@ -130,11 +130,11 @@ class Cp2kGpuCheck(Cp2kCheck):
     }
     refs_by_scale = {
         'small': {
-            'dom:gpu': {'time': (234, None, 0.05, 's')},
-            'daint:gpu': {'time': (234, None, 0.05, 's')}
+            'dom:gpu': {'time': (182.0, None, 0.05, 's')},
+            'daint:gpu': {'time': (182.0, None, 0.10, 's')}
         },
         'large': {
-            'daint:gpu': {'time': (147, None, 0.05, 's')}
+            'daint:gpu': {'time': (139.0, None, 0.10, 's')}
         }
     }
 

--- a/cscs-checks/apps/cpmd/cpmd_check.py
+++ b/cscs-checks/apps/cpmd/cpmd_check.py
@@ -27,19 +27,19 @@ class CPMDCheck(rfm.RunOnlyRegressionTest):
         6: {
             'sm_60': {
                 'dom:gpu': {'elapsed_time': (120.0, None, 0.15, 's')},
-                'daint:gpu': {'elapsed_time': (120.0, None, 0.15, 's')},
+                'daint:gpu': {'elapsed_time': (192.0, None, 0.10, 's')},
             },
             'broadwell': {
                 'dom:mc': {'elapsed_time': (150.0, None, 0.15, 's')},
-                'daint:mc': {'elapsed_time': (150.0, None, 0.15, 's')},
+                'daint:mc': {'elapsed_time': (237.0, None, 0.10, 's')},
             },
         },
         16: {
             'sm_60': {
-                'daint:gpu': {'elapsed_time': (120.0, None, 0.15, 's')}
+                'daint:gpu': {'elapsed_time': (212.0, None, 0.10, 's')}
             },
             'broadwell': {
-                'daint:mc': {'elapsed_time': (150.0, None, 0.15, 's')},
+                'daint:mc': {'elapsed_time': (309.0, None, 0.10, 's')},
             },
         }
     }

--- a/cscs-checks/apps/lammps/lammps_check.py
+++ b/cscs-checks/apps/lammps/lammps_check.py
@@ -59,10 +59,10 @@ class LAMMPSGPUCheck(LAMMPSCheck):
     refs_by_scale = {
         'small': {
             'dom:gpu': {'perf': (3132, -0.05, None, 'timesteps/s')},
-            'daint:gpu': {'perf': (2660, -0.35, None, 'timesteps/s')}
+            'daint:gpu': {'perf': (1463, -0.10, None, 'timesteps/s')}
         },
         'large': {
-            'daint:gpu': {'perf': (3430, -0.50, None, 'timesteps/s')}
+            'daint:gpu': {'perf': (1702, -0.10, None, 'timesteps/s')}
         }
     }
 
@@ -86,12 +86,12 @@ class LAMMPSCPUCheck(LAMMPSCheck):
     refs_by_scale = {
         'small': {
             'dom:mc': {'perf': (4394, -0.05, None, 'timesteps/s')},
-            'daint:mc': {'perf': (3350, -0.30, None, 'timesteps/s')},
+            'daint:mc': {'perf': (2348, -0.10, None, 'timesteps/s')},
             'eiger:mc': {'perf': (4500, -0.10, None, 'timesteps/s')},
             'pilatus:mc': {'perf': (5000, -0.10, None, 'timesteps/s')}
         },
         'large': {
-            'daint:mc': {'perf': (5360, -0.30, None, 'timesteps/s')},
+            'daint:mc': {'perf': (2075, -0.10, None, 'timesteps/s')},
             'eiger:mc': {'perf': (6500, -0.10, None, 'timesteps/s')},
             'pilatus:mc': {'perf': (7500, -0.10, None, 'timesteps/s')}
         }

--- a/cscs-checks/apps/quantumespresso/quantumespresso_check.py
+++ b/cscs-checks/apps/quantumespresso/quantumespresso_check.py
@@ -98,12 +98,12 @@ class QuantumESPRESSOCpuCheck(QuantumESPRESSOCheck):
         references = {
             'small': {
                 'dom:mc': {'time': (110.0, None, 0.05, 's')},
-                'daint:mc': {'time': (110.0, None, 0.20, 's')},
+                'daint:mc': {'time': (127.0, None, 0.10, 's')},
                 'eiger:mc': {'time': (66.0, None, 0.10, 's')},
                 'pilatus:mc': {'time': (66.0, None, 0.10, 's')}
             },
             'large': {
-                'daint:mc': {'time': (145.0, None, 0.30, 's')},
+                'daint:mc': {'time': (171.0, None, 0.10, 's')},
                 'eiger:mc': {'time': (53.0, None, 0.10, 's')},
                 'pilatus:mc': {'time': (53.0, None, 0.10, 's')}
             }
@@ -147,7 +147,7 @@ class QuantumESPRESSOGpuCheck(QuantumESPRESSOCheck):
                 'daint:gpu': {'time': (59.0, None, 0.05, 's')}
             },
             'large': {
-                'daint:gpu': {'time': (39.0, None, 0.05, 's')}
+                'daint:gpu': {'time': (40.0, None, 0.05, 's')}
             }
         }
         self.reference = references[self.scale]

--- a/cscs-checks/apps/vasp/vasp_check.py
+++ b/cscs-checks/apps/vasp/vasp_check.py
@@ -27,11 +27,11 @@ class VASPCheck(rfm.RunOnlyRegressionTest):
         6: {
             'sm_60': {
                 'dom:gpu': {'elapsed_time': (56.0, None, 0.10, 's')},
-                'daint:gpu': {'elapsed_time': (65.0, None, 0.15, 's')},
+                'daint:gpu': {'elapsed_time': (66.0, None, 0.10, 's')},
             },
             'broadwell': {
                 'dom:mc': {'elapsed_time': (58.0, None, 0.10, 's')},
-                'daint:mc': {'elapsed_time': (65.0, None, 0.15, 's')},
+                'daint:mc': {'elapsed_time': (65.0, None, 0.10, 's')},
             },
             'zen2': {
                 'eiger:mc': {'elapsed_time': (100.0, None, 0.10, 's')},
@@ -40,10 +40,10 @@ class VASPCheck(rfm.RunOnlyRegressionTest):
         },
         16: {
             'sm_60': {
-                'daint:gpu': {'elapsed_time': (55.0, None, 0.15, 's')},
+                'daint:gpu': {'elapsed_time': (78.0, None, 0.10, 's')},
             },
             'broadwell': {
-                'daint:mc': {'elapsed_time': (55.0, None, 0.15, 's')},
+                'daint:mc': {'elapsed_time': (131.0, None, 0.10, 's')},
             },
             'zen2': {
                 'eiger:mc': {'elapsed_time': (100.0, None, 0.10, 's')},


### PR DESCRIPTION
I propose to update the reference values of the checks that sometimes fail to meet the expected performance, based on the [percentiles of April 1st|https://kibana.cscs.ch/s/scs/goto/24f08c40-d078-11ec-9f58-45e10c97e13e]: the values of May 1st are somewhat larger, but they might have been affected by temporary issues on the system, therefore we will keep monitoring the references. Therefore, I would keep the tolerance to 10% rather than the strict 5% as it should be (see Dom).