### PR TITLE
[bugfix] Check that PBS output is written back to working directory before setting the job as completed

### DIFF
--- a/reframe/core/schedulers/pbs.py
+++ b/reframe/core/schedulers/pbs.py
@@ -205,16 +205,12 @@ class PbsJobScheduler(sched.JobScheduler):
         # Otherwise, it will return with return code 0 and print information
         # only for the jobs it could find.
         if completed.returncode in (153, 35):
-            self.log(f'Return code is {completed.returncode}: '
-                     f'assuming all jobs completed')
+            self.log(f'Return code is {completed.returncode}')
             for job in jobs:
                 job._state = 'COMPLETED'
                 if job.cancelled or output_ready(job):
+                    self.log(f'Assuming job {job.jobid} completed')
                     job._completed = True
-                else:
-                    self.log(f'Job {job.jobid} output has not been written '
-                             f'back to working directory yet; will poll '
-                             f'again later')
 
             return
 
@@ -236,15 +232,11 @@ class PbsJobScheduler(sched.JobScheduler):
 
         for job in jobs:
             if job.jobid not in jobinfo:
-                self.log(f'Job {job.jobid} not known to scheduler, '
-                         f'assuming job completed')
+                self.log(f'Job {job.jobid} not known to scheduler')
                 job._state = 'COMPLETED'
                 if job.cancelled or output_ready(job):
+                    self.log(f'Assuming job {job.jobid} completed')
                     job._completed = True
-                else:
-                    self.log(f'Job {job.jobid} output has not been written '
-                             f'back to working directory yet; will poll '
-                             f'again later')
 
                 continue
 

--- a/reframe/core/schedulers/pbs.py
+++ b/reframe/core/schedulers/pbs.py
@@ -181,7 +181,7 @@ class PbsJobScheduler(sched.JobScheduler):
         job._nodelist.sort()
 
     def poll(self, *jobs):
-        def out_ready(job):
+        def output_ready(job):
             # We report a job as finished only when its stdout/stderr are
             # written back to the working directory
             stdout = os.path.join(job.workdir, job.stdout)
@@ -209,7 +209,7 @@ class PbsJobScheduler(sched.JobScheduler):
                      f'assuming all jobs completed')
             for job in jobs:
                 job._state = 'COMPLETED'
-                if job.cancelled or out_ready(job):
+                if job.cancelled or output_ready(job):
                     job._completed = True
                 else:
                     self.log(f'Job {job.jobid} output has not been written '
@@ -239,7 +239,7 @@ class PbsJobScheduler(sched.JobScheduler):
                 self.log(f'Job {job.jobid} not known to scheduler, '
                          f'assuming job completed')
                 job._state = 'COMPLETED'
-                if job.cancelled or out_ready(job):
+                if job.cancelled or output_ready(job):
                     job._completed = True
                 else:
                     self.log(f'Job {job.jobid} output has not been written '
@@ -277,7 +277,7 @@ class PbsJobScheduler(sched.JobScheduler):
 
                 # We report a job as finished only when its stdout/stderr are
                 # written back to the working directory
-                done = job.cancelled or out_ready(job)
+                done = job.cancelled or output_ready(job)
                 if done:
                     job._completed = True
             elif (job.state in ['QUEUED', 'HELD', 'WAITING'] and


### PR DESCRIPTION
Pbs jobs can appear as completed before the stdout and stderr are written back to the working directory.
Fixes #2518 .
It might also be the reason @cblackworth-anl was getting this error in #1930.