### PR TITLE
[bugfix] Improve detection of ReFrame test files

### DIFF
--- a/cscs-checks/microbenchmarks/gpu/gpu_burn/gpu_burn_test.py
+++ b/cscs-checks/microbenchmarks/gpu/gpu_burn/gpu_burn_test.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-import reframe as rfm   # noqa: F501
+import reframe as rfm
 from hpctestlib.microbenchmarks.gpu.gpu_burn import gpu_burn_check
 
 


### PR DESCRIPTION
Now not only files that import `reframe` are consider, but also files that use the `@simple_test` decorator.

Fixes #2502.