### PR TITLE
[testlib] Fix broken symlinks to the Xdevice header library

### DIFF
--- a/hpctestlib/microbenchmarks/gpu/dgemm/src/Xdevice
+++ b/hpctestlib/microbenchmarks/gpu/dgemm/src/Xdevice
@@ -1,1 +1,1 @@
-../../Xdevice/
+../../src/common/Xdevice/

--- a/hpctestlib/microbenchmarks/gpu/kernel_latency/src/Xdevice
+++ b/hpctestlib/microbenchmarks/gpu/kernel_latency/src/Xdevice
@@ -1,1 +1,1 @@
-../../Xdevice/
+../../src/common/Xdevice/

--- a/hpctestlib/microbenchmarks/gpu/memory_bandwidth/src/Xdevice
+++ b/hpctestlib/microbenchmarks/gpu/memory_bandwidth/src/Xdevice
@@ -1,1 +1,1 @@
-../../Xdevice/
+../../src/common/Xdevice/

--- a/hpctestlib/microbenchmarks/gpu/pointer_chase/src/Xdevice
+++ b/hpctestlib/microbenchmarks/gpu/pointer_chase/src/Xdevice
@@ -1,1 +1,1 @@
-../../Xdevice/
+../../src/common/Xdevice/

--- a/hpctestlib/microbenchmarks/gpu/shmem/src/Xdevice
+++ b/hpctestlib/microbenchmarks/gpu/shmem/src/Xdevice
@@ -1,1 +1,1 @@
-../../Xdevice/
+../../src/common/Xdevice/


### PR DESCRIPTION
That's a bug introduced with #2503 and exposed by the CI of https://github.com/eth-cscs/cscs-reframe-tests/pull/2.