### PR TITLE
[bugfix] Reset poll rate every time a test finishes the compilation or run phase

### DIFF
--- a/reframe/frontend/executors/policies.py
+++ b/reframe/frontend/executors/policies.py
@@ -51,10 +51,11 @@ class _PollController:
 
     def reset_snooze_time(self):
         self._sleep_duration = self.SLEEP_MIN
+
+    def snooze(self):
         if self._num_polls == 0:
             self._t_init = time.time()
 
-    def snooze(self):
         t_elapsed = time.time() - self._t_init
         self._num_polls += 1
         poll_rate = self._num_polls / t_elapsed if t_elapsed else math.inf
@@ -310,7 +311,6 @@ class AsynchronousExecutionPolicy(ExecutionPolicy, TaskEventListener):
             self._init_pipeline_progress(len(self._current_tasks))
 
         self._pollctl.reset_snooze_time()
-
         while self._current_tasks:
             try:
                 self._poll_tasks()


### PR DESCRIPTION
One other thing we have talked about and would make sense to do in this PR is to expose `SLEEP_MIN`, `SLEEP_MAX` and `SLEEP_INC_RATE` in the configuration. It would be better to do it by partition but it would require more changes so maybe it's better to open an issue and do it in the next sprint. What do you think @vkarak ?

Fixes #2531.