### PR TITLE
[feat] Do not require to set `container_platform` for running containerised tests

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -472,6 +472,16 @@ ReFrame can launch containerized applications, but you need to configure properl
    - ``Singularity``: The `Singularity <https://sylabs.io/>`__ container runtime.
 
 
+.. js:attribute:: .systems[].partitions[].container_platforms[].default
+
+   :required: No
+
+   If set to ``true``, this is the default container platform of this partition.
+   If not specified, the default container platform is assumed to be the first in the list of :js:attr:`container_platforms`.
+
+   .. versionadded:: 3.12.0
+
+
 .. js:attribute:: .systems[].partitions[].container_platforms[].modules
 
    :required: No

--- a/docs/tutorial_advanced.rst
+++ b/docs/tutorial_advanced.rst
@@ -782,13 +782,14 @@ Otherwise, the *bare metal* version of the tested application will be run.
 The following test uses exactly this trick to test a series of GROMACS images as well as the native one provided on the Piz Daint supercomputer.
 It also extends the GROMACS benchmark tests that are provided with ReFrame's test library (see :doc:`hpctestlib`).
 For simplicity, we are assuming a single system here (the hybrid partition of Piz Daint) and we set fixed values for the :attr:`num_cpus_per_task` as well as the ``-ntomp`` option of GROMACS (NB: in a real-world test we would use the auto-detected processor topology information to set these values; see :ref:`proc-autodetection` for more information).
+We also redefine and restrict the benchmark's parameters ``benchmark_info`` and ``nb_impl`` to the values that are of interest for the demonstration of this test.
 Finally, we also reset the executable to use ``gmx`` instead of the ``gmx_mpi`` that is used from the library test.
 
 
 .. literalinclude:: ../tutorials/advanced/containers/gromacs_test.py
    :start-after: # rfmdocstart: gromacstest
 
-All this test does is to set the :attr:`~reframe.core.containers.ContainerPlatform.image` and the :attr:`~reframe.core.containers.ContainerPlatform.command` attributes of the :attr:`~reframe.core.pipeline.RegressionTest.container_platform`.
+All this test does in addition to the library test it inherits from is to set the :attr:`~reframe.core.containers.ContainerPlatform.image` and the :attr:`~reframe.core.containers.ContainerPlatform.command` attributes of the :attr:`~reframe.core.pipeline.RegressionTest.container_platform`.
 The former is set from the ``gromacs_image`` test parameter whereas the latter from the test's :attr:`~reframe.core.pipeline.RegressionTest.executable` and :attr:`~reframe.core.pipeline.RegressionTest.executable_opts` attributes.
 Remember that these attributes are ignored if the framework takes the path of launching  a container.
 Finally, if the image is :obj:`None` we handle the case of the native run, in which case we load the modules required to run GROMACS natively on the target system.
@@ -797,7 +798,7 @@ In the following, we run the GPU version of a single benchmark with a series of 
 
 .. code-block:: console
 
-   $ ./bin/reframe -C tutorials/config/settings.py -c tutorials/advanced/containers/gromacs_test.py -n '.*hEGFRDimerSmallerPL.*nb_impl=gpu.*' -r
+   $ ./bin/reframe -C tutorials/config/settings.py -c tutorials/advanced/containers/gromacs_test.py -r
 
 .. code-block:: console
 
@@ -827,17 +828,17 @@ We can also inspect the generated job scripts for the native and a containerized
 
 .. code-block:: console
 
-   cat output/daint/gpu/gnu/gromacs_containerized_test_42/rfm_gromacs_containerized_test_42_job.sh
+   cat output/daint/gpu/gnu/gromacs_containerized_test_0/rfm_gromacs_containerized_test_0_job.sh
 
 .. code-block:: bash
 
    #!/bin/bash
-   #SBATCH --job-name="rfm_gromacs_containerized_test_42_job"
+   #SBATCH --job-name="rfm_gromacs_containerized_test_0_job"
    #SBATCH --ntasks=1
    #SBATCH --ntasks-per-node=1
    #SBATCH --cpus-per-task=12
-   #SBATCH --output=rfm_gromacs_containerized_test_42_job.out
-   #SBATCH --error=rfm_gromacs_containerized_test_42_job.err
+   #SBATCH --output=rfm_gromacs_containerized_test_0_job.out
+   #SBATCH --error=rfm_gromacs_containerized_test_0_job.err
    #SBATCH -A csstaff
    #SBATCH --constraint=gpu
    #SBATCH --hint=nomultithread
@@ -852,17 +853,17 @@ And the containerized run:
 
 .. code-block:: console
 
-   cat output/daint/gpu/gnu/gromacs_containerized_test_43/rfm_gromacs_containerized_test_43_job.sh
+   cat output/daint/gpu/gnu/gromacs_containerized_test_1/rfm_gromacs_containerized_test_1_job.sh
 
 .. code-block:: bash
 
    #!/bin/bash
-   #SBATCH --job-name="rfm_gromacs_containerized_test_43_job"
+   #SBATCH --job-name="rfm_gromacs_containerized_test_1_job"
    #SBATCH --ntasks=1
    #SBATCH --ntasks-per-node=1
    #SBATCH --cpus-per-task=12
-   #SBATCH --output=rfm_gromacs_containerized_test_43_job.out
-   #SBATCH --error=rfm_gromacs_containerized_test_43_job.err
+   #SBATCH --output=rfm_gromacs_containerized_test_1_job.out
+   #SBATCH --error=rfm_gromacs_containerized_test_1_job.err
    #SBATCH -A csstaff
    #SBATCH --constraint=gpu
    #SBATCH --hint=nomultithread

--- a/docs/tutorial_advanced.rst
+++ b/docs/tutorial_advanced.rst
@@ -683,6 +683,9 @@ First, we need to enable the container platform support in ReFrame's configurati
 For each partition, users can define a list of container platforms supported using the :js:attr:`container_platforms` `configuration parameter <config_reference.html#.systems[].partitions[].container_platforms>`__.
 In this case, we define the `Sarus <https://github.com/eth-cscs/sarus>`__ platform for which we set the :js:attr:`modules` parameter in order to instruct ReFrame to load the ``sarus`` module, whenever it needs to run with this container platform.
 Similarly, we add an entry for the `Singularity <https://sylabs.io>`__ platform.
+Optionally, users are allowed to set the ``default`` attribute to :obj:`True` in order to mark a specific container platform as the default of that partition (see below on how this information is being used).
+If no default container platform is specified explicitly, then always the first in the list will be considered as suc
+
 
 The following parameterized test, will create two tests, one for each of the supported container platforms:
 
@@ -698,14 +701,17 @@ The following parameterized test, will create two tests, one for each of the sup
 
 A container-based test can be written as :class:`~reframe.core.pipeline.RunOnlyRegressionTest` that sets the :attr:`~reframe.core.pipeline.RegressionTest.container_platform` attribute.
 This attribute accepts a string that corresponds to the name of the container platform that will be used to run the container for this test.
-If such a platform is not `configured <config_reference.html#container-platform-configuration>`__ for the current system, the test will fail.
+It is not necessary to specify this attribute, in which case, the default container platform of the current partition will be used.
+You can still differentiate your test based on the actual container platform that is being used by checking the ``self.container_platform.name`` variable.
 
-As soon as the container platform to be used is defined, you need to specify the container image to use by setting the :attr:`~reframe.core.containers.ContainerPlatform.image`.
+As soon as the container platform to be used is determined, you need to specify the container image to use by setting the :attr:`~reframe.core.containers.ContainerPlatform.image`.
+If the image is not specified, then the container logic is skipped and the test executes as if the :attr:`~reframe.core.pipeline.RegressionTest.container_platform` was never set.
+
 In the ``Singularity`` test variant, we add the ``docker://`` prefix to the image name, in order to instruct ``Singularity`` to pull the image from `DockerHub <https://hub.docker.com/>`__.
 The default command that the container runs can be overwritten by setting the :attr:`~reframe.core.containers.ContainerPlatform.command` attribute of the container platform.
 
 The :attr:`~reframe.core.containers.ContainerPlatform.image` is the only mandatory attribute for container-based checks.
-It is important to note that the :attr:`~reframe.core.pipeline.RegressionTest.executable` and :attr:`~reframe.core.pipeline.RegressionTest.executable_opts` attributes of the actual test are ignored in case of container-based tests.
+It is important to note that the :attr:`~reframe.core.pipeline.RegressionTest.executable` and :attr:`~reframe.core.pipeline.RegressionTest.executable_opts` attributes of the actual test are ignored if the containerized code path is taken, i.e., when :attr:`~reframe.core.containers.ContainerPlatform.image` is not :obj:`None`.
 
 ReFrame will run the container according to the given platform as follows:
 
@@ -757,6 +763,11 @@ Therefore, the ``release.txt`` file can now be used in the subsequent sanity che
 
 For a complete list of the available attributes of a specific container platform, please have a look at the :ref:`container-platforms` section of the :doc:`regression_test_api` guide.
 On how to configure ReFrame for running containerized tests, please have a look at the :ref:`container-platform-configuration` section of the :doc:`config_reference`.
+
+
+.. versionchanged:: 3.12.0
+   There is no need any more to explicitly set the :attr:`container_platform` in the test.
+   This is automatically initialized from the default platform of the current partition.
 
 
 Writing reusable tests

--- a/docs/tutorial_advanced.rst
+++ b/docs/tutorial_advanced.rst
@@ -684,7 +684,7 @@ For each partition, users can define a list of container platforms supported usi
 In this case, we define the `Sarus <https://github.com/eth-cscs/sarus>`__ platform for which we set the :js:attr:`modules` parameter in order to instruct ReFrame to load the ``sarus`` module, whenever it needs to run with this container platform.
 Similarly, we add an entry for the `Singularity <https://sylabs.io>`__ platform.
 Optionally, users are allowed to set the ``default`` attribute to :obj:`True` in order to mark a specific container platform as the default of that partition (see below on how this information is being used).
-If no default container platform is specified explicitly, then always the first in the list will be considered as suc
+If no default container platform is specified explicitly, then always the first in the list will be considered as successful.
 
 
 The following parameterized test, will create two tests, one for each of the supported container platforms:

--- a/docs/tutorial_advanced.rst
+++ b/docs/tutorial_advanced.rst
@@ -770,6 +770,32 @@ On how to configure ReFrame for running containerized tests, please have a look 
    This is automatically initialized from the default platform of the current partition.
 
 
+
+Combining containerized and native application tests
+====================================================
+
+.. versionadded:: 3.12.0
+
+It is very easy in ReFrame to have a single run-only test to either test the native or the containerized version of an application.
+This is possible, since the framework will only take the "containerized" code path only if the :attr:`~reframe.core.containers.ContainerPlatform.image` attribute of the :attr:`~reframe.core.pipeline.RegressionTest.container_platform` is not :obj:`None`.
+Otherwise, the *bare metal* version of the tested application will be run.
+The following test uses exactly this trick to test a series of GROMACS images as well as the native one provided on the Piz Daint supercomputer.
+It also extends the GROMACS benchmark tests that are provided with ReFrame's test library (see :doc:`hpctestlib`).
+For simplicity, we are assuming a single system here (the hybrid partition of Piz Daint) and we set fixed values for the :attr:`num_cpus_per_task` as well as the ``-ntomp`` option of GROMACS (NB: in a real-world test we would use the auto-detected processor topology information to set these values; see :ref:`proc-autodetection` for more information).
+Finally, we also reset the executable to use ``gmx`` instead of the ``gmx_mpi`` that is used from the library test.
+
+
+.. literalinclude:: ../tutorials/advanced/containers/gromacs_test.py
+   :start-after: # rfmdocstart: gromacstest
+
+All this test does is to set the :attr:`~reframe.core.containers.ContainerPlatform.image` and the :attr:`~reframe.core.containers.ContainerPlatform.command` attributes of the :attr:`~reframe.core.pipeline.RegressionTest.container_platform`.
+The former is set from the ``gromacs_image`` test parameter whereas the latter from the test's :attr:`~reframe.core.pipeline.RegressionTest.executable` and :attr:`~reframe.core.pipeline.RegressionTest.executable_opts` attributes.
+Remember that these attributes are ignored if the framework takes the path of launching  a container.
+Finally, if the image is :obj:`None` we handle the case of the native run, in which case we load the modules required to run GROMACS natively on the target system.
+
+
+
+
 Writing reusable tests
 ----------------------
 

--- a/reframe/core/containers.py
+++ b/reframe/core/containers.py
@@ -7,6 +7,7 @@ import abc
 
 import reframe.core.fields as fields
 import reframe.core.warnings as warn
+import reframe.utility as util
 import reframe.utility.typecheck as typ
 
 
@@ -194,7 +195,7 @@ class Docker(ContainerPlatform):
 
         if self.commands:
             return (f"docker run --rm {' '.join(run_opts)} {self.image} "
-                    f"bash -c 'cd {self.workdir}; {'; '.join(self.commands)}'")
+                    f"bash -c '{'; '.join(self.commands)}'")
 
         return f'docker run --rm {" ".join(run_opts)} {self.image}'
 
@@ -236,14 +237,13 @@ class Sarus(ContainerPlatform):
             run_opts.append(f'-w {self.workdir}')
 
         run_opts += self.options
-
         if self.command:
             return (f'{self._command} run {" ".join(run_opts)} {self.image} '
                     f'{self.command}')
 
         if self.commands:
             return (f"{self._command} run {' '.join(run_opts)} {self.image} "
-                    f"bash -c 'cd {self.workdir}; {'; '.join(self.commands)}'")
+                    f"bash -c '{'; '.join(self.commands)}'")
 
         return f'{self._command} run {" ".join(run_opts)} {self.image}'
 
@@ -256,6 +256,12 @@ class Shifter(Sarus):
     def __init__(self):
         super().__init__()
         self._command = 'shifter'
+
+    def launch_command(self, stagedir):
+        # Temporarily change `workdir`, since Sarus and Shifter have otherwise
+        # the same interface
+        with util.temp_setattr(self, 'workdir', None):
+            return super().launch_command(stagedir)
 
 
 class Singularity(ContainerPlatform):
@@ -292,7 +298,7 @@ class Singularity(ContainerPlatform):
 
         if self.commands:
             return (f"singularity exec {' '.join(run_opts)} {self.image} "
-                    f"bash -c 'cd {self.workdir}; {'; '.join(self.commands)}'")
+                    f"bash -c '{'; '.join(self.commands)}'")
 
         return f'singularity run {" ".join(run_opts)} {self.image}'
 

--- a/reframe/core/containers.py
+++ b/reframe/core/containers.py
@@ -88,6 +88,9 @@ class ContainerPlatform(abc.ABC):
     #:
     #: :type: :class:`str`
     #: :default: ``/rfm_workdir``
+    #:
+    #: .. versionchanged:: 3.12.0
+    #:    This attribute is no more deprecated.
     workdir = fields.TypedField(str, type(None))
 
     def __init__(self):

--- a/reframe/core/containers.py
+++ b/reframe/core/containers.py
@@ -7,7 +7,6 @@ import abc
 
 import reframe.core.fields as fields
 import reframe.utility.typecheck as typ
-from reframe.core.exceptions import ContainerError
 
 
 _STAGEDIR_MOUNT = '/rfm_workdir'
@@ -162,10 +161,6 @@ class ContainerPlatform(abc.ABC):
         new.pull_image = other.pull_image
         return new
 
-    def validate(self):
-        if self.image is None:
-            raise ContainerError('no image specified')
-
     @property
     def name(self):
         return type(self).__name__
@@ -220,7 +215,8 @@ class Sarus(ContainerPlatform):
         # The format that Sarus uses to call the images is
         # <reposerver>/<user>/<image>:<tag>. If an image was loaded
         # locally from a tar file, the <reposerver> is 'load'.
-        if not self.pull_image or self.image.startswith('load/'):
+        if (not self.pull_image or not self.image or
+            self.image.startswith('load/')):
             return []
         else:
             return [f'{self._command} pull {self.image}']

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -472,24 +472,33 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #:
     #: The container platform to be used for launching this test.
     #:
-    #: If this field is set, the test will run inside a container using the
-    #: specified container runtime. Container-specific options must be defined
-    #: additionally after this field is set:
+    #: This field is set automatically by the default container runtime
+    #: associated with the current system partition. Users may also set this,
+    #: explicitly overriding any partition setting. If the
+    #: :attr:`~reframe.core.containers.ContainerPlatform.image` attribute of
+    #: :attr:`container_platform` is set, then the test will run inside a
+    #: container using the specified container runtime.
     #:
     #: .. code:: python
     #:
     #:    self.container_platform = 'Singularity'
     #:    self.container_platform.image = 'docker://ubuntu:18.04'
-    #:    self.container_platform.commands = ['cat /etc/os-release']
+    #:    self.container_platform.command = 'cat /etc/os-release'
     #:
-    #: If this field is set, :attr:`executable` and :attr:`executable_opts`
-    #: attributes are ignored. The container platform's :attr:`commands
-    #: <reframe.core.containers.ContainerPlatform.commands>` will be used
+    #: If the test will run inside a container, the :attr:`executable` and
+    #: :attr:`executable_opts` attributes are ignored. The container platform's
+    #: :attr:`~reframe.core.containers.ContainerPlatform.command` will be used
     #: instead.
     #:
     #: :type: :class:`str` or
-    #:     :class:`reframe.core.containers.ContainerPlatform`.
-    #: :default: :class:`None`.
+    #:     :class:`~reframe.core.containers.ContainerPlatform`.
+    #: :default: the container runtime specified in the current system
+    #:   partition's configuration (see also
+    #:   :ref:`container-platform-configuration`).
+    #:
+    #: .. versionchanged:: 3.12.0
+    #:    This field is now set automatically from the current partition's
+    #:    configuration.
     container_platform = variable(field=ContainerPlatformField,
                                   value=_NoRuntime())
 

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -35,7 +35,7 @@ import reframe.utility.typecheck as typ
 import reframe.utility.udeps as udeps
 from reframe.core.backends import getlauncher, getscheduler
 from reframe.core.buildsystems import BuildSystemField
-from reframe.core.containers import ContainerPlatformField
+from reframe.core.containers import (ContainerPlatform, ContainerPlatformField)
 from reframe.core.deferrable import (_DeferredExpression,
                                      _DeferredPerformanceExpression)
 from reframe.core.exceptions import (BuildError, DependencyError,
@@ -48,8 +48,21 @@ from reframe.core.variables import DEPRECATE_WR
 from reframe.core.warnings import user_deprecation_warning
 
 
-# Dependency kinds
+class _NoRuntime(ContainerPlatform):
+    '''Proxy container runtime for storing container platform info early enough.
 
+    This will be replaced by the framework with a concrete implementation
+    based on the current partition info.
+    '''
+
+    def emit_prepare_commands(self, stagedir):
+        raise NotImplementedError
+
+    def launch_command(self, stagedir):
+        raise NotImplementedError
+
+
+# Dependency kinds
 #: Constant to be passed as the ``how`` argument of the
 #: :func:`~RegressionTest.depends_on` method. It denotes that test case
 #: dependencies will be explicitly specified by the user.
@@ -476,8 +489,8 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #: :type: :class:`str` or
     #:     :class:`reframe.core.containers.ContainerPlatform`.
     #: :default: :class:`None`.
-    container_platform = variable(type(None),
-                                  field=ContainerPlatformField, value=None)
+    container_platform = variable(field=ContainerPlatformField,
+                                  value=_NoRuntime())
 
     #: .. versionadded:: 3.0
     #:
@@ -1564,7 +1577,7 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
         except OSError as e:
             raise PipelineError('failed to set up paths') from e
 
-    def _setup_job(self, name, force_local=False, **job_opts):
+    def _create_job(self, name, force_local=False, **job_opts):
         '''Setup the job related to this check.'''
 
         if force_local:
@@ -1586,8 +1599,30 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
                           sched_access=self._current_partition.access,
                           **job_opts)
 
+    def _setup_build_job(self, **job_opts):
+        self._build_job = self._create_job(f'rfm_{self.unique_name}_build',
+                                           self.local or self.build_locally,
+                                           **job_opts)
+
+    def _setup_run_job(self, **job_opts):
+        self._job = self._create_job(f'rfm_{self.unique_name}_job',
+                                     self.local, **job_opts)
+
     def _setup_perf_logging(self):
         self._perf_logger = logging.getperflogger(self)
+
+    def _setup_container_platform(self):
+        try:
+            self.container_platform.emit_prepare_commands(self.stagedir)
+        except NotImplementedError:
+            cplatf_name = self.current_partition.container_runtime
+            if cplatf_name:
+                try:
+                    self.container_platform = ContainerPlatform.create_from(
+                        cplatf_name, self.container_platform
+                    )
+                except ValueError:
+                    pass
 
     @final
     def setup(self, partition, environ, **job_opts):
@@ -1617,13 +1652,10 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
         self._current_partition = partition
         self._current_environ = environ
         self._setup_paths()
+        self._setup_build_job(**job_opts)
+        self._setup_run_job(**job_opts)
+        self._setup_container_platform()
         self._resolve_fixtures()
-        self._job = self._setup_job(f'rfm_{self.unique_name}_job',
-                                    self.local,
-                                    **job_opts)
-        self._build_job = self._setup_job(f'rfm_{self.unique_name}_build',
-                                          self.local or self.build_locally,
-                                          **job_opts)
 
     def _copy_to_stagedir(self, path):
         self.logger.debug(f'Copying {path} to stage directory')
@@ -1640,6 +1672,79 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
         osext.git_clone(
             self.sourcesdir, self._stagedir,
             timeout=rt.runtime().get_option('general/0/git_timeout')
+        )
+
+    def _get_contplatf_env(self):
+        try:
+            cp_name = self.container_platform.name
+            return self.current_partition.container_environs[cp_name]
+        except KeyError:
+            return None
+
+    def _prepare_build_job_containerized(self):
+        assert self.container_platform.image is not None
+
+        # We will use a dummy local job to generate a local shell script that
+        # will contain all the build commands; this will be then executed by
+        # the build job
+
+        build_script_name = f'_do_build_{self.unique_name}'
+        build_commands = [
+            *self.prebuild_cmds,
+            *self.build_system.emit_build_commands(self._current_environ),
+            *self.postbuild_cmds
+        ]
+        Job.create(
+            getscheduler('local')(),
+            getlauncher('local')(),
+            build_script_name
+        ).prepare(build_commands, [], trap_errors=True)
+
+        # Setup the build_job now so that it runs with selected container runtime
+        environs = [self.current_partition.local_env]
+        cp_env = self._get_contplatf_env()
+        if cp_env:
+            environs.append(cp_env)
+
+        cplatf = self.container_platform
+        cplatf_cmd_save = self.container_platform.command
+        try:
+            self.container_platform.commands = [f'./{build_sciprt_name}']
+            launch_cmd = self.build_job.launcher.run_command(self.build_job)
+            cplatf_launch_cmd = cplatf.launch_command(self.stagedir)
+        finally:
+            # Restore container platform commands
+            self.container_platform.command = cplatf_cmd_save
+
+        self.build_job.prepare(
+            f'{launch_cmd} {cplatf_launch_cmd}',
+            [self.current_partition.local_env],
+            login=rt.runtime().get_option('general/0/use_login_shell'),
+            trap_errors=True
+        )
+
+    def _prepare_build_job(self):
+        user_environ = env.Environment(self.unique_name,
+                                       self.modules, self.variables.items())
+
+        build_environs = [self.current_partition.local_env,
+                          self.current_environ,
+                          user_environ, self._cdt_environ]
+        build_commands = [
+            *self.prebuild_cmds,
+            *self.build_system.emit_build_commands(self._current_environ),
+            *self.postbuild_cmds
+        ]
+        self.build_job.time_limit = (
+            self.build_time_limit or rt.runtime().get_option(
+                f'systems/0/partitions/@{self.current_partition.name}'
+                f'/time_limit')
+        )
+        self.build_job.prepare(
+            build_commands, build_environs,
+            self.current_partition.prepare_cmds,
+            login=rt.runtime().get_option('general/0/use_login_shell'),
+            trap_errors=True
         )
 
     @final
@@ -1662,8 +1767,8 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
               more details.
 
         '''
-        if not self._current_environ:
-            raise PipelineError('no programming environment set')
+
+        assert self.current_environ
 
         # Copy the check's resources to the stage directory
         if self.sourcesdir:
@@ -1724,33 +1829,18 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
             self.build_system.srcfile = self.sourcepath
             self.build_system.executable = self.executable
 
-        user_environ = env.Environment(type(self).__name__,
-                                       self.modules, self.variables.items())
-        environs = [self._current_partition.local_env, self._current_environ,
-                    user_environ, self._cdt_environ]
-        self._build_job.time_limit = (
+        self.build_job.time_limit = (
             self.build_time_limit or rt.runtime().get_option(
                 f'systems/0/partitions/@{self.current_partition.name}'
                 f'/time_limit')
         )
-        with osext.change_dir(self._stagedir):
-            # Prepare build job
-            build_commands = [
-                *self.prebuild_cmds,
-                *self.build_system.emit_build_commands(self._current_environ),
-                *self.postbuild_cmds
-            ]
-            try:
-                self._build_job.prepare(
-                    build_commands, environs,
-                    self._current_partition.prepare_cmds,
-                    login=rt.runtime().get_option('general/0/use_login_shell'),
-                    trap_errors=True
-                )
-            except OSError as e:
-                raise PipelineError('failed to prepare build job') from e
+        with osext.change_dir(self.stagedir):
+            if self.container_platform.image:
+                self._prepare_build_job_containerized()
+            else:
+                self._prepare_build_job()
 
-            self._build_job.submit()
+            self.build_job.submit()
 
     @final
     def compile_wait(self):
@@ -1803,10 +1893,11 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
               more details.
 
         '''
-        if not self.current_system or not self._current_partition:
-            raise PipelineError('no system or system partition is set')
 
-        if self.container_platform:
+        assert self.current_system and self.current_partition
+
+        cp_env = None
+        if self.container_platform.image:
             try:
                 cp_name = type(self.container_platform).__name__
                 cp_env = self._current_partition.container_environs[cp_name]
@@ -1822,7 +1913,8 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
                 self.stagedir)
             self.executable_opts = []
             prepare_container = self.container_platform.emit_prepare_commands(
-                self.stagedir)
+                self.stagedir
+            )
             if prepare_container:
                 self.prerun_cmds += prepare_container
 
@@ -2495,8 +2587,8 @@ class RunOnlyRegressionTest(RegressionTest, special=True):
         self._current_partition = partition
         self._current_environ = environ
         self._setup_paths()
-        self._job = self._setup_job(f'rfm_{self.unique_name}_job',
-                                    self.local, **job_opts)
+        self._setup_run_job(**job_opts)
+        self._setup_container_platform()
         self._resolve_fixtures()
 
     def compile(self):
@@ -2552,9 +2644,8 @@ class CompileOnlyRegressionTest(RegressionTest, special=True):
         self._current_partition = partition
         self._current_environ = environ
         self._setup_paths()
-        self._build_job = self._setup_job(f'rfm_{self.unique_name}_build',
-                                          self.local or self.build_locally,
-                                          **job_opts)
+        self._setup_build_job(**job_opts)
+        self._setup_container_platform()
         self._resolve_fixtures()
 
     @property

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -490,6 +490,12 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #: :attr:`~reframe.core.containers.ContainerPlatform.command` will be used
     #: instead.
     #:
+    #: .. note::
+    #:
+    #:    Only the run phase of the test will run inside the container.
+    #:    If you enable the containerized run in a non run-only test, the
+    #:    compilation phase will still run natively.
+    #:
     #: :type: :class:`str` or
     #:     :class:`~reframe.core.containers.ContainerPlatform`.
     #: :default: the container runtime specified in the current system

--- a/reframe/core/systems.py
+++ b/reframe/core/systems.py
@@ -9,7 +9,6 @@ import json
 import reframe.utility as util
 import reframe.utility.jsonext as jsonext
 from reframe.core.backends import (getlauncher, getscheduler)
-from reframe.core.containers import ContainerPlatform
 from reframe.core.environments import (Environment, ProgEnvironment)
 from reframe.core.logging import getlogger
 from reframe.core.modules import ModulesSystem

--- a/reframe/core/systems.py
+++ b/reframe/core/systems.py
@@ -9,6 +9,7 @@ import json
 import reframe.utility as util
 import reframe.utility.jsonext as jsonext
 from reframe.core.backends import (getlauncher, getscheduler)
+from reframe.core.containers import ContainerPlatform
 from reframe.core.environments import (Environment, ProgEnvironment)
 from reframe.core.logging import getlogger
 from reframe.core.modules import ModulesSystem
@@ -164,8 +165,8 @@ class SystemPartition(jsonext.JSONSerializable):
     '''
 
     def __init__(self, *, parent, name, sched_type, launcher_type,
-                 descr, access, container_environs, resources,
-                 local_env, environs, max_jobs, prepare_cmds,
+                 descr, access, container_runtime, container_environs,
+                 resources, local_env, environs, max_jobs, prepare_cmds,
                  processor, devices, extras, features, time_limit):
         getlogger().debug(f'Initializing system partition {name!r}')
         self._parent_system = parent
@@ -175,6 +176,7 @@ class SystemPartition(jsonext.JSONSerializable):
         self._launcher_type = launcher_type
         self._descr = descr
         self._access = access
+        self._container_runtime = container_runtime
         self._container_environs = container_environs
         self._local_env = local_env
         self._environs = environs
@@ -211,6 +213,14 @@ class SystemPartition(jsonext.JSONSerializable):
         '''
 
         return util.SequenceView(self._environs)
+
+    @property
+    def container_runtime(self):
+        '''The default container runtime of this partition.
+
+        :type: :class:`str` or ``None``
+        '''
+        return self._container_runtime
 
     @property
     def container_environs(self):
@@ -537,6 +547,9 @@ class System(jsonext.JSONSerializable):
                     access=site_config.get(f'{partid}/access'),
                     resources=site_config.get(f'{partid}/resources'),
                     environs=part_environs,
+                    container_runtime=site_config.get(
+                        f'{partid}/container_runtime'
+                    ),
                     container_environs=part_container_environs,
                     local_env=Environment(
                         name=f'__rfm_env_{part_name}',

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -266,25 +266,19 @@
                                     "type": "array",
                                     "items": {"type": "string"}
                                 },
-                                "container_runtime": {"type": "string"},
                                 "container_platforms": {
                                     "type": "array",
                                     "items": {
                                         "type": "object",
                                         "properties": {
-                                            "type": {
-                                                "type": "string",
-                                                "enum": [
-                                                    "Docker", "Sarus",
-                                                    "Shifter", "Singularity"
-                                                ]
-                                            },
+                                            "type": {"type": "string"},
                                             "modules": {
                                                 "$ref": "#/defs/modules_list"
                                             },
                                             "variables": {
                                                 "$ref": "#/defs/envvar_list"
-                                            }
+                                            },
+                                            "default": {"type": "boolean"}
                                         },
                                         "required": ["type"]
                                     }

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -266,6 +266,7 @@
                                     "type": "array",
                                     "items": {"type": "string"}
                                 },
+                                "container_runtime": {"type": "string"},
                                 "container_platforms": {
                                     "type": "array",
                                     "items": {
@@ -578,6 +579,7 @@
         "systems/partitions/descr": "",
         "systems/partitions/access": [],
         "systems/partitions/environs": [],
+        "systems/partitions/container_runtime": null,
         "systems/partitions/container_platforms": [],
         "systems/partitions/container_platforms/*modules": [],
         "systems/partitions/container_platforms/*variables": [],

--- a/reframe/utility/__init__.py
+++ b/reframe/utility/__init__.py
@@ -925,6 +925,23 @@ def nodelist_abbrev(nodes):
     return ','.join(str(ng) for ng in node_groups)
 
 
+class temp_setattr:
+    '''Context manager to temporarily change the attribute value of an
+    object.'''
+
+    def __init__(self, obj, attr, val):
+        self._obj = obj
+        self._attr = attr
+        self._newval = val
+        self._saved = getattr(obj, attr)
+
+    def __enter__(self):
+        setattr(self._obj, self._attr, self._newval)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        setattr(self._obj, self._attr, self._saved)
+
+
 class ScopedDict(UserDict):
     '''This is a special dictionary that imposes scopes on its keys.
 

--- a/tutorials/advanced/containers/gromacs_test.py
+++ b/tutorials/advanced/containers/gromacs_test.py
@@ -8,8 +8,18 @@ import reframe as rfm
 from hpctestlib.sciapps.gromacs.benchmarks import gromacs_check
 
 
+def _hecbiosim_bench(params):
+    for p in params:
+        if p[0] == 'HECBioSim/hEGFRDimerSmallerPL':
+            return [p]
+
+
 @rfm.simple_test
 class gromacs_containerized_test(gromacs_check):
+    benchmark_info = parameter(inherit_params=True,
+                               filter_params=_hecbiosim_bench,
+                               fmt=lambda x: x[0])
+    nb_impl = parameter(['gpu'])
     gromacs_image = parameter([
         None,
         'nvcr.io/hpc/gromacs:2020',

--- a/tutorials/advanced/containers/gromacs_test.py
+++ b/tutorials/advanced/containers/gromacs_test.py
@@ -1,0 +1,32 @@
+import reframe as rfm
+from hpctestlib.sciapps.gromacs.benchmarks import gromacs_check
+
+
+@rfm.simple_test
+class gromacs_containerized_test(gromacs_check):
+    # gromacs_image = variable(str, type(None), value=None)
+    gromacs_image = parameter([
+        None,
+        'nvcr.io/hpc/gromacs:2020',
+        'nvcr.io/hpc/gromacs:2020.2',
+        'nvcr.io/hpc/gromacs:2021',
+        'nvcr.io/hpc/gromacs:2021.3',
+        'nvcr.io/hpc/gromacs:2022.1'
+    ])
+    valid_systems = ['daint:gpu']
+    valid_prog_environs = ['gnu']
+    use_multithreading = False
+    executable = 'gmx mdrun'
+    executable_opts += ['-dlb yes', '-ntomp 12', '-npme -1', '-v']
+    num_tasks = 1
+    num_tasks_per_node = 1
+    num_cpus_per_task = 12
+
+    @run_after('init')
+    def setup_container_run(self):
+        exec_cmd = ' '.join([self.executable, *self.executable_opts])
+        self.container_platform.image = self.gromacs_image
+        self.container_platform.command = exec_cmd
+
+        if self.gromacs_image is None:
+            self.modules = ['GROMACS']

--- a/tutorials/advanced/containers/gromacs_test.py
+++ b/tutorials/advanced/containers/gromacs_test.py
@@ -1,10 +1,15 @@
+# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# ReFrame Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# rfmdocstart: gromacstest
 import reframe as rfm
 from hpctestlib.sciapps.gromacs.benchmarks import gromacs_check
 
 
 @rfm.simple_test
 class gromacs_containerized_test(gromacs_check):
-    # gromacs_image = variable(str, type(None), value=None)
     gromacs_image = parameter([
         None,
         'nvcr.io/hpc/gromacs:2020',
@@ -29,4 +34,4 @@ class gromacs_containerized_test(gromacs_check):
         self.container_platform.command = exec_cmd
 
         if self.gromacs_image is None:
-            self.modules = ['GROMACS']
+            self.modules = ['daint-gpu', 'GROMACS']

--- a/tutorials/advanced/containers/gromacs_test.py
+++ b/tutorials/advanced/containers/gromacs_test.py
@@ -16,10 +16,13 @@ def _hecbiosim_bench(params):
 
 @rfm.simple_test
 class gromacs_containerized_test(gromacs_check):
+    # Restrict library test parameters to only those relevant for this example
     benchmark_info = parameter(inherit_params=True,
                                filter_params=_hecbiosim_bench,
                                fmt=lambda x: x[0])
     nb_impl = parameter(['gpu'])
+
+    # New parameter for testing the various images
     gromacs_image = parameter([
         None,
         'nvcr.io/hpc/gromacs:2020',
@@ -42,6 +45,5 @@ class gromacs_containerized_test(gromacs_check):
         exec_cmd = ' '.join([self.executable, *self.executable_opts])
         self.container_platform.image = self.gromacs_image
         self.container_platform.command = exec_cmd
-
         if self.gromacs_image is None:
             self.modules = ['daint-gpu', 'GROMACS']

--- a/unittests/resources/settings.py
+++ b/unittests/resources/settings.py
@@ -59,7 +59,12 @@ site_configuration = {
                     'launcher': 'local',
                     'environs': ['PrgEnv-cray', 'PrgEnv-gnu'],
                     'descr': 'Login nodes',
-                    'features': ['cross_compile']
+                    'features': ['cross_compile'],
+                    'container_platforms': [
+                        {'type': 'Sarus'},
+                        {'type': 'Docker', 'default': True},
+                        {'type': 'Singularity'}
+                    ]
                 },
                 {
                     'name': 'gpu',
@@ -89,6 +94,7 @@ site_configuration = {
                     'extras': {
                         'gpu_arch': 'a100'
                     },
+                    'container_platforms': [{'type': 'Sarus'}],
                     'environs': ['PrgEnv-gnu', 'builtin'],
                     'max_jobs': 10,
                     'processor': {

--- a/unittests/test_containers.py
+++ b/unittests/test_containers.py
@@ -7,7 +7,6 @@ import pytest
 
 import reframe.core.containers as containers
 import reframe.core.warnings as warn
-from reframe.core.exceptions import ContainerError
 
 
 @pytest.fixture(params=[
@@ -195,12 +194,6 @@ def test_mount_points(container_platform, expected_cmd_mount_points):
                                        ('/path/two', '/two')]
     cmd = container_platform.launch_command('/foo')
     assert cmd == expected_cmd_mount_points
-
-
-def test_missing_image(container_platform):
-    container_platform.image = None
-    with pytest.raises(ContainerError):
-        container_platform.validate()
 
 
 def test_prepare_command(container_platform, expected_cmd_prepare):

--- a/unittests/test_containers.py
+++ b/unittests/test_containers.py
@@ -49,35 +49,35 @@ def expected_cmd_mount_points(container_variant):
     if container_variant in {'Docker', 'Docker+nopull'}:
         return ('docker run --rm -v "/path/one":"/one" '
                 '-v "/path/two":"/two" '
-                '-v "/foo":"/rfm_workdir" image:tag cmd')
+                '-v "/foo":"/rfm_workdir" -w /rfm_workdir image:tag cmd')
     elif container_variant == 'Docker+nocommand':
         return ('docker run --rm -v "/path/one":"/one" '
                 '-v "/path/two":"/two" '
-                '-v "/foo":"/rfm_workdir" image:tag')
+                '-v "/foo":"/rfm_workdir" -w /rfm_workdir image:tag')
     elif container_variant in {'Sarus', 'Sarus+nopull'}:
         return ('sarus run '
                 '--mount=type=bind,source="/path/one",destination="/one" '
                 '--mount=type=bind,source="/path/two",destination="/two" '
                 '--mount=type=bind,source="/foo",destination="/rfm_workdir" '
-                'image:tag cmd')
+                '-w /rfm_workdir image:tag cmd')
     elif container_variant == 'Sarus+nocommand':
         return ('sarus run '
                 '--mount=type=bind,source="/path/one",destination="/one" '
                 '--mount=type=bind,source="/path/two",destination="/two" '
                 '--mount=type=bind,source="/foo",destination="/rfm_workdir" '
-                'image:tag')
+                '-w /rfm_workdir image:tag')
     elif container_variant == 'Sarus+mpi':
         return ('sarus run '
                 '--mount=type=bind,source="/path/one",destination="/one" '
                 '--mount=type=bind,source="/path/two",destination="/two" '
                 '--mount=type=bind,source="/foo",destination="/rfm_workdir" '
-                '--mpi image:tag cmd')
+                '--mpi -w /rfm_workdir image:tag cmd')
     elif container_variant == 'Sarus+load':
         return ('sarus run '
                 '--mount=type=bind,source="/path/one",destination="/one" '
                 '--mount=type=bind,source="/path/two",destination="/two" '
                 '--mount=type=bind,source="/foo",destination="/rfm_workdir" '
-                'load/library/image:tag cmd')
+                '-w /rfm_workdir load/library/image:tag cmd')
     elif container_variant in {'Shifter', 'Shifter+nopull'}:
         return ('shifter run '
                 '--mount=type=bind,source="/path/one",destination="/one" '
@@ -104,13 +104,16 @@ def expected_cmd_mount_points(container_variant):
                 'load/library/image:tag cmd')
     elif container_variant in {'Singularity', 'Singularity+nopull'}:
         return ('singularity exec -B"/path/one:/one" '
-                '-B"/path/two:/two" -B"/foo:/rfm_workdir" image:tag cmd')
+                '-B"/path/two:/two" -B"/foo:/rfm_workdir" '
+                '-W /rfm_workdir image:tag cmd')
     elif container_variant == 'Singularity+cuda':
         return ('singularity exec -B"/path/one:/one" '
-                '-B"/path/two:/two" -B"/foo:/rfm_workdir" --nv image:tag cmd')
+                '-B"/path/two:/two" -B"/foo:/rfm_workdir" --nv '
+                '-W /rfm_workdir image:tag cmd')
     elif container_variant == 'Singularity+nocommand':
         return ('singularity run -B"/path/one:/one" '
-                '-B"/path/two:/two" -B"/foo:/rfm_workdir" image:tag')
+                '-B"/path/two:/two" -B"/foo:/rfm_workdir" '
+                '-W /rfm_workdir image:tag')
 
 
 @pytest.fixture
@@ -204,6 +207,7 @@ def test_prepare_command(container_platform, expected_cmd_prepare):
 def test_run_opts(container_platform, expected_cmd_run_opts):
     container_platform.mount_points = [('/path/one', '/one')]
     container_platform.options = ['--foo', '--bar']
+    container_platform.workdir = None
     assert container_platform.launch_command('/foo') == expected_cmd_run_opts
 
 
@@ -215,7 +219,7 @@ def container_variant_noopt(request):
 
 
 @pytest.fixture
-def container_platform_noopt(container_variant_noopt):
+def container_platform_with_opts(container_variant_noopt):
     ret = containers.__dict__[container_variant_noopt]()
     ret.image = 'image:tag'
     ret.options = ['--foo']
@@ -226,61 +230,59 @@ def container_platform_noopt(container_variant_noopt):
 def expected_run_with_commands(container_variant_noopt):
     if container_variant_noopt == 'Docker':
         return ("docker run --rm -v \"/foo\":\"/rfm_workdir\" "
-                "--foo image:tag bash -c 'cd /rfm_workdir; cmd1; cmd2'")
+                "--foo image:tag bash -c 'cmd1; cmd2'")
     elif container_variant_noopt == 'Sarus':
         return (
             "sarus run "
             "--mount=type=bind,source=\"/foo\",destination=\"/rfm_workdir\" "
-            "--foo image:tag bash -c 'cd /rfm_workdir; cmd1; cmd2'"
+            "--foo image:tag bash -c 'cmd1; cmd2'"
         )
     elif container_variant_noopt == 'Shifter':
         return (
             "shifter run "
             "--mount=type=bind,source=\"/foo\",destination=\"/rfm_workdir\" "
-            "--foo image:tag bash -c 'cd /rfm_workdir; cmd1; cmd2'"
+            "--foo image:tag bash -c 'cmd1; cmd2'"
         )
     elif container_variant_noopt == 'Singularity':
         return ("singularity exec -B\"/foo:/rfm_workdir\" "
-                "--foo image:tag bash -c 'cd /rfm_workdir; cmd1; cmd2'")
+                "--foo image:tag bash -c 'cmd1; cmd2'")
 
 
 @pytest.fixture
 def expected_run_with_workdir(container_variant_noopt):
     if container_variant_noopt == 'Docker':
-        return ("docker run --rm -v \"/foo\":\"/rfm_workdir\" "
-                "--foo image:tag bash -c 'cd foodir; cmd1; cmd2'")
+        return ('docker run --rm -v "/foo":"/rfm_workdir" '
+                '-w foodir --foo image:tag cmd1')
     elif container_variant_noopt == 'Sarus':
         return (
-            "sarus run "
-            "--mount=type=bind,source=\"/foo\",destination=\"/rfm_workdir\" "
-            "--foo image:tag bash -c 'cd foodir; cmd1; cmd2'"
+            'sarus run '
+            '--mount=type=bind,source="/foo",destination="/rfm_workdir" '
+            '-w foodir --foo image:tag cmd1'
         )
     elif container_variant_noopt == 'Shifter':
         return (
-            "shifter run "
-            "--mount=type=bind,source=\"/foo\",destination=\"/rfm_workdir\" "
-            "--foo image:tag bash -c 'cd foodir; cmd1; cmd2'"
+            'shifter run '
+            '--mount=type=bind,source="/foo",destination="/rfm_workdir" '
+            '--foo image:tag cmd1'
         )
     elif container_variant_noopt == 'Singularity':
-        return ("singularity exec -B\"/foo:/rfm_workdir\" --foo image:tag "
-                "bash -c 'cd foodir; cmd1; cmd2'")
+        return ('singularity exec -B\"/foo:/rfm_workdir\" -W foodir '
+                '--foo image:tag cmd1')
 
 
-def test_run_with_commands(container_platform_noopt,
+def test_run_with_commands(container_platform_with_opts,
                            expected_run_with_commands):
+    container_platform_with_opts.workdir = None
     with pytest.warns(warn.ReframeDeprecationWarning):
-        container_platform_noopt.commands = ['cmd1', 'cmd2']
+        container_platform_with_opts.commands = ['cmd1', 'cmd2']
 
-    found_commands = container_platform_noopt.launch_command('/foo')
+    found_commands = container_platform_with_opts.launch_command('/foo')
     assert found_commands == expected_run_with_commands
 
 
-def test_run_with_workdir(container_platform_noopt, expected_run_with_workdir):
-    with pytest.warns(warn.ReframeDeprecationWarning):
-        container_platform_noopt.commands = ['cmd1', 'cmd2']
-
-    with pytest.warns(warn.ReframeDeprecationWarning):
-        container_platform_noopt.workdir = 'foodir'
-
-    found_commands = container_platform_noopt.launch_command('/foo')
+def test_run_with_workdir(container_platform_with_opts,
+                          expected_run_with_workdir):
+    container_platform_with_opts.command = 'cmd1'
+    container_platform_with_opts.workdir = 'foodir'
+    found_commands = container_platform_with_opts.launch_command('/foo')
     assert found_commands == expected_run_with_workdir

--- a/unittests/test_pipeline.py
+++ b/unittests/test_pipeline.py
@@ -1715,7 +1715,9 @@ def container_test(tmp_path):
 
             @run_after('init')
             def setup_container_platf(self):
-                self.container_platform = platform
+                if platform:
+                    self.container_platform = platform
+
                 self.container_platform.image = image
                 self.container_platform.command = (
                     f"bash -c 'cd {_STAGEDIR_MOUNT}; pwd; ls; "
@@ -1776,17 +1778,9 @@ def test_unknown_container_platform(container_test, local_exec_ctx):
 
 def test_not_configured_container_platform(container_test, local_exec_ctx):
     partition, environ = local_exec_ctx
-    platform = None
-    for cp in ['Docker', 'Singularity', 'Sarus', 'ShifterNG']:
-        if cp not in partition.container_environs.keys():
-            platform = cp
-            break
-
-    if platform is None:
-        pytest.skip('cannot find a supported platform that is not configured')
 
     with pytest.raises(PipelineError):
-        _run(container_test(platform, 'ubuntu:18.04'), *local_exec_ctx)
+        _run(container_test(None, 'ubuntu:18.04'), *local_exec_ctx)
 
 
 def test_skip_if_no_topo(HelloTest, local_exec_ctx):


### PR DESCRIPTION
This PR improves how tests handle the `container_platform` attribute. Users are no more required to set the `container_platform` in their tests. This will be taken from the default `container_platform` defined for the current partition in the configuration. Also, this PR brings back the `workdir` attribute of the container platform and each backend emits the right option.

The documentation and the tutorial are also adapted and a new tutorial example is added which show cases a tests of GROMACS that runs both natively and from different containers.

## Implementation details

In order to allow setting the `container_platform` attributes in the class body, we have employed the following trick. We assign a bogus `ContainerPlatform` that implements its abstract methods simply by raising a `NotImplementedError`. The purpose of this container platform is to hold any attributes set by the user. During the test's setup, when we know the current system partition, we replace the `container_platform` by creating a concrete one and copying any set attributes from the bogus. This whole mechanism is completely transparent to the users, which they can also set explicitly the `container_platform` if they wish, as in the past.

Fixes #2396.