### PR TITLE
[bugfix] Treat undefined variables correctly in run report

### DIFF
--- a/reframe/frontend/statistics.py
+++ b/reframe/frontend/statistics.py
@@ -196,7 +196,10 @@ class TestStats:
                 test_cls = type(check)
                 for name, var in test_cls.var_space.items():
                     if var.is_loggable():
-                        entry['check_vars'][name] = getattr(check, name)
+                        try:
+                            entry['check_vars'][name] = getattr(check, name)
+                        except AttributeError:
+                            entry['check_vars'][name] = '<undefined>'
 
                 entry['check_params'] = {}
                 test_cls = type(check)

--- a/unittests/resources/checks/frontend_checks.py
+++ b/unittests/resources/checks/frontend_checks.py
@@ -23,6 +23,15 @@ class BaseFrontendCheck(rfm.RunOnlyRegressionTest):
     executable = 'echo hello && echo perf: 10 Gflop/s'
     local = True
 
+    # Add two required variables that may affect the final run report
+    x = variable(int)
+    xlog = variable(int, loggable=True)
+
+    @run_after('setup')
+    def setx(self):
+        self.x = 1
+        self.xlog = 1
+
     @sanity_function
     def validate_output(self):
         return sn.assert_found('hello', self.stdout)

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -616,6 +616,7 @@ def _read_pid(job, attempts=3):
                 f'{attempts} attempts')
 
 
+@pytest.mark.flaky(reruns=3)
 def test_cancel_with_grace(minimal_job, scheduler, local_only):
     # This test emulates a spawned process that ignores the SIGTERM signal
     # and also spawns another process:


### PR DESCRIPTION
We print `<undefined>` in case a variable is not yet defined. This can be the case when a test exits early. An example is [here](https://jenkins.cscs.ch/blue/rest/organizations/jenkins/pipelines/reframe-pilatus-production-daily/runs/396/nodes/7/steps/21/log/?start=0) where the tests fail during the setup stage.

This bug was introduced by #2543.