### PR TITLE
[packaging] Bump version of `requests` in `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,8 @@ pytest-forked==1.4.0
 pytest-parallel==0.1.1
 pytest-rerunfailures==10.2
 PyYAML==6.0
-requests==2.28.1
+requests==2.27.1; python_version == '3.6'
+requests==2.28.1; python_version >= '3.7'
 semver==2.13.0
 setuptools==59.6.0
 wcwidth==0.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pytest-forked==1.4.0
 pytest-parallel==0.1.1
 pytest-rerunfailures==10.2
 PyYAML==6.0
-requests==2.27.1
+requests==2.28.1
 semver==2.13.0
 setuptools==59.6.0
 wcwidth==0.2.5


### PR DESCRIPTION
This makes `requests` compatible with `chardet` v5: https://github.com/psf/requests/pull/6179