### PR TITLE
[feat] Change default hostname autodetection parameters

### DIFF
--- a/ci-scripts/ci-runner.bash
+++ b/ci-scripts/ci-runner.bash
@@ -41,6 +41,7 @@ checked_exec()
 
 run_tutorial_checks()
 {
+    export RFM_AUTODETECT_XTHOSTNAME=1
     cmd="./bin/reframe -C tutorials/config/settings.py -J account=jenscscs \
 --save-log-files --flex-alloc-nodes=2 -r -x HelloThreadedExtendedTest|BZip2.*Check $@"
     echo "[INFO] Running tutorial checks with \`$cmd'"
@@ -157,6 +158,7 @@ else
     # Run unit tests with the scheduler backends
     tempdir=$(mktemp -d -p $SCRATCH)
     echo "[INFO] Using temporary directory: $tempdir"
+    export RFM_AUTODETECT_XTHOSTNAME=1
     if [[ $(hostname) =~ dom ]]; then
         PATH_save=$PATH
         export PATH=/apps/dom/UES/karakasv/slurm-wrappers/bin:$PATH

--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -1032,7 +1032,7 @@ Here is an alphabetical list of the environment variables recognized by ReFrame:
 .. envvar:: RFM_AUTODETECT_FQDN
 
    Use the fully qualified domain name as the hostname.
-   This is a boolean variable and defaults to ``1``.
+   This is a boolean variable and defaults to ``0``.
 
 
    .. table::
@@ -1045,6 +1045,9 @@ Here is an alphabetical list of the environment variables recognized by ReFrame:
 
 
    .. versionadded:: 3.11.0
+
+   .. versionchanged:: 4.0.0
+      This variable now defaults to ``0``.
 
 
 .. envvar:: RFM_AUTODETECT_METHOD
@@ -1071,7 +1074,7 @@ Here is an alphabetical list of the environment variables recognized by ReFrame:
 
    Use ``/etc/xthostname`` file, if present, to retrieve the current system's name.
    If the file cannot be found, the hostname will be retrieved using the ``hostname`` command.
-   This is a boolean variable and defaults to ``1``.
+   This is a boolean variable and defaults to ``0``.
 
    This option meaningful for Cray systems.
 
@@ -1086,6 +1089,8 @@ Here is an alphabetical list of the environment variables recognized by ReFrame:
 
    .. versionadded:: 3.11.0
 
+   .. versionchanged:: 4.0.0
+      This variable now defaults to ``0``.
 
 .. envvar:: RFM_CHECK_SEARCH_PATH
 

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -555,9 +555,9 @@ def main():
         dest='autodetect_fqdn',
         envvar='RFM_AUTODETECT_FQDN',
         action='store',
-        default=True,
+        default=False,
         type=typ.Bool,
-        help='Use FQDN as host name'
+        help='Use the full qualified domain name as host name'
     )
     argparser.add_argument(
         dest='autodetect_method',
@@ -570,9 +570,9 @@ def main():
         dest='autodetect_xthostname',
         envvar='RFM_AUTODETECT_XTHOSTNAME',
         action='store',
-        default=True,
+        default=False,
         type=typ.Bool,
-        help="Use Cray's xthostname file to find the host name"
+        help="Use Cray's xthostname file to retrieve the host name"
     )
     argparser.add_argument(
         dest='git_timeout',


### PR DESCRIPTION
`RFM_AUTODETECT_FQDN` and `RFM_AUTODETECT_XTHOSTNAME` are now set to `0` by default.

Please note that site-specific scripts relying on the previous defaults should now set these environment variables properly.

Fixes #2576.