### PR TITLE
[testlib] memory_bandwidth.cu: Handle `size` argument larger than int

### DIFF
--- a/hpctestlib/microbenchmarks/gpu/memory_bandwidth/src/memory_bandwidth.cu
+++ b/hpctestlib/microbenchmarks/gpu/memory_bandwidth/src/memory_bandwidth.cu
@@ -127,11 +127,11 @@ int main(int argc, char ** argv)
     }
     else if (str == "--size")
     {
-      copy_size = std::stoi((std::string)argv[++i]);
+      copy_size = std::stol((std::string)argv[++i]);
     }
     else if (str == "--copies")
     {
-      num_copies = std::stoi((std::string)argv[++i]);
+      num_copies = std::stol((std::string)argv[++i]);
     }
     else if (str == "--multi-gpu")
     {


### PR DESCRIPTION
The default of 1GB might be too small for newer systems to get a consistent measurement of memory bandwidth.
Need to be able to five larger values so fuse std:.stol instead of std:.stoi