### PR TITLE
[ci] Fix script that auto-generates the release notes

### DIFF
--- a/ci-scripts/genrelnotes.py
+++ b/ci-scripts/genrelnotes.py
@@ -49,7 +49,7 @@ if __name__ == '__main__':
         title_line = titles.get(tag, '## Other')
         sections.setdefault(title_line, [])
         for pr, descr in extract_release_notes(completed.stdout, tag):
-            descr_line = '- %s (%s)' % (descr, pr)
+            descr_line = f'- {descr} ([{pr}](https://github.com/reframe-hpc/reframe/pull/{pr[1:]}))'  # noqa: E501
             sections[title_line].append(descr_line)
 
     print('# Release Notes')


### PR DESCRIPTION
It seems that now the text in the release notes does not understand the `#PRNUM` notation, or more accurately, it seems not to render it correctly. It could be a bug in Github, so this is a workaround.