### PR TITLE
[bugfix] Remove redundant calls to git when trying to retrieve the version number

### DIFF
--- a/reframe/utility/__init__.py
+++ b/reframe/utility/__init__.py
@@ -925,6 +925,27 @@ def nodelist_abbrev(nodes):
     return ','.join(str(ng) for ng in node_groups)
 
 
+def cache_return_value(fn):
+    '''Decorator that caches the return value of the decorated function.
+
+    The function will only be called once and then the cached value will be
+    returned each time.
+    '''
+
+    undefined = []  # Any mutable object should do the job
+    cached = undefined
+
+    def _replace_fn(*args, **kwargs):
+        nonlocal cached
+
+        if cached is undefined:
+            cached = fn(*args, **kwargs)
+
+        return cached
+
+    return _replace_fn
+
+
 class temp_setattr:
     '''Context manager to temporarily change the attribute value of an
     object.'''

--- a/reframe/utility/osext.py
+++ b/reframe/utility/osext.py
@@ -23,6 +23,7 @@ import tempfile
 from urllib.parse import urlparse
 
 import reframe
+import reframe.utility as util
 from reframe.core.exceptions import (ReframeError, SpawnedProcessError,
                                      SpawnedProcessTimeout)
 from . import OrderedSet
@@ -480,6 +481,7 @@ def git_repo_hash(commit='HEAD', short=True, wd=None):
         return None
 
 
+@util.cache_return_value
 def reframe_version():
     '''Return ReFrame version.
 

--- a/unittests/test_utility.py
+++ b/unittests/test_utility.py
@@ -1805,3 +1805,19 @@ def test_nodelist_abbrev():
 
     with pytest.raises(TypeError, match='nodes argument cannot be a string'):
         nodelist('foo')
+
+
+def test_cached_return_value():
+
+    @util.cache_return_value
+    def calc():
+        time.sleep(.2)
+        return 10
+
+    t_start = time.time()
+    for _ in range(5):
+        r = calc()
+
+    t_elapsed = time.time() - t_start
+    assert r == 10
+    assert t_elapsed >= 0.2 and t_elapsed < 0.4


### PR DESCRIPTION
ReFrame's version is retrieved though the `osext.reframe_version()` function throughout the framework. This checks if you are running a version from the repo and appends the commit hash to the standard version number. This is called literally everywhere, as the default log format has the `%(version)s` specifier, which means we call `git rev-parse` in every single log call! In this PR, I'm introducing a utility decorator to cache the return value of a function eternally and I'm decorating with this the `reframe_version()`. The speed up is (of course) impressive.

w/ caching
```
time ./bin/reframe --system sys1 -C unittests/resources/settings.py -c unittests/resources/checks_unlisted/fixtures_complex.py -r
[...]
Executed in    6.91 secs   fish           external
   usr time    3.96 secs  143.00 micros    3.96 secs
   sys time    1.06 secs  1845.00 micros    1.06 secs
```

w/o caching (master)

```
Executed in   14.07 secs   fish           external
   usr time    6.96 secs    0.35 millis    6.96 secs
   sys time    5.99 secs    2.56 millis    5.99 secs
```