### PR TITLE
[feat] Add support for the Flux scheduler

### DIFF
--- a/.github/workflows/test-flux.yaml
+++ b/.github/workflows/test-flux.yaml
@@ -1,0 +1,46 @@
+name: Test Flux Scheduler
+on:
+  pull_request: []
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        container: ['fluxrm/flux-sched:focal']
+
+    container:
+      image: ${{ matrix.container }}
+      options: "--platform=linux/amd64 --user root -it"
+
+    name: ${{ matrix.container }}
+    steps:
+      - name: Make Space
+        run: |        
+          rm -rf /usr/share/dotnet
+          rm -rf /opt/ghc
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Reframe
+        run: |
+          wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh           
+          /bin/bash ~/miniconda.sh -b -p /opt/conda
+          export PATH=/opt/conda:/bin:$PATH
+          /bin/bash ./bootstrap.sh
+          pip install pytest
+          export PATH=$PWD/bin:$PATH
+          which reframe
+
+      # Any additional examples added here will be tested
+      - name: Start Flux and Run Test
+        run: |
+          export PATH=$PWD/bin:$PATH
+          which reframe           
+          flux start reframe -c tutorials/flux -C tutorials/flux/settings.py -l
+          flux start reframe -c tutorials/flux -C tutorials/flux/settings.py --run
+          flux start python3 ./test_reframe.py --rfm-user-config=tutorials/flux/settings.py -vvvv unittests/test_schedulers.py

--- a/.github/workflows/test-flux.yaml
+++ b/.github/workflows/test-flux.yaml
@@ -40,4 +40,11 @@ jobs:
           which reframe   
           flux start reframe -c tutorials/flux -C tutorials/flux/settings.py -l
           flux start reframe -c tutorials/flux -C tutorials/flux/settings.py --run
-          flux start --test-size=1 python3 ./test_reframe.py --rfm-user-config=tutorials/flux/settings.py -vvvv
+          # For unit tests, start flux in the background
+          flux start sleep inf & FLUX_URI=$(flux uri pid:$!)
+          echo "Flux is running at URI: ${FLUX_URI}"
+          export FLUX_URI
+          flux resource info
+          python3 ./test_reframe.py --rfm-user-config=tutorials/flux/settings.py -vvvv
+          # force stop flux instance
+          flux shutdown

--- a/.github/workflows/test-flux.yaml
+++ b/.github/workflows/test-flux.yaml
@@ -28,11 +28,8 @@ jobs:
 
       - name: Install Reframe
         run: |
-          wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh           
-          /bin/bash ~/miniconda.sh -b -p /opt/conda
-          export PATH=/opt/conda:/bin:$PATH
           /bin/bash ./bootstrap.sh
-          pip install pytest
+          python3 -m pip install pytest
           export PATH=$PWD/bin:$PATH
           which reframe
 
@@ -40,7 +37,8 @@ jobs:
       - name: Start Flux and Run Test
         run: |
           export PATH=$PWD/bin:$PATH
-          which reframe           
+          which reframe   
           flux start reframe -c tutorials/flux -C tutorials/flux/settings.py -l
           flux start reframe -c tutorials/flux -C tutorials/flux/settings.py --run
-          flux start python3 ./test_reframe.py --rfm-user-config=tutorials/flux/settings.py -vvvv unittests/test_schedulers.py
+          flux mini run python3 ./test_reframe.py --rfm-user-config=tutorials/flux/settings.py -vvvv unittests/test_schedulers.py::test_cancel_term_ignore unittests/test_schedulers.py::test_cancel_with_grace
+          flux mini run --env SKIP_FLAKY_CANCEL=true python3 ./test_reframe.py --rfm-user-config=tutorials/flux/settings.py -vvvv

--- a/.github/workflows/test-flux.yaml
+++ b/.github/workflows/test-flux.yaml
@@ -40,5 +40,4 @@ jobs:
           which reframe   
           flux start reframe -c tutorials/flux -C tutorials/flux/settings.py -l
           flux start reframe -c tutorials/flux -C tutorials/flux/settings.py --run
-          flux mini run python3 ./test_reframe.py --rfm-user-config=tutorials/flux/settings.py -vvvv unittests/test_schedulers.py::test_cancel_term_ignore unittests/test_schedulers.py::test_cancel_with_grace
-          flux mini run --env SKIP_FLAKY_CANCEL=true python3 ./test_reframe.py --rfm-user-config=tutorials/flux/settings.py -vvvv
+          flux start --test-size=1 python3 ./test_reframe.py --rfm-user-config=tutorials/flux/settings.py -vvvv

--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -223,6 +223,7 @@ System Partition Configuration
    Supported schedulers are the following:
 
    - ``local``: Jobs will be launched locally without using any job scheduler.
+   - ``flux``: Jobs will be launched using the `Flux Framework <https://flux-framework.org/>`_ scheduler.
    - ``oar``: Jobs will be launched using the `OAR <https://oar.imag.fr/>`__ scheduler.
    - ``pbs``: Jobs will be launched using the `PBS Pro <https://en.wikipedia.org/wiki/Portable_Batch_System>`__ scheduler.
    - ``sge``: Jobs will be launched using the `Sun Grid Engine <https://arc.liv.ac.uk/SGE/htmlman/manuals.html>`__ scheduler.

--- a/docs/tutorial_flux.rst
+++ b/docs/tutorial_flux.rst
@@ -32,7 +32,7 @@ And then reframe will again be in the local ``bin`` directory:
    # which reframe
    /code/bin/reframe
 
-Then we can run reframe with the custom config `config.py <config.py>`__
+Then we can run ReFrame with the custom config `config.py <config.py>`__
 for flux.
 
 .. code:: bash

--- a/docs/tutorial_flux.rst
+++ b/docs/tutorial_flux.rst
@@ -1,0 +1,108 @@
+========================================
+Tutorial 7: The Flux Framework Scheduler
+========================================
+
+This is a tutorial that will show how to use refame with `Flux
+Framework <https://github.com/flux-framework/>`__. First, build the
+container here from the root of reframe.
+
+.. code:: bash
+
+   $ docker build -f tutorials/flux/Dockerfile -t flux-reframe .
+
+Then shell inside, optionally binding the present working directory if
+you want to develop.
+
+.. code:: bash
+
+   $ docker run -it -v $PWD:/code flux-reframe
+   $ docker run -it flux-reframe
+
+Note that if you build the local repository, you’ll need to bootstrap
+and install again, as we have over-written the bin!
+
+.. code:: bash
+
+   ./bootstrap.sh
+
+And then reframe will again be in the local ``bin`` directory:
+
+.. code:: bash
+
+   # which reframe
+   /code/bin/reframe
+
+Then we can run reframe with the custom config `config.py <config.py>`__
+for flux.
+
+.. code:: bash
+
+   # What tests are under tutorials/flux?
+   $ cd tutorials/flux
+   $ reframe -c . -C settings.py -l
+
+.. code:: console
+
+   [ReFrame Setup]
+     version:           4.0.0-dev.1
+     command:           '/code/bin/reframe -c tutorials/flux -C tutorials/flux/settings.py -l'
+     launched by:       root@b1f6650222bc
+     working directory: '/code'
+     settings file:     'tutorials/flux/settings.py'
+     check search path: '/code/tutorials/flux'
+     stage directory:   '/code/stage'
+     output directory:  '/code/output'
+
+   [List of matched checks]
+   - EchoRandTest /66b93401
+   Found 1 check(s)
+
+   Log file(s) saved in '/tmp/rfm-ilqg7fqg.log'
+
+This also works
+
+.. code:: bash
+
+   $ reframe -c tutorials/flux -C tutorials/flux/settings.py -l
+
+And then to run tests, just replace ``-l`` (for list) with ``-r`` or
+``--run`` (for run):
+
+.. code:: bash
+
+   $ reframe -c tutorials/flux -C tutorials/flux/settings.py --run
+
+.. code:: console
+
+   root@b1f6650222bc:/code# reframe -c tutorials/flux -C tutorials/flux/settings.py --run
+   [ReFrame Setup]
+     version:           4.0.0-dev.1
+     command:           '/code/bin/reframe -c tutorials/flux -C tutorials/flux/settings.py --run'
+     launched by:       root@b1f6650222bc
+     working directory: '/code'
+     settings file:     'tutorials/flux/settings.py'
+     check search path: '/code/tutorials/flux'
+     stage directory:   '/code/stage'
+     output directory:  '/code/output'
+
+   [==========] Running 1 check(s)
+   [==========] Started on Fri Sep 16 20:47:15 2022 
+
+   [----------] start processing checks
+   [ RUN      ] EchoRandTest /66b93401 @generic:default+builtin
+   [       OK ] (1/1) EchoRandTest /66b93401 @generic:default+builtin
+   [----------] all spawned checks have finished
+
+   [  PASSED  ] Ran 1/1 test case(s) from 1 check(s) (0 failure(s), 0 skipped)
+   [==========] Finished on Fri Sep 16 20:47:15 2022 
+   Run report saved in '/root/.reframe/reports/run-report.json'
+   Log file(s) saved in '/tmp/rfm-0avso9nb.log'
+   
+For advanced users or developers, here is how to run tests within the container:
+
+Testing
+-------
+
+.. code:: console
+
+    ./test_reframe.py --rfm-user-config=tutorials/flux/settings.py unittests/test_schedulers.py -xs

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -11,7 +11,7 @@ ReFrame Tutorials
    tutorial_fixtures
    tutorial_build_automation
    tutorial_tips_tricks
-
+   tutorial_flux
 
 Online Tutorials
 ----------------

--- a/reframe/core/backends.py
+++ b/reframe/core/backends.py
@@ -17,6 +17,7 @@ _launcher_backend_modules = [
 ]
 _launchers = {}
 _scheduler_backend_modules = [
+    'reframe.core.schedulers.flux',
     'reframe.core.schedulers.local',
     'reframe.core.schedulers.lsf',
     'reframe.core.schedulers.pbs',

--- a/reframe/core/schedulers/flux.py
+++ b/reframe/core/schedulers/flux.py
@@ -6,17 +6,18 @@
 #
 # Flux-Framework backend
 #
-# - Initial version submitted by Vanessa Sochat, Lawrence Livermore National Lab
+# - Initial version submitted by Vanessa Sochat,
+#   Lawrence Livermore National Lab
 #
 
+import itertools
 import os
 import time
 
 import reframe.core.runtime as rt
 from reframe.core.backends import register_scheduler
-from reframe.core.exceptions import JobSchedulerError, JobError
-from reframe.core.schedulers.pbs import PbsJobScheduler
-
+from reframe.core.exceptions import JobError
+from reframe.core.schedulers import JobScheduler, Job
 
 # Just import flux once
 try:
@@ -24,18 +25,58 @@ try:
     import flux.job
     from flux.job import JobspecV1
 except ImportError:
-    flux = None
+    error = "no flux Python bindings found"
+else:
+    error = None
 
 waiting_states = ["QUEUED", "HELD", "WAITING", "PENDING"]
 
 
-@register_scheduler("flux")
-class FluxJobScheduler(PbsJobScheduler):
+class _FluxJob(Job):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._cancelled = False
+
+        # This is set by the scheduler when both the job's state is
+        # 'COMPLETED' and the job's stdout and stderr are written back
+        self._completed = False
+        self.create_job(**kwargs)
+
+    def create_job(self, **kwargs):
+        """
+        Create the flux job (and future) to watch.
+        """
+        # Generate the flux job
+        self.fluxjob = JobspecV1.from_command(
+            command=["/bin/bash", self.script_filename],
+            num_tasks=self.num_tasks_per_core or 1,
+            cores_per_task=self.num_cpus_per_task or 1,
+        )
+
+        # We must use absolute paths for Flux
+        out = os.path.join(os.path.abspath(self.workdir), self.stdout)
+        err = os.path.join(os.path.abspath(self.workdir), self.stderr)
+
+        # A duration of zero (the default) means unlimited
+        self.fluxjob.duration = self.time_limit or 0
+        self.fluxjob.stdout = out
+        self.fluxjob.stderr = err
+        self.fluxjob.cwd = os.path.abspath(self.workdir)
+        self.fluxjob.environment = dict(os.environ)
+
+    @property
+    def cancelled(self):
+        return self._cancelled
+
+    @property
+    def completed(self):
+        return self._completed
+
+
+@register_scheduler("flux", error=error)
+class FluxJobScheduler(JobScheduler):
     def __init__(self):
-        if not flux:
-            raise JobSchedulerError(
-                "Cannot import flux. Is a cluster available to you with Python bindings?"
-            )
         self._fexecutor = flux.job.FluxExecutor()
         self._submit_timeout = rt.runtime().get_option(
             f"schedulers/@{self.registered_name}/job_submit_timeout"
@@ -45,45 +86,41 @@ class FluxJobScheduler(PbsJobScheduler):
         # We don't need to submit with a file, so we don't need a preamble.
         return []
 
+    def make_job(self, *args, **kwargs):
+        return _FluxJob(*args, **kwargs)
+
     def submit(self, job):
         """
         Submit a job to the flux executor.
         """
-        # Output and error files
-        script_prefix = job.script_filename.split(".")[0]
-        output = os.path.join(job.workdir, f"{script_prefix}.out")
-        error = os.path.join(job.workdir, f"{script_prefix}.err")
-
-        # Generate the flux job
-        # Assume the filename includes a hashbang
-        # flux does not support mem_mb, disk_mb
-        fluxjob = JobspecV1.from_command(
-            command=["/bin/bash", job.script_filename],
-            num_tasks=job.num_tasks_per_core or 1,
-            cores_per_task=job.num_cpus_per_task or 1,
-        )
-
-        # A duration of zero (the default) means unlimited
-        fluxjob.duration = job.time_limit or 0
-        fluxjob.stdout = output
-        fluxjob.stderr = error
-
-        # This doesn't seem to be used?
-        fluxjob.cwd = job.workdir
-        fluxjob.environment = dict(os.environ)
-        flux_future = self._fexecutor.submit(fluxjob)
+        flux_future = self._fexecutor.submit(job.fluxjob)
         job._jobid = str(flux_future.jobid())
         job._submit_time = time.time()
         job._flux_future = flux_future
 
     def cancel(self, job):
-        # Job cannot cancel once running or completed
+        """
+        Cancel a running Flux job.
+        """
+        # Job future cannot cancel once running or completed
         if not job._flux_future.cancel():
             # This will raise JobException with event=cancel (on poll)
             flux.job.cancel(flux.Flux(), job._flux_future.jobid())
+
+        # In testing, cancel is too "soft" - or often the pid is still remaining
+        # after. We thus do a cancel in addition to a kill.
+        try:
+            flux.job.kill(flux.Flux(), job._flux_future.jobid())
+
+        # Job is inactive
+        except EnvironmentError:
+            pass
         job._is_cancelling = True
 
     def poll(self, *jobs):
+        """
+        Poll running Flux jobs for updated states.
+        """
         if jobs:
             # filter out non-jobs
             jobs = [job for job in jobs if job is not None]
@@ -93,18 +130,15 @@ class FluxJobScheduler(PbsJobScheduler):
 
         # Loop through active jobs and act on status
         for job in jobs:
-
             if job._flux_future.done():
                 # The exit code can help us determine if the job was successful
                 try:
                     exit_code = job._flux_future.result(0)
-
-                # Currently the only state we see is cancelled here
                 except flux.job.JobException:
+                    # Currently the only state we see is cancelled here
                     self.log(f"Job {job.jobid} was likely cancelled.")
                     job._state = "CANCELLED"
                     job._cancelled = True
-
                 except RuntimeError:
                     # Assume some runtime issue (suspended)
                     self.log(f"Job {job.jobid} was likely suspended.")
@@ -113,21 +147,41 @@ class FluxJobScheduler(PbsJobScheduler):
                     # the job finished (but possibly with nonzero exit code)
                     if exit_code != 0:
                         self.log(f"Job {job.jobid} did not finish successfully")
-                    job._state = "COMPLETED"
-                job._completed = True
 
+                    job._state = "COMPLETED"
+
+                job._completed = True
             elif job.state in waiting_states and job.max_pending_time:
                 if time.time() - job.submit_time >= job.max_pending_time:
                     self.cancel(job)
                     job._exception = JobError(
                         "maximum pending time exceeded", job.jobid
                     )
-
-            # Otherwise, we are still running
             else:
+                # Otherwise, we are still running
                 job._state = "RUNNING"
+
+    def allnodes(self):
+        """
+        Return a set of all free nodes.
+        """
+        rpc = flux.resource.list.resource_list(flux.Flux())
+        listing = rpc.get()
+        return {str(node) for node in listing.free.nodelist}
+
+    def filternodes(self, job, nodes):
+        raise NotImplementedError("flux backend does not support node filtering")
+
+    def wait(self, job):
+        """
+        Wait until a job is finished.
+        """
+        intervals = itertools.cycle([1, 2, 3])
+        while not self.finished(job):
+            self.poll(job)
+            time.sleep(next(intervals))
 
     def finished(self, job):
         if job.exception:
             raise job.exception
-        return job.state in ["COMPLETED", "CANCELLED", "SUSPENDED"]
+        return job.completed

--- a/reframe/core/schedulers/flux.py
+++ b/reframe/core/schedulers/flux.py
@@ -41,9 +41,9 @@ class _FluxJob(Job):
         # This is set by the scheduler when both the job's state is
         # 'COMPLETED' and the job's stdout and stderr are written back
         self._completed = False
-        self.create_job(**kwargs)
+        self.create_job()
 
-    def create_job(self, **kwargs):
+    def create_job(self):
         """
         Create the flux job (and future) to watch.
         """
@@ -115,7 +115,6 @@ class FluxJobScheduler(JobScheduler):
         # Job is inactive
         except EnvironmentError:
             pass
-        job._is_cancelling = True
 
     def poll(self, *jobs):
         """
@@ -162,12 +161,7 @@ class FluxJobScheduler(JobScheduler):
                 job._state = "RUNNING"
 
     def allnodes(self):
-        """
-        Return a set of all free nodes.
-        """
-        rpc = flux.resource.list.resource_list(flux.Flux())
-        listing = rpc.get()
-        return {str(node) for node in listing.free.nodelist}
+        raise NotImplementedError("flux backend does not support node listing")
 
     def filternodes(self, job, nodes):
         raise NotImplementedError("flux backend does not support node filtering")

--- a/reframe/core/schedulers/flux.py
+++ b/reframe/core/schedulers/flux.py
@@ -25,31 +25,22 @@ try:
     import flux.job
     from flux.job import JobspecV1
 except ImportError:
-    error = "no flux Python bindings found"
+    error = 'no flux Python bindings found'
 else:
     error = None
 
-waiting_states = ["QUEUED", "HELD", "WAITING", "PENDING"]
+WAITING_STATES = ('QUEUED', 'HELD', 'WAITING', 'PENDING')
 
 
 class _FluxJob(Job):
     def __init__(self, *args, **kwargs):
+        '''Create the flux job (and future) to watch.'''
+
         super().__init__(*args, **kwargs)
 
-        self._cancelled = False
-
-        # This is set by the scheduler when both the job's state is
-        # 'COMPLETED' and the job's stdout and stderr are written back
-        self._completed = False
-        self.create_job()
-
-    def create_job(self):
-        """
-        Create the flux job (and future) to watch.
-        """
         # Generate the flux job
         self.fluxjob = JobspecV1.from_command(
-            command=["/bin/bash", self.script_filename],
+            command=['/bin/bash', self.script_filename],
             num_tasks=self.num_tasks_per_core or 1,
             cores_per_task=self.num_cpus_per_task or 1,
         )
@@ -66,20 +57,16 @@ class _FluxJob(Job):
         self.fluxjob.environment = dict(os.environ)
 
     @property
-    def cancelled(self):
-        return self._cancelled
-
-    @property
     def completed(self):
-        return self._completed
+        return not self.state in WAITING_STATES
 
 
-@register_scheduler("flux", error=error)
+@register_scheduler('flux', error=error)
 class FluxJobScheduler(JobScheduler):
     def __init__(self):
         self._fexecutor = flux.job.FluxExecutor()
         self._submit_timeout = rt.runtime().get_option(
-            f"schedulers/@{self.registered_name}/job_submit_timeout"
+            f'schedulers/@{self.registered_name}/job_submit_timeout'
         )
 
     def emit_preamble(self, job):
@@ -90,36 +77,24 @@ class FluxJobScheduler(JobScheduler):
         return _FluxJob(*args, **kwargs)
 
     def submit(self, job):
-        """
-        Submit a job to the flux executor.
-        """
+        '''Submit a job to the flux executor.'''
+
         flux_future = self._fexecutor.submit(job.fluxjob)
         job._jobid = str(flux_future.jobid())
         job._submit_time = time.time()
         job._flux_future = flux_future
 
     def cancel(self, job):
-        """
-        Cancel a running Flux job.
-        """
+        '''Cancel a running Flux job.'''
+
         # Job future cannot cancel once running or completed
         if not job._flux_future.cancel():
             # This will raise JobException with event=cancel (on poll)
             flux.job.cancel(flux.Flux(), job._flux_future.jobid())
 
-        # In testing, cancel is too "soft" - or often the pid is still remaining
-        # after. We thus do a cancel in addition to a kill.
-        try:
-            flux.job.kill(flux.Flux(), job._flux_future.jobid())
-
-        # Job is inactive
-        except EnvironmentError:
-            pass
-
     def poll(self, *jobs):
-        """
-        Poll running Flux jobs for updated states.
-        """
+        '''Poll running Flux jobs for updated states.'''
+
         if jobs:
             # filter out non-jobs
             jobs = [job for job in jobs if job is not None]
@@ -135,41 +110,43 @@ class FluxJobScheduler(JobScheduler):
                     exit_code = job._flux_future.result(0)
                 except flux.job.JobException:
                     # Currently the only state we see is cancelled here
-                    self.log(f"Job {job.jobid} was likely cancelled.")
-                    job._state = "CANCELLED"
-                    job._cancelled = True
+                    self.log(f'Job {job.jobid} was likely cancelled.')
+                    job._state = 'CANCELLED'
                 except RuntimeError:
                     # Assume some runtime issue (suspended)
-                    self.log(f"Job {job.jobid} was likely suspended.")
-                    job._state = "SUSPENDED"
+                    self.log(f'Job {job.jobid} was likely suspended.')
+                    job._state = 'SUSPENDED'
                 else:
                     # the job finished (but possibly with nonzero exit code)
                     if exit_code != 0:
-                        self.log(f"Job {job.jobid} did not finish successfully")
+                        self.log(
+                            f'Job {job.jobid} did not finish successfully'
+                        )
 
-                    job._state = "COMPLETED"
+                    job._state = 'COMPLETED'
 
                 job._completed = True
-            elif job.state in waiting_states and job.max_pending_time:
+            elif job.state in WAITING_STATES and job.max_pending_time:
                 if time.time() - job.submit_time >= job.max_pending_time:
                     self.cancel(job)
                     job._exception = JobError(
-                        "maximum pending time exceeded", job.jobid
+                        'maximum pending time exceeded', job.jobid
                     )
             else:
                 # Otherwise, we are still running
-                job._state = "RUNNING"
+                job._state = 'RUNNING'
 
     def allnodes(self):
-        raise NotImplementedError("flux backend does not support node listing")
+        raise NotImplementedError('flux backend does not support node listing')
 
     def filternodes(self, job, nodes):
-        raise NotImplementedError("flux backend does not support node filtering")
+        raise NotImplementedError(
+            'flux backend does not support node filtering'
+        )
 
     def wait(self, job):
-        """
-        Wait until a job is finished.
-        """
+        '''Wait until a job is finished.'''
+
         intervals = itertools.cycle([1, 2, 3])
         while not self.finished(job):
             self.poll(job)
@@ -178,4 +155,5 @@ class FluxJobScheduler(JobScheduler):
     def finished(self, job):
         if job.exception:
             raise job.exception
+
         return job.completed

--- a/reframe/core/schedulers/flux.py
+++ b/reframe/core/schedulers/flux.py
@@ -1,0 +1,133 @@
+# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# ReFrame Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+#
+# Flux-Framework backend
+#
+# - Initial version submitted by Vanessa Sochat, Lawrence Livermore National Lab
+#
+
+import os
+import time
+
+import reframe.core.runtime as rt
+from reframe.core.backends import register_scheduler
+from reframe.core.exceptions import JobSchedulerError, JobError
+from reframe.core.schedulers.pbs import PbsJobScheduler
+
+
+# Just import flux once
+try:
+    import flux
+    import flux.job
+    from flux.job import JobspecV1
+except ImportError:
+    flux = None
+
+waiting_states = ["QUEUED", "HELD", "WAITING", "PENDING"]
+
+
+@register_scheduler("flux")
+class FluxJobScheduler(PbsJobScheduler):
+    def __init__(self):
+        if not flux:
+            raise JobSchedulerError(
+                "Cannot import flux. Is a cluster available to you with Python bindings?"
+            )
+        self._fexecutor = flux.job.FluxExecutor()
+        self._submit_timeout = rt.runtime().get_option(
+            f"schedulers/@{self.registered_name}/job_submit_timeout"
+        )
+
+    def emit_preamble(self, job):
+        # We don't need to submit with a file, so we don't need a preamble.
+        return []
+
+    def submit(self, job):
+        """
+        Submit a job to the flux executor.
+        """
+        # Output and error files
+        script_prefix = job.script_filename.split(".")[0]
+        output = os.path.join(job.workdir, f"{script_prefix}.out")
+        error = os.path.join(job.workdir, f"{script_prefix}.err")
+
+        # Generate the flux job
+        # Assume the filename includes a hashbang
+        # flux does not support mem_mb, disk_mb
+        fluxjob = JobspecV1.from_command(
+            command=["/bin/bash", job.script_filename],
+            num_tasks=job.num_tasks_per_core or 1,
+            cores_per_task=job.num_cpus_per_task or 1,
+        )
+
+        # A duration of zero (the default) means unlimited
+        fluxjob.duration = job.time_limit or 0
+        fluxjob.stdout = output
+        fluxjob.stderr = error
+
+        # This doesn't seem to be used?
+        fluxjob.cwd = job.workdir
+        fluxjob.environment = dict(os.environ)
+        flux_future = self._fexecutor.submit(fluxjob)
+        job._jobid = str(flux_future.jobid())
+        job._submit_time = time.time()
+        job._flux_future = flux_future
+
+    def cancel(self, job):
+        # Job cannot cancel once running or completed
+        if not job._flux_future.cancel():
+            # This will raise JobException with event=cancel (on poll)
+            flux.job.cancel(flux.Flux(), job._flux_future.jobid())
+        job._is_cancelling = True
+
+    def poll(self, *jobs):
+        if jobs:
+            # filter out non-jobs
+            jobs = [job for job in jobs if job is not None]
+
+        if not jobs:
+            return
+
+        # Loop through active jobs and act on status
+        for job in jobs:
+
+            if job._flux_future.done():
+                # The exit code can help us determine if the job was successful
+                try:
+                    exit_code = job._flux_future.result(0)
+
+                # Currently the only state we see is cancelled here
+                except flux.job.JobException:
+                    self.log(f"Job {job.jobid} was likely cancelled.")
+                    job._state = "CANCELLED"
+                    job._cancelled = True
+
+                except RuntimeError:
+                    # Assume some runtime issue (suspended)
+                    self.log(f"Job {job.jobid} was likely suspended.")
+                    job._state = "SUSPENDED"
+                else:
+                    # the job finished (but possibly with nonzero exit code)
+                    if exit_code != 0:
+                        self.log(f"Job {job.jobid} did not finish successfully")
+                    job._state = "COMPLETED"
+                job._completed = True
+
+            elif job.state in waiting_states and job.max_pending_time:
+                if time.time() - job.submit_time >= job.max_pending_time:
+                    self.cancel(job)
+                    job._exception = JobError(
+                        "maximum pending time exceeded", job.jobid
+                    )
+
+            # Otherwise, we are still running
+            else:
+                job._state = "RUNNING"
+
+    def finished(self, job):
+        if job.exception:
+            raise job.exception
+        return job.state in ["COMPLETED", "CANCELLED", "SUSPENDED"]

--- a/reframe/core/schedulers/registry.py
+++ b/reframe/core/schedulers/registry.py
@@ -35,6 +35,7 @@ def getscheduler(name):
 
 
 # Import the schedulers modules to trigger their registration
+import reframe.core.schedulers.flux    # noqa: F401, F403
 import reframe.core.schedulers.local   # noqa: F401, F403
 import reframe.core.schedulers.lsf     # noqa: F401, F403
 import reframe.core.schedulers.oar     # noqa: F401, F403

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -246,7 +246,7 @@
                                 "scheduler": {
                                     "type": "string",
                                     "enum": [
-                                        "local", "lsf", "oar", "pbs",
+                                        "flux", "local", "lsf", "oar", "pbs",
                                         "sge", "slurm", "squeue", "torque"
                                     ]
                                 },
@@ -383,7 +383,7 @@
                 "properties": {
                     "name": {
                         "type": "string",
-                        "enum": ["local", "lsf", "oar", "pbs",
+                        "enum": ["flux", "local", "lsf", "oar", "pbs",
                                  "sge", "slurm", "squeue", "torque"]
                     },
                     "ignore_reqnodenotavail": {"type": "boolean"},

--- a/tutorials/flux/Dockerfile
+++ b/tutorials/flux/Dockerfile
@@ -6,7 +6,8 @@ USER root
 ENV PATH=/opt/conda/bin:$PATH
 WORKDIR /code
 COPY . /code
-RUN /bin/bash /code/bootstrap.sh
+RUN /bin/bash /code/bootstrap.sh && \
+    python3 -m pip install pytest
 ENV PATH=/code/bin:$PATH
 # If you want to develop, you'll need to comment this
 # USER fluxuser

--- a/tutorials/flux/Dockerfile
+++ b/tutorials/flux/Dockerfile
@@ -1,0 +1,12 @@
+FROM fluxrm/flux-sched:focal
+# docker build -f tutorials/flux/Dockerfile -t flux-reframe .
+# docker run -it -v $PWD:/code flux-reframe
+# docker run -it flux-reframe
+USER root
+ENV PATH=/opt/conda/bin:$PATH
+WORKDIR /code
+COPY . /code
+RUN /bin/bash /code/bootstrap.sh
+ENV PATH=/code/bin:$PATH
+# If you want to develop, you'll need to comment this
+# USER fluxuser

--- a/tutorials/flux/README.md
+++ b/tutorials/flux/README.md
@@ -1,4 +1,4 @@
 # Flux Framework Tutorial
 
-This is a demo that will show how to use refame with [Flux Framework](https://github.com/flux-framework/).
+This is a demo that will show how to use ReFrame with [Flux Framework](https://github.com/flux-framework/).
 You can find the full instruction in the [online documentation](https://reframe-hpc.readthedocs.io/en/stable/tutorial_flux.html).

--- a/tutorials/flux/README.md
+++ b/tutorials/flux/README.md
@@ -1,0 +1,4 @@
+# Flux Framework Tutorial
+
+This is a demo that will show how to use refame with [Flux Framework](https://github.com/flux-framework/).
+You can find the full instruction in the [online documentation](https://reframe-hpc.readthedocs.io/en/stable/tutorial_flux.html).

--- a/tutorials/flux/example1.py
+++ b/tutorials/flux/example1.py
@@ -1,0 +1,32 @@
+# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# ReFrame Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# rfmdocstart: echorand
+import reframe as rfm
+import reframe.utility.sanity as sn
+
+
+@rfm.simple_test
+class EchoRandTest(rfm.RunOnlyRegressionTest):
+    descr = 'A simple test that echoes a random number'
+    valid_systems = ['*']
+    valid_prog_environs = ['*']
+    lower = variable(int, value=90)
+    upper = variable(int, value=100)
+    executable = 'echo'
+    executable_opts = [
+        'Random: ',
+        f'$((RANDOM%({upper}+1-{lower})+{lower}))'
+    ]
+
+    @sanity_function
+    def assert_solution(self):
+        return sn.assert_bounded(
+            sn.extractsingle(
+                r'Random: (?P<number>\S+)', self.stdout, 'number', float
+            ),
+            self.lower, self.upper
+        )
+# rfmdocend: echorand

--- a/tutorials/flux/settings.py
+++ b/tutorials/flux/settings.py
@@ -1,0 +1,69 @@
+# Copyright 2016-2022 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# ReFrame Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+#
+# Generic fallback configuration
+#
+
+site_configuration = {
+    'systems': [
+        {
+            'name': 'generic',
+            'descr': 'Generic example system',
+            'hostnames': ['.*'],
+            'partitions': [
+                {
+                    'name': 'default',
+                    'scheduler': 'flux',                    
+                    'launcher': 'local',
+                    'environs': ['builtin']
+                }
+            ]
+        },
+    ],
+    'environments': [
+        {
+            'name': 'builtin',
+            'cc': 'cc',
+            'cxx': '',
+            'ftn': ''
+        },
+    ],
+    'logging': [
+        {
+            'handlers': [
+                {
+                    'type': 'stream',
+                    'name': 'stdout',
+                    'level': 'info',
+                    'format': '%(message)s'
+                },
+                {
+                    'type': 'file',
+                    'level': 'debug',
+                    'format': '[%(asctime)s] %(levelname)s: %(check_info)s: %(message)s',   # noqa: E501
+                    'append': False
+                }
+            ],
+            'handlers_perflog': [
+                {
+                    'type': 'filelog',
+                    'prefix': '%(check_system)s/%(check_partition)s',
+                    'level': 'info',
+                    'format': (
+                        '%(check_job_completion_time)s|reframe %(version)s|'
+                        '%(check_info)s|jobid=%(check_jobid)s|'
+                        '%(check_perf_var)s=%(check_perf_value)s|'
+                        'ref=%(check_perf_ref)s '
+                        '(l=%(check_perf_lower_thres)s, '
+                        'u=%(check_perf_upper_thres)s)|'
+                        '%(check_perf_unit)s'
+                    ),
+                    'append': True
+                }
+            ]
+        }
+    ],
+}

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -397,7 +397,7 @@ def test_submit(make_job, exec_ctx):
         assert [socket.gethostname()] == minimal_job.nodelist
         assert minimal_job.exitcode == 0
         assert minimal_job.state == 'SUCCESS'
-    elif sched_name in ('slurm', 'squeue', 'pbs', 'torque', 'flux'):
+    elif sched_name in ('slurm', 'squeue', 'pbs', 'torque'):
         num_tasks_per_node = minimal_job.num_tasks_per_node or 1
         num_nodes = minimal_job.num_tasks // num_tasks_per_node
         assert num_nodes == len(minimal_job.nodelist)
@@ -667,8 +667,12 @@ def test_cancel_with_grace(minimal_job, scheduler, local_only):
     assert minimal_job.signal == signal.SIGKILL
 
     # Verify that the spawned sleep is killed, too, but back off a bit in
-    # order to allow the sleep process to wake up and get the signal
-    time.sleep(0.1)
+    # order to allow the init process to reap it.
+    #
+    # NOTE: If this unit test is run inside a container, make sure that the
+    # PID 1 process is able to reap zombie processes; if not, make sure that
+    # the container is launched with the proper options, e.g., `docker --init`.
+    time.sleep(0.2)
     assert_process_died(sleep_pid)
 
 
@@ -710,8 +714,12 @@ def test_cancel_term_ignore(minimal_job, scheduler, local_only):
     assert minimal_job.signal == signal.SIGKILL
 
     # Verify that the spawned sleep is killed, too, but back off a bit in
-    # order to allow the sleep process to wake up and get the signal
-    time.sleep(0.1)
+    # order to allow the init process to reap it.
+    #
+    # NOTE: If this unit test is run inside a container, make sure that the
+    # PID 1 process is able to reap zombie processes; if not, make sure that
+    # the container is launched with the proper options, e.g., `docker --init`.
+    time.sleep(0.2)
     assert_process_died(sleep_pid)
 
 

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -397,7 +397,7 @@ def test_submit(make_job, exec_ctx):
         assert [socket.gethostname()] == minimal_job.nodelist
         assert minimal_job.exitcode == 0
         assert minimal_job.state == 'SUCCESS'
-    elif sched_name == ('slurm', 'squeue', 'pbs', 'torque', 'flux'):
+    elif sched_name in ('slurm', 'squeue', 'pbs', 'torque', 'flux'):
         num_tasks_per_node = minimal_job.num_tasks_per_node or 1
         num_nodes = minimal_job.num_tasks // num_tasks_per_node
         assert num_nodes == len(minimal_job.nodelist)

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -397,7 +397,7 @@ def test_submit(make_job, exec_ctx):
         assert [socket.gethostname()] == minimal_job.nodelist
         assert minimal_job.exitcode == 0
         assert minimal_job.state == 'SUCCESS'
-    elif sched_name in ('slurm', 'squeue', 'pbs', 'torque'):
+    elif sched_name in ('slurm', 'pbs', 'torque'):
         num_tasks_per_node = minimal_job.num_tasks_per_node or 1
         num_nodes = minimal_job.num_tasks // num_tasks_per_node
         assert num_nodes == len(minimal_job.nodelist)

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -629,10 +629,6 @@ def _read_pid(job, attempts=3):
                 f'{attempts} attempts')
 
 
-@pytest.mark.skipif(
-    os.environ.get('SKIP_FLAKY_CANCEL') is not None,
-    reason="Local cancel tests are flaky when running with Flux."
-)
 @pytest.mark.flaky(reruns=3)
 def test_cancel_with_grace(minimal_job, scheduler, local_only):
     # This test emulates a spawned process that ignores the SIGTERM signal
@@ -676,10 +672,6 @@ def test_cancel_with_grace(minimal_job, scheduler, local_only):
     assert_process_died(sleep_pid)
 
 
-@pytest.mark.skipif(
-    os.environ.get('SKIP_FLAKY_CANCEL') is not None,
-    reason="Local cancel tests are flaky when running with Flux."
-)
 @pytest.mark.flaky(reruns=3)
 def test_cancel_term_ignore(minimal_job, scheduler, local_only):
     # This test emulates a descendant process of the spawned job that


### PR DESCRIPTION
This will add a basic scheduler that can interact with Flux: https://github.com/flux-framework/flux-core

Today is the first day I've ever used (and developed for) reframe, so I will need to ask for guidance on the best way to run tests, as either we will need a container base with flux or to mock something. The way I was able to develop and test is by adding a tutorial that I ran in a container! I also suspect I'll need to add proper documentation, if you could point me to the best places to do that. Thank you!

 - [x] Discuss testing strategy
 - [x] Documentation updates?

Signed-off-by: vsoch <vsoch@users.noreply.github.com>