### PR TITLE
[feat] Revert to generating unique run reports

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -1483,13 +1483,15 @@ General Configuration
 .. js:attribute:: .general[].report_file
 
    :required: No
-   :default: ``"${HOME}/.reframe/reports/run-report.json"``
+   :default: ``"${HOME}/.reframe/reports/run-report-{sessionid}.json"``
 
    The file where ReFrame will store its report.
 
    .. versionadded:: 3.1
    .. versionchanged:: 3.2
       Default value has changed to avoid generating a report file per session.
+   .. versionchanged:: 4.0.0
+      Default value was reverted back to generate a new file per run.
 
 
 .. js:attribute:: .general[].report_junit

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -528,7 +528,7 @@
         "general/purge_environment": false,
         "general/remote_detect": false,
         "general/remote_workdir": ".",
-        "general/report_file": "${HOME}/.reframe/reports/run-report.json",
+        "general/report_file": "${HOME}/.reframe/reports/run-report-{sessionid}.json",
         "general/report_junit": null,
         "general/resolve_module_conflicts": true,
         "general/save_log_files": false,


### PR DESCRIPTION
I think it's better, because it allows you to look up previous runs by default.