### PR TITLE
[feat] Stop execution with an error when a cli module fails to load

### DIFF
--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -1241,9 +1241,10 @@ def main():
                 rt.modules_system.load_module(**m, force=True)
             except errors.EnvironError as e:
                 printer.error(
-                    f'could not load module {m["name"]!r} correctly'
+                    f'could not load module {m["name"]!r} correctly; rerun '
+                    f'with -vv for more information'
                 )
-                printer.error(str(e))
+                printer.debug(str(e))
                 sys.exit(1)
 
         options.flex_alloc_nodes = options.flex_alloc_nodes or 'idle'

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -1240,11 +1240,11 @@ def main():
             try:
                 rt.modules_system.load_module(**m, force=True)
             except errors.EnvironError as e:
-                printer.warning(
-                    f'could not load module {m["name"]!r} correctly; '
-                    f'skipping...'
+                printer.error(
+                    f'could not load module {m["name"]!r} correctly'
                 )
-                printer.debug(str(e))
+                printer.error(str(e))
+                sys.exit(1)
 
         options.flex_alloc_nodes = options.flex_alloc_nodes or 'idle'
 

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -721,7 +721,7 @@ def test_unuse_module_path(run_reframe, user_exec_ctx):
     ms.searchpath_remove(module_path)
     assert "could not load module 'testmod_foo' correctly" in stdout
     assert 'Traceback' not in stderr
-    assert returncode == 0
+    assert returncode == 1
 
 
 def test_use_module_path(run_reframe, user_exec_ctx):


### PR DESCRIPTION
The output will look something like this:
```bash
$ reframe -m wrong_module -v ...
[ReFrame Setup]
...

./bin/reframe: could not load module 'wrong_module' correctly
Log file(s) saved in ...
```

With `-vv` then the output is:
```bash
$ reframe -m wrong_module -vv ...
[ReFrame Setup]
...

./bin/reframe: could not load module 'wrong_module' correctly
./bin/reframe: could not execute module operation: command 'modulecmd python show wrong_module' failed with exit code 0:
--- stdout ---
--- stdout ---
--- stderr ---
ModuleCmd_Display.c(157):ERROR:105: Unable to locate a modulefile for 'wrong_module'


--- stderr ---
Log file(s) saved in ...
```

Closes #2597 .