### PR TITLE
[doc] Adapt README for dark and light Github modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-<div align="left">
- <img src="docs/_static/img/reframe_logo-width400p.png#gh-light-mode-only" width="400px">
- <img src="docs/_static/img/reframe-logo-dark-bg.png#gh-dark-mode-only" width="400px">
-</div>
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/_static/img/reframe-logo-dark-bg.png" width="400px">
+  <source media="(prefers-color-scheme: light)" srcset="docs/_static/img/reframe_logo-full.png" width="400px">
+  <img alt="ReFrame logo" src="https://raw.githubusercontent.com/reframe-hpc/reframe/master/docs/_static/img/reframe_logo-full.png">
+</picture>
 
 [![Build Status](https://github.com/reframe-hpc/reframe/workflows/ReFrame%20CI/badge.svg)](https://github.com/reframe-hpc/reframe/actions?query=workflow%3A%22ReFrame+CI%22)
 [![Documentation Status](https://readthedocs.org/projects/reframe-hpc/badge/?version=latest)](https://reframe-hpc.readthedocs.io/en/latest/?badge=latest)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <picture>
-  <source media="(prefers-color-scheme: light)" srcset="docs/_static/img/reframe-logo-dark-bg.png" width="400px">
-  <source media="(prefers-color-scheme: dark)" srcset="docs/_static/img/reframe_logo-full.png" width="400px">
+  <source media="(prefers-color-scheme: dark)" srcset="docs/_static/img/reframe-logo-dark-bg.png">
+  <source media="(prefers-color-scheme: light)" srcset="docs/_static/img/reframe_logo-full.png">
   <img alt="ReFrame logo" src="https://raw.githubusercontent.com/reframe-hpc/reframe/master/docs/_static/img/reframe_logo-full.png">
 </picture>
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="docs/_static/img/reframe-logo-dark-bg.png">
-  <source media="(prefers-color-scheme: light)" srcset="docs/_static/img/reframe_logo-full.png">
-  <img alt="ReFrame logo" src="https://raw.githubusercontent.com/reframe-hpc/reframe/master/docs/_static/img/reframe_logo-full.png">
-</picture>
+<div align="left">
+ <img src="docs/_static/img/reframe_logo-width400p.png#gh-light-mode-only" width="400px">
+ <img src="docs/_static/img/reframe-logo-dark-bg.png#gh-dark-mode-only" width="400px">
+</div>
 
 [![Build Status](https://github.com/reframe-hpc/reframe/workflows/ReFrame%20CI/badge.svg)](https://github.com/reframe-hpc/reframe/actions?query=workflow%3A%22ReFrame+CI%22)
 [![Documentation Status](https://readthedocs.org/projects/reframe-hpc/badge/?version=latest)](https://reframe-hpc.readthedocs.io/en/latest/?badge=latest)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/_static/img/reframe-logo-dark-bg.png">
   <source media="(prefers-color-scheme: light)" srcset="docs/_static/img/reframe_logo-full.png">
+  <img alt="ReFrame logo" src="https://raw.githubusercontent.com/reframe-hpc/reframe/master/docs/_static/img/reframe_logo-full.png">
 </picture>
 
 [![Build Status](https://github.com/reframe-hpc/reframe/workflows/ReFrame%20CI/badge.svg)](https://github.com/reframe-hpc/reframe/actions?query=workflow%3A%22ReFrame+CI%22)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
  <img src="docs/_static/img/reframe-logo-dark-bg.png#gh-dark-mode-only" width="400px">
 </div>
 
-[![ReFrame Logo](https://raw.githubusercontent.com/reframe-hpc/reframe/master/docs/_static/img/reframe_logo-width400p.png)](https://github.com/reframe-hpc/reframe)<br/>
 [![Build Status](https://github.com/reframe-hpc/reframe/workflows/ReFrame%20CI/badge.svg)](https://github.com/reframe-hpc/reframe/actions?query=workflow%3A%22ReFrame+CI%22)
 [![Documentation Status](https://readthedocs.org/projects/reframe-hpc/badge/?version=latest)](https://reframe-hpc.readthedocs.io/en/latest/?badge=latest)
 [![codecov.io](https://codecov.io/gh/reframe-hpc/reframe/branch/master/graph/badge.svg)](https://codecov.io/github/reframe-hpc/reframe)<br/>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/_static/img/reframe-logo-dark-bg.png">
   <source media="(prefers-color-scheme: light)" srcset="docs/_static/img/reframe_logo-full.png">
-  <img alt="ReFrame logo" src="https://raw.githubusercontent.com/reframe-hpc/reframe/master/docs/_static/img/reframe_logo-full.png">
 </picture>
 
 [![Build Status](https://github.com/reframe-hpc/reframe/workflows/ReFrame%20CI/badge.svg)](https://github.com/reframe-hpc/reframe/actions?query=workflow%3A%22ReFrame+CI%22)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center">
+<div align="left">
  <img src="docs/_static/img/reframe_logo-width400p.png#gh-light-mode-only" width="400px">
  <img src="docs/_static/img/reframe-logo-dark-bg.png#gh-dark-mode-only" width="400px">
 </div>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="docs/_static/img/reframe-logo-dark-bg.png" width="400px">
-  <source media="(prefers-color-scheme: light)" srcset="docs/_static/img/reframe_logo-full.png" width="400px">
+  <source media="(prefers-color-scheme: light)" srcset="docs/_static/img/reframe-logo-dark-bg.png" width="400px">
+  <source media="(prefers-color-scheme: dark)" srcset="docs/_static/img/reframe_logo-full.png" width="400px">
   <img alt="ReFrame logo" src="https://raw.githubusercontent.com/reframe-hpc/reframe/master/docs/_static/img/reframe_logo-full.png">
 </picture>
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+<div align="center">
+ <img src="docs/_static/img/reframe_logo-width400p.png#gh-light-mode-only" width="400px">
+ <img src="docs/_static/img/reframe-logo-dark-bg.png#gh-dark-mode-only" width="400px">
+</div>
+
 [![ReFrame Logo](https://raw.githubusercontent.com/reframe-hpc/reframe/master/docs/_static/img/reframe_logo-width400p.png)](https://github.com/reframe-hpc/reframe)<br/>
 [![Build Status](https://github.com/reframe-hpc/reframe/workflows/ReFrame%20CI/badge.svg)](https://github.com/reframe-hpc/reframe/actions?query=workflow%3A%22ReFrame+CI%22)
 [![Documentation Status](https://readthedocs.org/projects/reframe-hpc/badge/?version=latest)](https://reframe-hpc.readthedocs.io/en/latest/?badge=latest)

--- a/README_minimal.md
+++ b/README_minimal.md
@@ -25,63 +25,7 @@ ReFrame offers an intuitive and very powerful syntax that allows users to create
 ReFrame will load the tests and send them down a well-defined pipeline that will execute them in parallel.
 The stages of this pipeline take care of all the system interaction details, such as programming environment switching, compilation, job submission, job status query, sanity checking and performance assessment.
 
-Please visit the project's documentation [page](https://reframe-hpc.readthedocs.io/) for all the details!
-
-
-## Installation
-
-ReFrame is fairly easy to install.
-All you need is Python 3.6 or above and to run its bootstrap script:
-
-```bash
-git clone https://github.com/reframe-hpc/reframe.git
-cd reframe
-./bootstrap.sh
-./bin/reframe -V
-```
-
-If you want a specific release, please refer to the documentation [page](https://reframe-hpc.readthedocs.io/en/stable/started.html).
-
-
-### Running the unit tests
-
-You can optionally run the framework's unit tests with the following command:
-
-```bash
-./test_reframe.py -v
-```
-
-NOTE: Unit tests require a POSIX-compliant C compiler (available through the `cc` command), as well as the `make` utility.
-
-### Building the documentation locally
-
-You may build the documentation of the master manually as follows:
-
-```
-./bootstrap.sh +docs
-```
-
-For viewing it, you may do the following:
-
-```
-cd docs/html
-python3 -m http.server
-```
-
-The documentation is now up on [localhost:8000](http://localhost:8000), where you can navigate with your browser.
-
-
-## Test library
-
-The framework comes with a library of tests that users can either run them from the command line directly or extend them and fine tune them for their systems. See [here](https://reframe-hpc.readthedocs.io/en/stable/hpctestlib.html) for more details.
-
-
-## Test examples
-
-You can find examples of real tests under the ReFrame HPC [community Github page](https://github.com/reframe-hpc).
-The most complete suite of tests currently publicly available is that of [CSCS](https://cscs.ch/), which you can also find [here](https://github.com/eth-cscs/cscs-reframe-tests).
-You can use those tests as a starting point for implementing your own tests.
-
+Please visit the project's documentation [page](https://reframe-hpc.readthedocs.io/) and [GitHub repository](https://github.com/reframe-hpc/reframe) for all the details!
 
 ## Contact
 

--- a/README_pypi.md
+++ b/README_pypi.md
@@ -1,0 +1,104 @@
+[![ReFrame Logo](https://raw.githubusercontent.com/reframe-hpc/reframe/master/docs/_static/img/reframe_logo-width400p.png)](https://github.com/reframe-hpc/reframe)<br/>
+[![Build Status](https://github.com/reframe-hpc/reframe/workflows/ReFrame%20CI/badge.svg)](https://github.com/reframe-hpc/reframe/actions?query=workflow%3A%22ReFrame+CI%22)
+[![Documentation Status](https://readthedocs.org/projects/reframe-hpc/badge/?version=latest)](https://reframe-hpc.readthedocs.io/en/latest/?badge=latest)
+[![codecov.io](https://codecov.io/gh/reframe-hpc/reframe/branch/master/graph/badge.svg)](https://codecov.io/github/reframe-hpc/reframe)<br/>
+![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/reframe-hpc/reframe?include_prereleases)
+![GitHub commits since latest release](https://img.shields.io/github/commits-since/reframe-hpc/reframe/latest)
+![GitHub contributors](https://img.shields.io/github/contributors-anon/reframe-hpc/reframe)<br/>
+[![PyPI version](https://badge.fury.io/py/ReFrame-HPC.svg)](https://badge.fury.io/py/ReFrame-HPC)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/reframe-hpc)
+[![Downloads](https://pepy.tech/badge/reframe-hpc)](https://pepy.tech/project/reframe-hpc)
+[![Downloads](https://pepy.tech/badge/reframe-hpc/month)](https://pepy.tech/project/reframe-hpc)<br/>
+[![Slack](https://reframe-slack.herokuapp.com/badge.svg)](https://reframe-slack.herokuapp.com/)<br/>
+[![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
+[![DOI](https://zenodo.org/badge/89384186.svg)](https://zenodo.org/badge/latestdoi/89384186)<br/>
+[![Twitter Follow](https://img.shields.io/twitter/follow/ReFrameHPC?style=social)](https://twitter.com/ReFrameHPC)
+
+# ReFrame in a Nutshell
+
+ReFrame is a powerful framework for writing system regression tests and benchmarks, specifically targeted to HPC systems.
+The goal of the framework is to abstract away the complexity of the interactions with the system, separating the logic of a test from the low-level details, which pertain to the system configuration and setup.
+This allows users to write portable tests in a declarative way that describes only the test's functionality.
+
+Tests in ReFrame are simple Python classes that specify the basic variables and parameters of the test.
+ReFrame offers an intuitive and very powerful syntax that allows users to create test libraries, test factories, as well as complete test workflows using other tests as fixtures.
+ReFrame will load the tests and send them down a well-defined pipeline that will execute them in parallel.
+The stages of this pipeline take care of all the system interaction details, such as programming environment switching, compilation, job submission, job status query, sanity checking and performance assessment.
+
+Please visit the project's documentation [page](https://reframe-hpc.readthedocs.io/) for all the details!
+
+
+## Installation
+
+ReFrame is fairly easy to install.
+All you need is Python 3.6 or above and to run its bootstrap script:
+
+```bash
+git clone https://github.com/reframe-hpc/reframe.git
+cd reframe
+./bootstrap.sh
+./bin/reframe -V
+```
+
+If you want a specific release, please refer to the documentation [page](https://reframe-hpc.readthedocs.io/en/stable/started.html).
+
+
+### Running the unit tests
+
+You can optionally run the framework's unit tests with the following command:
+
+```bash
+./test_reframe.py -v
+```
+
+NOTE: Unit tests require a POSIX-compliant C compiler (available through the `cc` command), as well as the `make` utility.
+
+### Building the documentation locally
+
+You may build the documentation of the master manually as follows:
+
+```
+./bootstrap.sh +docs
+```
+
+For viewing it, you may do the following:
+
+```
+cd docs/html
+python3 -m http.server
+```
+
+The documentation is now up on [localhost:8000](http://localhost:8000), where you can navigate with your browser.
+
+
+## Test library
+
+The framework comes with a library of tests that users can either run them from the command line directly or extend them and fine tune them for their systems. See [here](https://reframe-hpc.readthedocs.io/en/stable/hpctestlib.html) for more details.
+
+
+## Test examples
+
+You can find examples of real tests under the ReFrame HPC [community Github page](https://github.com/reframe-hpc).
+The most complete suite of tests currently publicly available is that of [CSCS](https://cscs.ch/), which you can also find [here](https://github.com/eth-cscs/cscs-reframe-tests).
+You can use those tests as a starting point for implementing your own tests.
+
+
+## Contact
+
+You can get in contact with the ReFrame community in the following ways:
+
+### Slack
+
+Please join the community's [Slack channel](https://reframe-slack.herokuapp.com) for keeping up with the latest news about ReFrame, posting questions and, generally getting in touch with other users and the developers.
+
+### Mailing list
+
+You may also [subscribe](mailto:reframe-subscribe@sympa.cscs.ch) to the [mailing list](mailto:reframe@sympa.cscs.ch).
+Only subscribers can send messages to the list.
+For unsubscribing, you may send an empty message [here](mailto:reframe-unsubscribe@sympa.cscs.ch).
+
+
+## Contributing back
+
+ReFrame is an open-source project and we welcome and encourage contributions!
+Check out our Contribution Guide [here](https://github.com/reframe-hpc/reframe/wiki/contributing-to-reframe).

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ author = CSCS Swiss National Supercomputing Center
 description = ReFrame is a powerful framework for writing system regression tests and benchmarks, specifically targeted to HPC systems
 url = https://github.com/reframe-hpc/reframe
 license = BSD 3-Clause
-long_description = file: README_pypi.md
+long_description = file: README_minimal.md
 long_description_content_type = text/markdown
 classifiers =
     Development Status :: 5 - Production/Stable

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ author = CSCS Swiss National Supercomputing Center
 description = ReFrame is a powerful framework for writing system regression tests and benchmarks, specifically targeted to HPC systems
 url = https://github.com/reframe-hpc/reframe
 license = BSD 3-Clause
-long_description = file: README.md
+long_description = file: README_pypi.md
 long_description_content_type = text/markdown
 classifiers =
     Development Status :: 5 - Production/Stable


### PR DESCRIPTION
@rsarm found an example from DeepSpeed's README.md https://github.com/microsoft/DeepSpeed/blob/master/README.md

You can see directly how it looks in https://github.com/ekouts/reframe/tree/dark_logo

(Hadn't noticed that there was an issue and a slightly different solution from Teo actually 😅)
Closes #2204