### PR TITLE
[feat] Improve framework messages and the performance report

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,7 +92,7 @@ release = osext.reframe_version()
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/listings/alltests_daint.txt
+++ b/docs/listings/alltests_daint.txt
@@ -1,130 +1,130 @@
 [ReFrame Setup]
-  version:           3.10.0-dev.3+605af31a
+  version:           4.0.0-dev.1+6c51b548
   command:           './bin/reframe -c tutorials/basics/ -R -n HelloMultiLangTest|HelloThreadedExtended2Test|StreamWithRefTest --performance-report -r'
-  launched by:       user@host
+  launched by:       user@daint104
   working directory: '/home/user/Devel/reframe'
   settings file:     '/home/user/Devel/reframe/tutorials/config/settings.py'
   check search path: (R) '/home/user/Devel/reframe/tutorials/basics'
   stage directory:   '/home/user/Devel/reframe/stage'
   output directory:  '/home/user/Devel/reframe/output'
+  log files:         '/tmp/rfm-ean8ypz0.log'
 
 [==========] Running 4 check(s)
-[==========] Started on Sat Jan 22 22:43:38 2022
+[==========] Started on Wed Oct  5 14:53:41 2022
 
 [----------] start processing checks
-[ RUN      ] HelloMultiLangTest %lang=cpp @daint:login+builtin
-[ RUN      ] HelloMultiLangTest %lang=cpp @daint:login+gnu
-[ RUN      ] HelloMultiLangTest %lang=cpp @daint:login+intel
-[ RUN      ] HelloMultiLangTest %lang=cpp @daint:login+nvidia
-[ RUN      ] HelloMultiLangTest %lang=cpp @daint:login+cray
-[ RUN      ] HelloMultiLangTest %lang=cpp @daint:gpu+gnu
-[ RUN      ] HelloMultiLangTest %lang=cpp @daint:gpu+intel
-[ RUN      ] HelloMultiLangTest %lang=cpp @daint:gpu+nvidia
-[ RUN      ] HelloMultiLangTest %lang=cpp @daint:gpu+cray
-[ RUN      ] HelloMultiLangTest %lang=cpp @daint:mc+gnu
-[ RUN      ] HelloMultiLangTest %lang=cpp @daint:mc+intel
-[ RUN      ] HelloMultiLangTest %lang=cpp @daint:mc+nvidia
-[ RUN      ] HelloMultiLangTest %lang=cpp @daint:mc+cray
-[ RUN      ] HelloMultiLangTest %lang=c @daint:login+builtin
-[ RUN      ] HelloMultiLangTest %lang=c @daint:login+gnu
-[ RUN      ] HelloMultiLangTest %lang=c @daint:login+intel
-[ RUN      ] HelloMultiLangTest %lang=c @daint:login+nvidia
-[ RUN      ] HelloMultiLangTest %lang=c @daint:login+cray
-[ RUN      ] HelloMultiLangTest %lang=c @daint:gpu+gnu
-[ RUN      ] HelloMultiLangTest %lang=c @daint:gpu+intel
-[ RUN      ] HelloMultiLangTest %lang=c @daint:gpu+nvidia
-[ RUN      ] HelloMultiLangTest %lang=c @daint:gpu+cray
-[ RUN      ] HelloMultiLangTest %lang=c @daint:mc+gnu
-[ RUN      ] HelloMultiLangTest %lang=c @daint:mc+intel
-[ RUN      ] HelloMultiLangTest %lang=c @daint:mc+nvidia
-[ RUN      ] HelloMultiLangTest %lang=c @daint:mc+cray
-[ RUN      ] HelloThreadedExtended2Test @daint:login+builtin
-[ RUN      ] HelloThreadedExtended2Test @daint:login+gnu
-[ RUN      ] HelloThreadedExtended2Test @daint:login+intel
-[ RUN      ] HelloThreadedExtended2Test @daint:login+nvidia
-[ RUN      ] HelloThreadedExtended2Test @daint:login+cray
-[ RUN      ] HelloThreadedExtended2Test @daint:gpu+gnu
-[ RUN      ] HelloThreadedExtended2Test @daint:gpu+intel
-[ RUN      ] HelloThreadedExtended2Test @daint:gpu+nvidia
-[ RUN      ] HelloThreadedExtended2Test @daint:gpu+cray
-[ RUN      ] HelloThreadedExtended2Test @daint:mc+gnu
-[ RUN      ] HelloThreadedExtended2Test @daint:mc+intel
-[ RUN      ] HelloThreadedExtended2Test @daint:mc+nvidia
-[ RUN      ] HelloThreadedExtended2Test @daint:mc+cray
-[ RUN      ] StreamWithRefTest @daint:login+gnu
-[ RUN      ] StreamWithRefTest @daint:gpu+gnu
-[ RUN      ] StreamWithRefTest @daint:mc+gnu
-[       OK ] ( 1/42) HelloMultiLangTest %lang=cpp @daint:login+builtin
-[       OK ] ( 2/42) HelloMultiLangTest %lang=cpp @daint:login+gnu
-[       OK ] ( 3/42) HelloMultiLangTest %lang=cpp @daint:login+intel
-[       OK ] ( 4/42) HelloMultiLangTest %lang=cpp @daint:login+nvidia
-[       OK ] ( 5/42) HelloMultiLangTest %lang=cpp @daint:login+cray
-[       OK ] ( 6/42) HelloMultiLangTest %lang=cpp @daint:gpu+gnu
-[       OK ] ( 7/42) HelloMultiLangTest %lang=cpp @daint:gpu+intel
-[       OK ] ( 8/42) HelloMultiLangTest %lang=c @daint:login+builtin
-[       OK ] ( 9/42) HelloMultiLangTest %lang=c @daint:login+gnu
-[       OK ] (10/42) HelloMultiLangTest %lang=c @daint:login+intel
-[       OK ] (11/42) HelloMultiLangTest %lang=c @daint:login+nvidia
-[       OK ] (12/42) HelloMultiLangTest %lang=c @daint:login+cray
-[       OK ] (13/42) HelloThreadedExtended2Test @daint:login+builtin
-[       OK ] (14/42) HelloThreadedExtended2Test @daint:login+gnu
-[       OK ] (15/42) HelloThreadedExtended2Test @daint:login+intel
-[       OK ] (16/42) HelloThreadedExtended2Test @daint:login+nvidia
-[       OK ] (17/42) HelloThreadedExtended2Test @daint:login+cray
-[       OK ] (18/42) HelloMultiLangTest %lang=cpp @daint:mc+intel
-[       OK ] (19/42) HelloMultiLangTest %lang=cpp @daint:mc+nvidia
-[       OK ] (20/42) HelloMultiLangTest %lang=cpp @daint:mc+cray
-[       OK ] (21/42) HelloMultiLangTest %lang=c @daint:mc+nvidia
-[       OK ] (22/42) HelloMultiLangTest %lang=c @daint:mc+cray
-[       OK ] (23/42) HelloMultiLangTest %lang=cpp @daint:gpu+nvidia
-[       OK ] (24/42) HelloMultiLangTest %lang=cpp @daint:gpu+cray
-[       OK ] (25/42) HelloMultiLangTest %lang=c @daint:gpu+gnu
-[       OK ] (26/42) HelloMultiLangTest %lang=c @daint:gpu+cray
-[       OK ] (27/42) HelloMultiLangTest %lang=c @daint:mc+gnu
-[       OK ] (28/42) HelloMultiLangTest %lang=c @daint:gpu+intel
-[       OK ] (29/42) HelloMultiLangTest %lang=c @daint:gpu+nvidia
-[       OK ] (30/42) HelloThreadedExtended2Test @daint:gpu+gnu
-[       OK ] (31/42) HelloThreadedExtended2Test @daint:gpu+nvidia
-[       OK ] (32/42) HelloThreadedExtended2Test @daint:gpu+cray
-[       OK ] (33/42) HelloThreadedExtended2Test @daint:mc+gnu
-[       OK ] (34/42) HelloThreadedExtended2Test @daint:mc+intel
-[       OK ] (35/42) StreamWithRefTest @daint:login+gnu
-[       OK ] (36/42) HelloMultiLangTest %lang=c @daint:mc+intel
-[       OK ] (37/42) HelloMultiLangTest %lang=cpp @daint:mc+gnu
-[       OK ] (38/42) HelloThreadedExtended2Test @daint:gpu+intel
-[       OK ] (39/42) HelloThreadedExtended2Test @daint:mc+nvidia
-[       OK ] (40/42) HelloThreadedExtended2Test @daint:mc+cray
-[       OK ] (41/42) StreamWithRefTest @daint:gpu+gnu
-[       OK ] (42/42) StreamWithRefTest @daint:mc+gnu
+[ RUN      ] HelloMultiLangTest %lang=cpp /71bf65a3 @daint:login+builtin
+[ RUN      ] HelloMultiLangTest %lang=cpp /71bf65a3 @daint:login+gnu
+[ RUN      ] HelloMultiLangTest %lang=cpp /71bf65a3 @daint:login+intel
+[ RUN      ] HelloMultiLangTest %lang=cpp /71bf65a3 @daint:login+nvidia
+[ RUN      ] HelloMultiLangTest %lang=cpp /71bf65a3 @daint:login+cray
+[ RUN      ] HelloMultiLangTest %lang=cpp /71bf65a3 @daint:gpu+gnu
+[ RUN      ] HelloMultiLangTest %lang=cpp /71bf65a3 @daint:gpu+intel
+[ RUN      ] HelloMultiLangTest %lang=cpp /71bf65a3 @daint:gpu+nvidia
+[ RUN      ] HelloMultiLangTest %lang=cpp /71bf65a3 @daint:gpu+cray
+[ RUN      ] HelloMultiLangTest %lang=cpp /71bf65a3 @daint:mc+gnu
+[ RUN      ] HelloMultiLangTest %lang=cpp /71bf65a3 @daint:mc+intel
+[ RUN      ] HelloMultiLangTest %lang=cpp /71bf65a3 @daint:mc+nvidia
+[ RUN      ] HelloMultiLangTest %lang=cpp /71bf65a3 @daint:mc+cray
+[ RUN      ] HelloMultiLangTest %lang=c /7cfa870e @daint:login+builtin
+[ RUN      ] HelloMultiLangTest %lang=c /7cfa870e @daint:login+gnu
+[ RUN      ] HelloMultiLangTest %lang=c /7cfa870e @daint:login+intel
+[ RUN      ] HelloMultiLangTest %lang=c /7cfa870e @daint:login+nvidia
+[ RUN      ] HelloMultiLangTest %lang=c /7cfa870e @daint:login+cray
+[ RUN      ] HelloMultiLangTest %lang=c /7cfa870e @daint:gpu+gnu
+[ RUN      ] HelloMultiLangTest %lang=c /7cfa870e @daint:gpu+intel
+[ RUN      ] HelloMultiLangTest %lang=c /7cfa870e @daint:gpu+nvidia
+[ RUN      ] HelloMultiLangTest %lang=c /7cfa870e @daint:gpu+cray
+[ RUN      ] HelloMultiLangTest %lang=c /7cfa870e @daint:mc+gnu
+[ RUN      ] HelloMultiLangTest %lang=c /7cfa870e @daint:mc+intel
+[ RUN      ] HelloMultiLangTest %lang=c /7cfa870e @daint:mc+nvidia
+[ RUN      ] HelloMultiLangTest %lang=c /7cfa870e @daint:mc+cray
+[ RUN      ] HelloThreadedExtended2Test /57223829 @daint:login+builtin
+[ RUN      ] HelloThreadedExtended2Test /57223829 @daint:login+gnu
+[ RUN      ] HelloThreadedExtended2Test /57223829 @daint:login+intel
+[ RUN      ] HelloThreadedExtended2Test /57223829 @daint:login+nvidia
+[ RUN      ] HelloThreadedExtended2Test /57223829 @daint:login+cray
+[ RUN      ] HelloThreadedExtended2Test /57223829 @daint:gpu+gnu
+[ RUN      ] HelloThreadedExtended2Test /57223829 @daint:gpu+intel
+[ RUN      ] HelloThreadedExtended2Test /57223829 @daint:gpu+nvidia
+[ RUN      ] HelloThreadedExtended2Test /57223829 @daint:gpu+cray
+[ RUN      ] HelloThreadedExtended2Test /57223829 @daint:mc+gnu
+[ RUN      ] HelloThreadedExtended2Test /57223829 @daint:mc+intel
+[ RUN      ] HelloThreadedExtended2Test /57223829 @daint:mc+nvidia
+[ RUN      ] HelloThreadedExtended2Test /57223829 @daint:mc+cray
+[ RUN      ] StreamWithRefTest /f925207b @daint:login+gnu
+[ RUN      ] StreamWithRefTest /f925207b @daint:gpu+gnu
+[ RUN      ] StreamWithRefTest /f925207b @daint:mc+gnu
+[       OK ] ( 1/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:login+builtin
+[       OK ] ( 2/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:login+gnu
+[       OK ] ( 3/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:login+intel
+[       OK ] ( 4/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:login+cray
+[       OK ] ( 5/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:login+nvidia
+[       OK ] ( 6/42) HelloMultiLangTest %lang=c /7cfa870e @daint:login+builtin
+[       OK ] ( 7/42) HelloMultiLangTest %lang=c /7cfa870e @daint:login+gnu
+[       OK ] ( 8/42) HelloMultiLangTest %lang=c /7cfa870e @daint:login+intel
+[       OK ] ( 9/42) HelloMultiLangTest %lang=c /7cfa870e @daint:login+nvidia
+[       OK ] (10/42) HelloMultiLangTest %lang=c /7cfa870e @daint:login+cray
+[       OK ] (11/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:mc+gnu
+[       OK ] (12/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:mc+cray
+[       OK ] (13/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:mc+intel
+[       OK ] (14/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:mc+nvidia
+[       OK ] (15/42) HelloThreadedExtended2Test /57223829 @daint:login+builtin
+[       OK ] (16/42) HelloThreadedExtended2Test /57223829 @daint:login+gnu
+[       OK ] (17/42) HelloThreadedExtended2Test /57223829 @daint:login+intel
+[       OK ] (18/42) HelloThreadedExtended2Test /57223829 @daint:login+nvidia
+[       OK ] (19/42) HelloThreadedExtended2Test /57223829 @daint:login+cray
+[       OK ] (20/42) StreamWithRefTest /f925207b @daint:login+gnu
+P: Copy: 71974.7 MB/s (r:0, l:None, u:None)
+P: Scale: 44895.9 MB/s (r:0, l:None, u:None)
+P: Add: 48523.9 MB/s (r:0, l:None, u:None)
+P: Triad: 48533.0 MB/s (r:0, l:None, u:None)
+[       OK ] (21/42) HelloMultiLangTest %lang=c /7cfa870e @daint:mc+gnu
+[       OK ] (22/42) HelloMultiLangTest %lang=c /7cfa870e @daint:mc+intel
+[       OK ] (23/42) HelloMultiLangTest %lang=c /7cfa870e @daint:mc+nvidia
+[       OK ] (24/42) HelloMultiLangTest %lang=c /7cfa870e @daint:mc+cray
+[       OK ] (25/42) HelloThreadedExtended2Test /57223829 @daint:mc+gnu
+[       OK ] (26/42) HelloThreadedExtended2Test /57223829 @daint:mc+intel
+[       OK ] (27/42) HelloThreadedExtended2Test /57223829 @daint:mc+nvidia
+[       OK ] (28/42) HelloThreadedExtended2Test /57223829 @daint:mc+cray
+[       OK ] (29/42) StreamWithRefTest /f925207b @daint:mc+gnu
+P: Copy: 48993.7 MB/s (r:0, l:None, u:None)
+P: Scale: 31578.9 MB/s (r:0, l:None, u:None)
+P: Add: 33267.3 MB/s (r:0, l:None, u:None)
+P: Triad: 33772.6 MB/s (r:0, l:None, u:None)
+[       OK ] (30/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:gpu+cray
+[       OK ] (31/42) HelloMultiLangTest %lang=c /7cfa870e @daint:gpu+cray
+[       OK ] (32/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:gpu+gnu
+[       OK ] (33/42) HelloThreadedExtended2Test /57223829 @daint:gpu+gnu
+[       OK ] (34/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:gpu+nvidia
+[       OK ] (35/42) HelloThreadedExtended2Test /57223829 @daint:gpu+intel
+[       OK ] (36/42) HelloMultiLangTest %lang=c /7cfa870e @daint:gpu+gnu
+[       OK ] (37/42) HelloMultiLangTest %lang=c /7cfa870e @daint:gpu+nvidia
+[       OK ] (38/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:gpu+intel
+[       OK ] (39/42) HelloMultiLangTest %lang=c /7cfa870e @daint:gpu+intel
+[       OK ] (40/42) HelloThreadedExtended2Test /57223829 @daint:gpu+nvidia
+[       OK ] (41/42) HelloThreadedExtended2Test /57223829 @daint:gpu+cray
+[       OK ] (42/42) StreamWithRefTest /f925207b @daint:gpu+gnu
+P: Copy: 50927.3 MB/s (r:0, l:None, u:None)
+P: Scale: 35346.2 MB/s (r:0, l:None, u:None)
+P: Add: 38842.0 MB/s (r:0, l:None, u:None)
+P: Triad: 38657.1 MB/s (r:0, l:None, u:None)
 [----------] all spawned checks have finished
 
 [  PASSED  ] Ran 42/42 test case(s) from 4 check(s) (0 failure(s), 0 skipped)
-[==========] Finished on Sat Jan 22 22:47:28 2022
-==============================================================================
+[==========] Finished on Wed Oct  5 15:02:20 2022
+
+================================================================================
 PERFORMANCE REPORT
-------------------------------------------------------------------------------
-StreamWithRefTest
-- daint:login
-   - gnu
-      * num_tasks: 1
-      * Copy: 67915.3 MB/s
-      * Scale: 37485.6 MB/s
-      * Add: 39545.5 MB/s
-      * Triad: 39906.2 MB/s
-- daint:gpu
-   - gnu
-      * num_tasks: 1
-      * Copy: 50553.4 MB/s
-      * Scale: 34780.1 MB/s
-      * Add: 38043.6 MB/s
-      * Triad: 38522.2 MB/s
-- daint:mc
-   - gnu
-      * num_tasks: 1
-      * Copy: 48200.9 MB/s
-      * Scale: 31370.4 MB/s
-      * Add: 33000.2 MB/s
-      * Triad: 33205.5 MB/s
-------------------------------------------------------------------------------
-Run report saved in '/home/user/.reframe/reports/run-report.json'
-Log file(s) saved in '/tmp/rfm-n3d18lq9.log'
+--------------------------------------------------------------------------------
+[StreamWithRefTest /f925207b @daint:mc:gnu]
+  num_gpus_per_node: 0
+  num_tasks: 1
+  performance:
+    - Copy: 48993.7 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Scale: 31578.9 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Add: 33267.3 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Triad: 33772.6 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+--------------------------------------------------------------------------------
+Run report saved in '/home/user/.reframe/reports/run-report-63.json'
+Log file(s) saved in '/tmp/rfm-ean8ypz0.log'

--- a/docs/listings/alltests_daint.txt
+++ b/docs/listings/alltests_daint.txt
@@ -1,5 +1,5 @@
 [ReFrame Setup]
-  version:           4.0.0-dev.1+6c51b548
+  version:           4.0.0-dev.1+a4a2a15f
   command:           './bin/reframe -c tutorials/basics/ -R -n HelloMultiLangTest|HelloThreadedExtended2Test|StreamWithRefTest --performance-report -r'
   launched by:       user@daint104
   working directory: '/home/user/Devel/reframe'
@@ -7,10 +7,10 @@
   check search path: (R) '/home/user/Devel/reframe/tutorials/basics'
   stage directory:   '/home/user/Devel/reframe/stage'
   output directory:  '/home/user/Devel/reframe/output'
-  log files:         '/tmp/rfm-ean8ypz0.log'
+  log files:         '/tmp/rfm-_wgq5paa.log'
 
 [==========] Running 4 check(s)
-[==========] Started on Wed Oct  5 14:53:41 2022
+[==========] Started on Fri Oct  7 11:17:20 2022
 
 [----------] start processing checks
 [ RUN      ] HelloMultiLangTest %lang=cpp /71bf65a3 @daint:login+builtin
@@ -58,73 +58,89 @@
 [       OK ] ( 1/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:login+builtin
 [       OK ] ( 2/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:login+gnu
 [       OK ] ( 3/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:login+intel
-[       OK ] ( 4/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:login+cray
-[       OK ] ( 5/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:login+nvidia
+[       OK ] ( 4/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:login+nvidia
+[       OK ] ( 5/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:login+cray
 [       OK ] ( 6/42) HelloMultiLangTest %lang=c /7cfa870e @daint:login+builtin
 [       OK ] ( 7/42) HelloMultiLangTest %lang=c /7cfa870e @daint:login+gnu
 [       OK ] ( 8/42) HelloMultiLangTest %lang=c /7cfa870e @daint:login+intel
 [       OK ] ( 9/42) HelloMultiLangTest %lang=c /7cfa870e @daint:login+nvidia
 [       OK ] (10/42) HelloMultiLangTest %lang=c /7cfa870e @daint:login+cray
-[       OK ] (11/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:mc+gnu
-[       OK ] (12/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:mc+cray
+[       OK ] (11/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:gpu+nvidia
+[       OK ] (12/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:gpu+intel
 [       OK ] (13/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:mc+intel
 [       OK ] (14/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:mc+nvidia
-[       OK ] (15/42) HelloThreadedExtended2Test /57223829 @daint:login+builtin
-[       OK ] (16/42) HelloThreadedExtended2Test /57223829 @daint:login+gnu
-[       OK ] (17/42) HelloThreadedExtended2Test /57223829 @daint:login+intel
-[       OK ] (18/42) HelloThreadedExtended2Test /57223829 @daint:login+nvidia
-[       OK ] (19/42) HelloThreadedExtended2Test /57223829 @daint:login+cray
-[       OK ] (20/42) StreamWithRefTest /f925207b @daint:login+gnu
-P: Copy: 71974.7 MB/s (r:0, l:None, u:None)
-P: Scale: 44895.9 MB/s (r:0, l:None, u:None)
-P: Add: 48523.9 MB/s (r:0, l:None, u:None)
-P: Triad: 48533.0 MB/s (r:0, l:None, u:None)
-[       OK ] (21/42) HelloMultiLangTest %lang=c /7cfa870e @daint:mc+gnu
-[       OK ] (22/42) HelloMultiLangTest %lang=c /7cfa870e @daint:mc+intel
-[       OK ] (23/42) HelloMultiLangTest %lang=c /7cfa870e @daint:mc+nvidia
-[       OK ] (24/42) HelloMultiLangTest %lang=c /7cfa870e @daint:mc+cray
-[       OK ] (25/42) HelloThreadedExtended2Test /57223829 @daint:mc+gnu
-[       OK ] (26/42) HelloThreadedExtended2Test /57223829 @daint:mc+intel
-[       OK ] (27/42) HelloThreadedExtended2Test /57223829 @daint:mc+nvidia
-[       OK ] (28/42) HelloThreadedExtended2Test /57223829 @daint:mc+cray
-[       OK ] (29/42) StreamWithRefTest /f925207b @daint:mc+gnu
-P: Copy: 48993.7 MB/s (r:0, l:None, u:None)
-P: Scale: 31578.9 MB/s (r:0, l:None, u:None)
-P: Add: 33267.3 MB/s (r:0, l:None, u:None)
-P: Triad: 33772.6 MB/s (r:0, l:None, u:None)
-[       OK ] (30/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:gpu+cray
-[       OK ] (31/42) HelloMultiLangTest %lang=c /7cfa870e @daint:gpu+cray
-[       OK ] (32/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:gpu+gnu
-[       OK ] (33/42) HelloThreadedExtended2Test /57223829 @daint:gpu+gnu
-[       OK ] (34/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:gpu+nvidia
-[       OK ] (35/42) HelloThreadedExtended2Test /57223829 @daint:gpu+intel
-[       OK ] (36/42) HelloMultiLangTest %lang=c /7cfa870e @daint:gpu+gnu
-[       OK ] (37/42) HelloMultiLangTest %lang=c /7cfa870e @daint:gpu+nvidia
-[       OK ] (38/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:gpu+intel
-[       OK ] (39/42) HelloMultiLangTest %lang=c /7cfa870e @daint:gpu+intel
-[       OK ] (40/42) HelloThreadedExtended2Test /57223829 @daint:gpu+nvidia
-[       OK ] (41/42) HelloThreadedExtended2Test /57223829 @daint:gpu+cray
+[       OK ] (15/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:mc+cray
+[       OK ] (16/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:gpu+cray
+[       OK ] (17/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:mc+gnu
+[       OK ] (18/42) HelloMultiLangTest %lang=cpp /71bf65a3 @daint:gpu+gnu
+[       OK ] (19/42) HelloThreadedExtended2Test /57223829 @daint:login+builtin
+[       OK ] (20/42) HelloThreadedExtended2Test /57223829 @daint:login+gnu
+[       OK ] (21/42) HelloThreadedExtended2Test /57223829 @daint:login+intel
+[       OK ] (22/42) HelloThreadedExtended2Test /57223829 @daint:login+nvidia
+[       OK ] (23/42) HelloThreadedExtended2Test /57223829 @daint:login+cray
+[       OK ] (24/42) HelloMultiLangTest %lang=c /7cfa870e @daint:mc+gnu
+[       OK ] (25/42) HelloMultiLangTest %lang=c /7cfa870e @daint:mc+intel
+[       OK ] (26/42) HelloMultiLangTest %lang=c /7cfa870e @daint:mc+nvidia
+[       OK ] (27/42) HelloMultiLangTest %lang=c /7cfa870e @daint:mc+cray
+[       OK ] (28/42) HelloThreadedExtended2Test /57223829 @daint:mc+gnu
+[       OK ] (29/42) HelloThreadedExtended2Test /57223829 @daint:mc+intel
+[       OK ] (30/42) HelloThreadedExtended2Test /57223829 @daint:mc+nvidia
+[       OK ] (31/42) StreamWithRefTest /f925207b @daint:login+gnu
+P: Copy: 71563.0 MB/s (r:0, l:None, u:None)
+P: Scale: 44535.4 MB/s (r:0, l:None, u:None)
+P: Add: 48558.8 MB/s (r:0, l:None, u:None)
+P: Triad: 48609.1 MB/s (r:0, l:None, u:None)
+[       OK ] (32/42) HelloThreadedExtended2Test /57223829 @daint:mc+cray
+[       OK ] (33/42) StreamWithRefTest /f925207b @daint:mc+gnu
+P: Copy: 49028.9 MB/s (r:0, l:None, u:None)
+P: Scale: 32063.7 MB/s (r:0, l:None, u:None)
+P: Add: 33367.9 MB/s (r:0, l:None, u:None)
+P: Triad: 33669.6 MB/s (r:0, l:None, u:None)
+[       OK ] (34/42) HelloMultiLangTest %lang=c /7cfa870e @daint:gpu+nvidia
+[       OK ] (35/42) HelloMultiLangTest %lang=c /7cfa870e @daint:gpu+cray
+[       OK ] (36/42) HelloMultiLangTest %lang=c /7cfa870e @daint:gpu+intel
+[       OK ] (37/42) HelloMultiLangTest %lang=c /7cfa870e @daint:gpu+gnu
+[       OK ] (38/42) HelloThreadedExtended2Test /57223829 @daint:gpu+intel
+[       OK ] (39/42) HelloThreadedExtended2Test /57223829 @daint:gpu+gnu
+[       OK ] (40/42) HelloThreadedExtended2Test /57223829 @daint:gpu+cray
+[       OK ] (41/42) HelloThreadedExtended2Test /57223829 @daint:gpu+nvidia
 [       OK ] (42/42) StreamWithRefTest /f925207b @daint:gpu+gnu
-P: Copy: 50927.3 MB/s (r:0, l:None, u:None)
-P: Scale: 35346.2 MB/s (r:0, l:None, u:None)
-P: Add: 38842.0 MB/s (r:0, l:None, u:None)
-P: Triad: 38657.1 MB/s (r:0, l:None, u:None)
+P: Copy: 50682.0 MB/s (r:0, l:None, u:None)
+P: Scale: 35014.2 MB/s (r:0, l:None, u:None)
+P: Add: 38535.3 MB/s (r:0, l:None, u:None)
+P: Triad: 38559.1 MB/s (r:0, l:None, u:None)
 [----------] all spawned checks have finished
 
 [  PASSED  ] Ran 42/42 test case(s) from 4 check(s) (0 failure(s), 0 skipped)
-[==========] Finished on Wed Oct  5 15:02:20 2022
+[==========] Finished on Fri Oct  7 11:22:14 2022
 
 ================================================================================
 PERFORMANCE REPORT
 --------------------------------------------------------------------------------
+[StreamWithRefTest /f925207b @daint:login:gnu]
+  num_gpus_per_node: 0
+  num_tasks: 1
+  performance:
+    - Copy: 71563.0 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Scale: 44535.4 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Add: 48558.8 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Triad: 48609.1 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+[StreamWithRefTest /f925207b @daint:gpu:gnu]
+  num_gpus_per_node: 0
+  num_tasks: 1
+  performance:
+    - Copy: 50682.0 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Scale: 35014.2 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Add: 38535.3 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Triad: 38559.1 MB/s (r: 0 MB/s l: -inf% u: +inf%)
 [StreamWithRefTest /f925207b @daint:mc:gnu]
   num_gpus_per_node: 0
   num_tasks: 1
   performance:
-    - Copy: 48993.7 MB/s (r: 0 MB/s l: -inf% u: +inf%)
-    - Scale: 31578.9 MB/s (r: 0 MB/s l: -inf% u: +inf%)
-    - Add: 33267.3 MB/s (r: 0 MB/s l: -inf% u: +inf%)
-    - Triad: 33772.6 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Copy: 49028.9 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Scale: 32063.7 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Add: 33367.9 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Triad: 33669.6 MB/s (r: 0 MB/s l: -inf% u: +inf%)
 --------------------------------------------------------------------------------
-Run report saved in '/home/user/.reframe/reports/run-report-63.json'
-Log file(s) saved in '/tmp/rfm-ean8ypz0.log'
+Run report saved in '/home/user/.reframe/reports/run-report-70.json'
+Log file(s) saved in '/tmp/rfm-_wgq5paa.log'

--- a/docs/listings/deps_complex_run.txt
+++ b/docs/listings/deps_complex_run.txt
@@ -1,65 +1,88 @@
 [ReFrame Setup]
-  version:           3.10.0-dev.3+149af549
+  version:           4.0.0-dev.1+36ffa085
   command:           './bin/reframe -c unittests/resources/checks_unlisted/deps_complex.py -r'
-  launched by:       user@host
+  launched by:       user@tresa.local
   working directory: '/home/user/Repositories/reframe'
-  settings file:     '<builtin>'
+  settings file:     '/home/user/Repositories/reframe/tutorials/config/settings.py'
   check search path: '/home/user/Repositories/reframe/unittests/resources/checks_unlisted/deps_complex.py'
   stage directory:   '/home/user/Repositories/reframe/stage'
   output directory:  '/home/user/Repositories/reframe/output'
+  log files:         '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-jr16q567.log'
 
 [==========] Running 10 check(s)
-[==========] Started on Sat Jan 22 23:44:18 2022
+[==========] Started on Sat Oct  1 20:06:35 2022 
 
 [----------] start processing checks
-[ RUN      ] T0 @generic:default+builtin
-[       OK ] ( 1/10) T0 @generic:default+builtin
-[ RUN      ] T4 @generic:default+builtin
-[       OK ] ( 2/10) T4 @generic:default+builtin
-[ RUN      ] T5 @generic:default+builtin
-[       OK ] ( 3/10) T5 @generic:default+builtin
-[ RUN      ] T1 @generic:default+builtin
-[       OK ] ( 4/10) T1 @generic:default+builtin
-[ RUN      ] T8 @generic:default+builtin
-[     FAIL ] ( 5/10) T8 @generic:default+builtin
-==> test failed during 'setup': test staged in '/home/user/Repositories/reframe/stage/generic/default/builtin/T8'
-[     FAIL ] ( 6/10) T9 @generic:default+builtin
+[ RUN      ] T0 /c9c2be9f @catalina:default+gnu
+[ RUN      ] T0 /c9c2be9f @catalina:default+clang
+[       OK ] ( 1/20) T0 /c9c2be9f @catalina:default+gnu
+[       OK ] ( 2/20) T0 /c9c2be9f @catalina:default+clang
+[ RUN      ] T4 /11ee5e9a @catalina:default+gnu
+[ RUN      ] T4 /11ee5e9a @catalina:default+clang
+[       OK ] ( 3/20) T4 /11ee5e9a @catalina:default+gnu
+[       OK ] ( 4/20) T4 /11ee5e9a @catalina:default+clang
+[ RUN      ] T5 /020d01e5 @catalina:default+gnu
+[ RUN      ] T5 /020d01e5 @catalina:default+clang
+[       OK ] ( 5/20) T5 /020d01e5 @catalina:default+gnu
+[       OK ] ( 6/20) T5 /020d01e5 @catalina:default+clang
+[ RUN      ] T1 /1f93603d @catalina:default+gnu
+[ RUN      ] T1 /1f93603d @catalina:default+clang
+[       OK ] ( 7/20) T1 /1f93603d @catalina:default+gnu
+[       OK ] ( 8/20) T1 /1f93603d @catalina:default+clang
+[ RUN      ] T8 /605fc1d6 @catalina:default+gnu
+[     FAIL ] ( 9/20) T8 /605fc1d6 @catalina:default+gnu
+==> test failed during 'setup': test staged in '/home/user/Repositories/reframe/stage/catalina/default/gnu/T8'
+[ RUN      ] T8 /605fc1d6 @catalina:default+clang
+[     FAIL ] (10/20) T8 /605fc1d6 @catalina:default+clang
+==> test failed during 'setup': test staged in '/home/user/Repositories/reframe/stage/catalina/default/clang/T8'
+[     FAIL ] (11/20) T9 /78a78a4e @catalina:default+gnu
 ==> test failed during 'startup': test staged in None
-[ RUN      ] T6 @generic:default+builtin
-[       OK ] ( 7/10) T6 @generic:default+builtin
-[ RUN      ] T2 @generic:default+builtin
-[ RUN      ] T3 @generic:default+builtin
-[     FAIL ] ( 8/10) T2 @generic:default+builtin
-==> test failed during 'sanity': test staged in '/home/user/Repositories/reframe/stage/generic/default/builtin/T2'
-[     FAIL ] ( 9/10) T7 @generic:default+builtin
+[     FAIL ] (12/20) T9 /78a78a4e @catalina:default+clang
 ==> test failed during 'startup': test staged in None
-[       OK ] (10/10) T3 @generic:default+builtin
+[ RUN      ] T6 /6dbdaf93 @catalina:default+gnu
+[ RUN      ] T6 /6dbdaf93 @catalina:default+clang
+[       OK ] (13/20) T6 /6dbdaf93 @catalina:default+gnu
+[       OK ] (14/20) T6 /6dbdaf93 @catalina:default+clang
+[ RUN      ] T2 /0f617ba9 @catalina:default+gnu
+[ RUN      ] T2 /0f617ba9 @catalina:default+clang
+[ RUN      ] T3 /5dd67f7f @catalina:default+gnu
+[ RUN      ] T3 /5dd67f7f @catalina:default+clang
+[     FAIL ] (15/20) T2 /0f617ba9 @catalina:default+gnu
+==> test failed during 'sanity': test staged in '/home/user/Repositories/reframe/stage/catalina/default/gnu/T2'
+[     FAIL ] (16/20) T2 /0f617ba9 @catalina:default+clang
+==> test failed during 'sanity': test staged in '/home/user/Repositories/reframe/stage/catalina/default/clang/T2'
+[     FAIL ] (17/20) T7 /f005e93d @catalina:default+gnu
+==> test failed during 'startup': test staged in None
+[     FAIL ] (18/20) T7 /f005e93d @catalina:default+clang
+==> test failed during 'startup': test staged in None
+[       OK ] (19/20) T3 /5dd67f7f @catalina:default+gnu
+[       OK ] (20/20) T3 /5dd67f7f @catalina:default+clang
 [----------] all spawned checks have finished
 
-[  FAILED  ] Ran 10/10 test case(s) from 10 check(s) (4 failure(s), 0 skipped)
-[==========] Finished on Sat Jan 22 23:44:21 2022
+[  FAILED  ] Ran 20/20 test case(s) from 10 check(s) (8 failure(s), 0 skipped)
+[==========] Finished on Sat Oct  1 20:06:37 2022 
 
-==============================================================================
+================================================================================
 SUMMARY OF FAILURES
-------------------------------------------------------------------------------
-FAILURE INFO for T8
+--------------------------------------------------------------------------------
+FAILURE INFO for T8 
   * Expanded name: T8
-  * Description: T8
-  * System partition: generic:default
-  * Environment: builtin
-  * Stage directory: /home/user/Repositories/reframe/stage/generic/default/builtin/T8
-  * Node list:
+  * Description: 
+  * System partition: catalina:default
+  * Environment: gnu
+  * Stage directory: /home/user/Repositories/reframe/stage/catalina/default/gnu/T8
+  * Node list: 
   * Job type: local (id=None)
   * Dependencies (conceptual): ['T1']
-  * Dependencies (actual): [('T1', 'generic:default', 'builtin')]
+  * Dependencies (actual): [('T1', 'catalina:default', 'gnu')]
   * Maintainers: []
   * Failing phase: setup
-  * Rerun with '-n T8 -p builtin --system generic:default -r'
+  * Rerun with '-n /605fc1d6 -p gnu --system catalina:default -r'
   * Reason: exception
 Traceback (most recent call last):
-  File "/home/user/Repositories/reframe/reframe/frontend/executors/__init__.py", line 291, in _safe_call
+  File "/home/user/Repositories/reframe/reframe/frontend/executors/__init__.py", line 303, in _safe_call
     return fn(*args, **kwargs)
-  File "/home/user/Repositories/reframe/reframe/core/hooks.py", line 82, in _fn
+  File "/home/user/Repositories/reframe/reframe/core/hooks.py", line 101, in _fn
     getattr(obj, h.__name__)()
   File "/home/user/Repositories/reframe/reframe/core/hooks.py", line 32, in _fn
     func(*args, **kwargs)
@@ -67,51 +90,122 @@ Traceback (most recent call last):
     raise Exception
 Exception
 
-------------------------------------------------------------------------------
-FAILURE INFO for T9
+--------------------------------------------------------------------------------
+FAILURE INFO for T8 
+  * Expanded name: T8
+  * Description: 
+  * System partition: catalina:default
+  * Environment: clang
+  * Stage directory: /home/user/Repositories/reframe/stage/catalina/default/clang/T8
+  * Node list: 
+  * Job type: local (id=None)
+  * Dependencies (conceptual): ['T1']
+  * Dependencies (actual): [('T1', 'catalina:default', 'clang')]
+  * Maintainers: []
+  * Failing phase: setup
+  * Rerun with '-n /605fc1d6 -p clang --system catalina:default -r'
+  * Reason: exception
+Traceback (most recent call last):
+  File "/home/user/Repositories/reframe/reframe/frontend/executors/__init__.py", line 303, in _safe_call
+    return fn(*args, **kwargs)
+  File "/home/user/Repositories/reframe/reframe/core/hooks.py", line 101, in _fn
+    getattr(obj, h.__name__)()
+  File "/home/user/Repositories/reframe/reframe/core/hooks.py", line 32, in _fn
+    func(*args, **kwargs)
+  File "/home/user/Repositories/reframe/unittests/resources/checks_unlisted/deps_complex.py", line 180, in fail
+    raise Exception
+Exception
+
+--------------------------------------------------------------------------------
+FAILURE INFO for T9 
   * Expanded name: T9
-  * Description: T9
-  * System partition: generic:default
-  * Environment: builtin
+  * Description: 
+  * System partition: catalina:default
+  * Environment: gnu
   * Stage directory: None
-  * Node list:
+  * Node list: 
   * Job type: local (id=None)
   * Dependencies (conceptual): ['T8']
-  * Dependencies (actual): [('T8', 'generic:default', 'builtin')]
+  * Dependencies (actual): [('T8', 'catalina:default', 'gnu')]
   * Maintainers: []
   * Failing phase: startup
-  * Rerun with '-n T9 -p builtin --system generic:default -r'
+  * Rerun with '-n /78a78a4e -p gnu --system catalina:default -r'
   * Reason: task dependency error: dependencies failed
-------------------------------------------------------------------------------
-FAILURE INFO for T2
+--------------------------------------------------------------------------------
+FAILURE INFO for T9 
+  * Expanded name: T9
+  * Description: 
+  * System partition: catalina:default
+  * Environment: clang
+  * Stage directory: None
+  * Node list: 
+  * Job type: local (id=None)
+  * Dependencies (conceptual): ['T8']
+  * Dependencies (actual): [('T8', 'catalina:default', 'clang')]
+  * Maintainers: []
+  * Failing phase: startup
+  * Rerun with '-n /78a78a4e -p clang --system catalina:default -r'
+  * Reason: task dependency error: dependencies failed
+--------------------------------------------------------------------------------
+FAILURE INFO for T2 
   * Expanded name: T2
-  * Description: T2
-  * System partition: generic:default
-  * Environment: builtin
-  * Stage directory: /home/user/Repositories/reframe/stage/generic/default/builtin/T2
+  * Description: 
+  * System partition: catalina:default
+  * Environment: gnu
+  * Stage directory: /home/user/Repositories/reframe/stage/catalina/default/gnu/T2
   * Node list: tresa.localNone
-  * Job type: local (id=49427)
+  * Job type: local (id=92028)
   * Dependencies (conceptual): ['T6']
-  * Dependencies (actual): [('T6', 'generic:default', 'builtin')]
+  * Dependencies (actual): [('T6', 'catalina:default', 'gnu')]
   * Maintainers: []
   * Failing phase: sanity
-  * Rerun with '-n T2 -p builtin --system generic:default -r'
+  * Rerun with '-n /0f617ba9 -p gnu --system catalina:default -r'
   * Reason: sanity error: 31 != 30
-------------------------------------------------------------------------------
-FAILURE INFO for T7
+--------------------------------------------------------------------------------
+FAILURE INFO for T2 
+  * Expanded name: T2
+  * Description: 
+  * System partition: catalina:default
+  * Environment: clang
+  * Stage directory: /home/user/Repositories/reframe/stage/catalina/default/clang/T2
+  * Node list: tresa.localNone
+  * Job type: local (id=92029)
+  * Dependencies (conceptual): ['T6']
+  * Dependencies (actual): [('T6', 'catalina:default', 'clang')]
+  * Maintainers: []
+  * Failing phase: sanity
+  * Rerun with '-n /0f617ba9 -p clang --system catalina:default -r'
+  * Reason: sanity error: 31 != 30
+--------------------------------------------------------------------------------
+FAILURE INFO for T7 
   * Expanded name: T7
-  * Description: T7
-  * System partition: generic:default
-  * Environment: builtin
+  * Description: 
+  * System partition: catalina:default
+  * Environment: gnu
   * Stage directory: None
-  * Node list:
+  * Node list: 
   * Job type: local (id=None)
   * Dependencies (conceptual): ['T2']
-  * Dependencies (actual): [('T2', 'generic:default', 'builtin')]
+  * Dependencies (actual): [('T2', 'catalina:default', 'gnu')]
   * Maintainers: []
   * Failing phase: startup
-  * Rerun with '-n T7 -p builtin --system generic:default -r'
+  * Rerun with '-n /f005e93d -p gnu --system catalina:default -r'
   * Reason: task dependency error: dependencies failed
-------------------------------------------------------------------------------
-Run report saved in '/home/user/.reframe/reports/run-report.json'
-Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-92y3fr5s.log'
+--------------------------------------------------------------------------------
+FAILURE INFO for T7 
+  * Expanded name: T7
+  * Description: 
+  * System partition: catalina:default
+  * Environment: clang
+  * Stage directory: None
+  * Node list: 
+  * Job type: local (id=None)
+  * Dependencies (conceptual): ['T2']
+  * Dependencies (actual): [('T2', 'catalina:default', 'clang')]
+  * Maintainers: []
+  * Failing phase: startup
+  * Rerun with '-n /f005e93d -p clang --system catalina:default -r'
+  * Reason: task dependency error: dependencies failed
+--------------------------------------------------------------------------------
+Run report saved in '/home/user/.reframe/reports/run-report-109.json'
+Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-jr16q567.log'

--- a/docs/listings/deps_rerun_t6.txt
+++ b/docs/listings/deps_rerun_t6.txt
@@ -1,22 +1,25 @@
 [ReFrame Setup]
-  version:           3.10.0-dev.3+149af549
+  version:           4.0.0-dev.1+36ffa085
   command:           './bin/reframe --restore-session --keep-stage-files -n T6 -r'
-  launched by:       user@host
+  launched by:       user@tresa.local
   working directory: '/home/user/Repositories/reframe'
-  settings file:     '<builtin>'
+  settings file:     '/home/user/Repositories/reframe/tutorials/config/settings.py'
   check search path: '/home/user/Repositories/reframe/unittests/resources/checks_unlisted/deps_complex.py'
   stage directory:   '/home/user/Repositories/reframe/stage'
   output directory:  '/home/user/Repositories/reframe/output'
+  log files:         '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-xwildgxp.log'
 
 [==========] Running 1 check(s)
-[==========] Started on Sat Jan 22 23:44:25 2022
+[==========] Started on Sat Oct  1 20:06:40 2022 
 
 [----------] start processing checks
-[ RUN      ] T6 @generic:default+builtin
-[       OK ] (1/1) T6 @generic:default+builtin
+[ RUN      ] T6 /6dbdaf93 @catalina:default+gnu
+[ RUN      ] T6 /6dbdaf93 @catalina:default+clang
+[       OK ] (1/2) T6 /6dbdaf93 @catalina:default+gnu
+[       OK ] (2/2) T6 /6dbdaf93 @catalina:default+clang
 [----------] all spawned checks have finished
 
-[  PASSED  ] Ran 1/1 test case(s) from 1 check(s) (0 failure(s), 0 skipped)
-[==========] Finished on Sat Jan 22 23:44:25 2022
-Run report saved in '/home/user/.reframe/reports/run-report.json'
-Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-mug0a4cb.log'
+[  PASSED  ] Ran 2/2 test case(s) from 1 check(s) (0 failure(s), 0 skipped)
+[==========] Finished on Sat Oct  1 20:06:41 2022 
+Run report saved in '/home/user/.reframe/reports/run-report-111.json'
+Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-xwildgxp.log'

--- a/docs/listings/deps_rerun_t6.txt
+++ b/docs/listings/deps_rerun_t6.txt
@@ -1,25 +1,23 @@
 [ReFrame Setup]
-  version:           4.0.0-dev.1+36ffa085
+  version:           4.0.0-dev.1+3b06b112
   command:           './bin/reframe --restore-session --keep-stage-files -n T6 -r'
-  launched by:       user@tresa.local
+  launched by:       user@host
   working directory: '/home/user/Repositories/reframe'
-  settings file:     '/home/user/Repositories/reframe/tutorials/config/settings.py'
+  settings file:     '<builtin>'
   check search path: '/home/user/Repositories/reframe/unittests/resources/checks_unlisted/deps_complex.py'
   stage directory:   '/home/user/Repositories/reframe/stage'
   output directory:  '/home/user/Repositories/reframe/output'
-  log files:         '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-xwildgxp.log'
+  log files:         '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-r1gopvcr.log'
 
 [==========] Running 1 check(s)
-[==========] Started on Sat Oct  1 20:06:40 2022 
+[==========] Started on Fri Oct  7 23:06:23 2022 
 
 [----------] start processing checks
-[ RUN      ] T6 /6dbdaf93 @catalina:default+gnu
-[ RUN      ] T6 /6dbdaf93 @catalina:default+clang
-[       OK ] (1/2) T6 /6dbdaf93 @catalina:default+gnu
-[       OK ] (2/2) T6 /6dbdaf93 @catalina:default+clang
+[ RUN      ] T6 /6dbdaf93 @generic:default+builtin
+[       OK ] (1/1) T6 /6dbdaf93 @generic:default+builtin
 [----------] all spawned checks have finished
 
-[  PASSED  ] Ran 2/2 test case(s) from 1 check(s) (0 failure(s), 0 skipped)
-[==========] Finished on Sat Oct  1 20:06:41 2022 
-Run report saved in '/home/user/.reframe/reports/run-report-111.json'
-Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-xwildgxp.log'
+[  PASSED  ] Ran 1/1 test case(s) from 1 check(s) (0 failure(s), 0 skipped)
+[==========] Finished on Fri Oct  7 23:06:24 2022 
+Run report saved in '/home/user/.reframe/reports/run-report-125.json'
+Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-r1gopvcr.log'

--- a/docs/listings/deps_run_t6.txt
+++ b/docs/listings/deps_run_t6.txt
@@ -1,41 +1,31 @@
 [ReFrame Setup]
-  version:           4.0.0-dev.1+36ffa085
+  version:           4.0.0-dev.1+3b06b112
   command:           './bin/reframe -c unittests/resources/checks_unlisted/deps_complex.py -n T6 -r'
-  launched by:       user@tresa.local
+  launched by:       user@host
   working directory: '/home/user/Repositories/reframe'
-  settings file:     '/home/user/Repositories/reframe/tutorials/config/settings.py'
+  settings file:     '<builtin>'
   check search path: '/home/user/Repositories/reframe/unittests/resources/checks_unlisted/deps_complex.py'
   stage directory:   '/home/user/Repositories/reframe/stage'
   output directory:  '/home/user/Repositories/reframe/output'
-  log files:         '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-c0lbgx86.log'
+  log files:         '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-1o9az02k.log'
 
 [==========] Running 5 check(s)
-[==========] Started on Sat Oct  1 20:06:41 2022 
+[==========] Started on Fri Oct  7 23:06:14 2022 
 
 [----------] start processing checks
-[ RUN      ] T0 /c9c2be9f @catalina:default+gnu
-[ RUN      ] T0 /c9c2be9f @catalina:default+clang
-[       OK ] ( 1/10) T0 /c9c2be9f @catalina:default+gnu
-[       OK ] ( 2/10) T0 /c9c2be9f @catalina:default+clang
-[ RUN      ] T4 /11ee5e9a @catalina:default+gnu
-[ RUN      ] T4 /11ee5e9a @catalina:default+clang
-[       OK ] ( 3/10) T4 /11ee5e9a @catalina:default+gnu
-[       OK ] ( 4/10) T4 /11ee5e9a @catalina:default+clang
-[ RUN      ] T5 /020d01e5 @catalina:default+gnu
-[ RUN      ] T5 /020d01e5 @catalina:default+clang
-[       OK ] ( 5/10) T5 /020d01e5 @catalina:default+gnu
-[       OK ] ( 6/10) T5 /020d01e5 @catalina:default+clang
-[ RUN      ] T1 /1f93603d @catalina:default+gnu
-[ RUN      ] T1 /1f93603d @catalina:default+clang
-[       OK ] ( 7/10) T1 /1f93603d @catalina:default+gnu
-[       OK ] ( 8/10) T1 /1f93603d @catalina:default+clang
-[ RUN      ] T6 /6dbdaf93 @catalina:default+gnu
-[ RUN      ] T6 /6dbdaf93 @catalina:default+clang
-[       OK ] ( 9/10) T6 /6dbdaf93 @catalina:default+gnu
-[       OK ] (10/10) T6 /6dbdaf93 @catalina:default+clang
+[ RUN      ] T0 /c9c2be9f @generic:default+builtin
+[       OK ] (1/5) T0 /c9c2be9f @generic:default+builtin
+[ RUN      ] T4 /11ee5e9a @generic:default+builtin
+[       OK ] (2/5) T4 /11ee5e9a @generic:default+builtin
+[ RUN      ] T5 /020d01e5 @generic:default+builtin
+[       OK ] (3/5) T5 /020d01e5 @generic:default+builtin
+[ RUN      ] T1 /1f93603d @generic:default+builtin
+[       OK ] (4/5) T1 /1f93603d @generic:default+builtin
+[ RUN      ] T6 /6dbdaf93 @generic:default+builtin
+[       OK ] (5/5) T6 /6dbdaf93 @generic:default+builtin
 [----------] all spawned checks have finished
 
-[  PASSED  ] Ran 10/10 test case(s) from 5 check(s) (0 failure(s), 0 skipped)
-[==========] Finished on Sat Oct  1 20:06:42 2022 
-Run report saved in '/home/user/.reframe/reports/run-report-112.json'
-Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-c0lbgx86.log'
+[  PASSED  ] Ran 5/5 test case(s) from 5 check(s) (0 failure(s), 0 skipped)
+[==========] Finished on Fri Oct  7 23:06:16 2022 
+Run report saved in '/home/user/.reframe/reports/run-report-123.json'
+Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-1o9az02k.log'

--- a/docs/listings/deps_run_t6.txt
+++ b/docs/listings/deps_run_t6.txt
@@ -1,30 +1,41 @@
 [ReFrame Setup]
-  version:           3.10.0-dev.3+149af549
+  version:           4.0.0-dev.1+36ffa085
   command:           './bin/reframe -c unittests/resources/checks_unlisted/deps_complex.py -n T6 -r'
-  launched by:       user@host
+  launched by:       user@tresa.local
   working directory: '/home/user/Repositories/reframe'
-  settings file:     '<builtin>'
+  settings file:     '/home/user/Repositories/reframe/tutorials/config/settings.py'
   check search path: '/home/user/Repositories/reframe/unittests/resources/checks_unlisted/deps_complex.py'
   stage directory:   '/home/user/Repositories/reframe/stage'
   output directory:  '/home/user/Repositories/reframe/output'
+  log files:         '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-c0lbgx86.log'
 
 [==========] Running 5 check(s)
-[==========] Started on Sat Jan 22 23:44:25 2022
+[==========] Started on Sat Oct  1 20:06:41 2022 
 
 [----------] start processing checks
-[ RUN      ] T0 @generic:default+builtin
-[       OK ] (1/5) T0 @generic:default+builtin
-[ RUN      ] T4 @generic:default+builtin
-[       OK ] (2/5) T4 @generic:default+builtin
-[ RUN      ] T5 @generic:default+builtin
-[       OK ] (3/5) T5 @generic:default+builtin
-[ RUN      ] T1 @generic:default+builtin
-[       OK ] (4/5) T1 @generic:default+builtin
-[ RUN      ] T6 @generic:default+builtin
-[       OK ] (5/5) T6 @generic:default+builtin
+[ RUN      ] T0 /c9c2be9f @catalina:default+gnu
+[ RUN      ] T0 /c9c2be9f @catalina:default+clang
+[       OK ] ( 1/10) T0 /c9c2be9f @catalina:default+gnu
+[       OK ] ( 2/10) T0 /c9c2be9f @catalina:default+clang
+[ RUN      ] T4 /11ee5e9a @catalina:default+gnu
+[ RUN      ] T4 /11ee5e9a @catalina:default+clang
+[       OK ] ( 3/10) T4 /11ee5e9a @catalina:default+gnu
+[       OK ] ( 4/10) T4 /11ee5e9a @catalina:default+clang
+[ RUN      ] T5 /020d01e5 @catalina:default+gnu
+[ RUN      ] T5 /020d01e5 @catalina:default+clang
+[       OK ] ( 5/10) T5 /020d01e5 @catalina:default+gnu
+[       OK ] ( 6/10) T5 /020d01e5 @catalina:default+clang
+[ RUN      ] T1 /1f93603d @catalina:default+gnu
+[ RUN      ] T1 /1f93603d @catalina:default+clang
+[       OK ] ( 7/10) T1 /1f93603d @catalina:default+gnu
+[       OK ] ( 8/10) T1 /1f93603d @catalina:default+clang
+[ RUN      ] T6 /6dbdaf93 @catalina:default+gnu
+[ RUN      ] T6 /6dbdaf93 @catalina:default+clang
+[       OK ] ( 9/10) T6 /6dbdaf93 @catalina:default+gnu
+[       OK ] (10/10) T6 /6dbdaf93 @catalina:default+clang
 [----------] all spawned checks have finished
 
-[  PASSED  ] Ran 5/5 test case(s) from 5 check(s) (0 failure(s), 0 skipped)
-[==========] Finished on Sat Jan 22 23:44:28 2022
-Run report saved in '/home/user/.reframe/reports/run-report.json'
-Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-ktylyaqk.log'
+[  PASSED  ] Ran 10/10 test case(s) from 5 check(s) (0 failure(s), 0 skipped)
+[==========] Finished on Sat Oct  1 20:06:42 2022 
+Run report saved in '/home/user/.reframe/reports/run-report-112.json'
+Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-c0lbgx86.log'

--- a/docs/listings/hello1.txt
+++ b/docs/listings/hello1.txt
@@ -1,22 +1,23 @@
 [ReFrame Setup]
-  version:           3.10.0-dev.3+c22440c1
+  version:           4.0.0-dev.1+36ffa085
   command:           './bin/reframe -c tutorials/basics/hello/hello1.py -r'
-  launched by:       user@host
-  working directory: '/path/to/reframe'
+  launched by:       user@tresa.local
+  working directory: '/home/user/Repositories/reframe'
   settings file:     '<builtin>'
-  check search path: '/path/to/reframe/tutorials/basics/hello/hello1.py'
-  stage directory:   '/path/to/reframe/stage'
-  output directory:  '/path/to/reframe/output'
+  check search path: '/home/user/Repositories/reframe/tutorials/basics/hello/hello1.py'
+  stage directory:   '/home/user/Repositories/reframe/stage'
+  output directory:  '/home/user/Repositories/reframe/output'
+  log files:         '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-twt_xiob.log'
 
 [==========] Running 1 check(s)
-[==========] Started on Sat Jan 22 13:21:50 2022
+[==========] Started on Sat Oct  1 20:06:21 2022 
 
 [----------] start processing checks
-[ RUN      ] HelloTest @generic:default+builtin
-[       OK ] (1/1) HelloTest @generic:default+builtin
+[ RUN      ] HelloTest /2b3e4546 @generic:default+builtin
+[       OK ] (1/1) HelloTest /2b3e4546 @generic:default+builtin
 [----------] all spawned checks have finished
 
 [  PASSED  ] Ran 1/1 test case(s) from 1 check(s) (0 failure(s), 0 skipped)
-[==========] Finished on Sat Jan 22 13:21:51 2022
-Run report saved in '/home/user/.reframe/reports/run-report.json'
-Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-8c6ybdvg.log'
+[==========] Finished on Sat Oct  1 20:06:22 2022 
+Run report saved in '/home/user/.reframe/reports/run-report-103.json'
+Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-twt_xiob.log'

--- a/docs/listings/hello2.txt
+++ b/docs/listings/hello2.txt
@@ -1,44 +1,45 @@
 [ReFrame Setup]
-  version:           3.10.0-dev.3+c22440c1
+  version:           4.0.0-dev.1+36ffa085
   command:           './bin/reframe -c tutorials/basics/hello/hello2.py -r'
-  launched by:       user@host
-  working directory: '/path/to/reframe'
+  launched by:       user@tresa.local
+  working directory: '/home/user/Repositories/reframe'
   settings file:     '<builtin>'
-  check search path: '/path/to/reframe/tutorials/basics/hello/hello2.py'
-  stage directory:   '/path/to/reframe/stage'
-  output directory:  '/path/to/reframe/output'
+  check search path: '/home/user/Repositories/reframe/tutorials/basics/hello/hello2.py'
+  stage directory:   '/home/user/Repositories/reframe/stage'
+  output directory:  '/home/user/Repositories/reframe/output'
+  log files:         '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-iz0z1c2r.log'
 
 [==========] Running 2 check(s)
-[==========] Started on Sat Jan 22 13:21:51 2022
+[==========] Started on Sat Oct  1 20:06:23 2022 
 
 [----------] start processing checks
-[ RUN      ] HelloMultiLangTest %lang=cpp @generic:default+builtin
-[ RUN      ] HelloMultiLangTest %lang=c @generic:default+builtin
-[     FAIL ] (1/2) HelloMultiLangTest %lang=cpp @generic:default+builtin
-==> test failed during 'compile': test staged in '/path/to/reframe/stage/generic/default/builtin/HelloMultiLangTest_cpp'
-[       OK ] (2/2) HelloMultiLangTest %lang=c @generic:default+builtin
+[ RUN      ] HelloMultiLangTest %lang=cpp /71bf65a3 @generic:default+builtin
+[ RUN      ] HelloMultiLangTest %lang=c /7cfa870e @generic:default+builtin
+[     FAIL ] (1/2) HelloMultiLangTest %lang=cpp /71bf65a3 @generic:default+builtin
+==> test failed during 'compile': test staged in '/home/user/Repositories/reframe/stage/generic/default/builtin/HelloMultiLangTest_71bf65a3'
+[       OK ] (2/2) HelloMultiLangTest %lang=c /7cfa870e @generic:default+builtin
 [----------] all spawned checks have finished
 
 [  FAILED  ] Ran 2/2 test case(s) from 2 check(s) (1 failure(s), 0 skipped)
-[==========] Finished on Sat Jan 22 13:21:52 2022
+[==========] Finished on Sat Oct  1 20:06:23 2022 
 
-==============================================================================
+================================================================================
 SUMMARY OF FAILURES
-------------------------------------------------------------------------------
-FAILURE INFO for HelloMultiLangTest_cpp
+--------------------------------------------------------------------------------
+FAILURE INFO for HelloMultiLangTest_1 
   * Expanded name: HelloMultiLangTest %lang=cpp
-  * Description: HelloMultiLangTest %lang=cpp
+  * Description: 
   * System partition: generic:default
   * Environment: builtin
-  * Stage directory: /path/to/reframe/stage/generic/default/builtin/HelloMultiLangTest_cpp
-  * Node list:
+  * Stage directory: /home/user/Repositories/reframe/stage/generic/default/builtin/HelloMultiLangTest_71bf65a3
+  * Node list: 
   * Job type: local (id=None)
   * Dependencies (conceptual): []
   * Dependencies (actual): []
   * Maintainers: []
   * Failing phase: compile
-  * Rerun with '-n HelloMultiLangTest_cpp -p builtin --system generic:default -r'
+  * Rerun with '-n /71bf65a3 -p builtin --system generic:default -r'
   * Reason: build system error: I do not know how to compile a C++ program
-------------------------------------------------------------------------------
-Run report saved in '/home/user/.reframe/reports/run-report.json'
-Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-tse_opq0.log'
+--------------------------------------------------------------------------------
+Run report saved in '/home/user/.reframe/reports/run-report-104.json'
+Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-iz0z1c2r.log'

--- a/docs/listings/hello2_catalina.txt
+++ b/docs/listings/hello2_catalina.txt
@@ -1,28 +1,29 @@
 [ReFrame Setup]
-  version:           3.10.0-dev.3+c22440c1
+  version:           4.0.0-dev.1+36ffa085
   command:           './bin/reframe -C tutorials/config/settings.py -c tutorials/basics/hello/hello2.py -r'
-  launched by:       user@host
-  working directory: '/path/to/reframe'
+  launched by:       user@tresa.local
+  working directory: '/home/user/Repositories/reframe'
   settings file:     'tutorials/config/settings.py'
-  check search path: '/path/to/reframe/tutorials/basics/hello/hello2.py'
-  stage directory:   '/path/to/reframe/stage'
-  output directory:  '/path/to/reframe/output'
+  check search path: '/home/user/Repositories/reframe/tutorials/basics/hello/hello2.py'
+  stage directory:   '/home/user/Repositories/reframe/stage'
+  output directory:  '/home/user/Repositories/reframe/output'
+  log files:         '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-48ioicki.log'
 
 [==========] Running 2 check(s)
-[==========] Started on Sat Jan 22 13:21:53 2022
+[==========] Started on Sat Oct  1 20:06:24 2022 
 
 [----------] start processing checks
-[ RUN      ] HelloMultiLangTest %lang=cpp @catalina:default+gnu
-[ RUN      ] HelloMultiLangTest %lang=cpp @catalina:default+clang
-[ RUN      ] HelloMultiLangTest %lang=c @catalina:default+gnu
-[ RUN      ] HelloMultiLangTest %lang=c @catalina:default+clang
-[       OK ] (1/4) HelloMultiLangTest %lang=c @catalina:default+gnu
-[       OK ] (2/4) HelloMultiLangTest %lang=c @catalina:default+clang
-[       OK ] (3/4) HelloMultiLangTest %lang=cpp @catalina:default+gnu
-[       OK ] (4/4) HelloMultiLangTest %lang=cpp @catalina:default+clang
+[ RUN      ] HelloMultiLangTest %lang=cpp /71bf65a3 @catalina:default+gnu
+[ RUN      ] HelloMultiLangTest %lang=cpp /71bf65a3 @catalina:default+clang
+[ RUN      ] HelloMultiLangTest %lang=c /7cfa870e @catalina:default+gnu
+[ RUN      ] HelloMultiLangTest %lang=c /7cfa870e @catalina:default+clang
+[       OK ] (1/4) HelloMultiLangTest %lang=c /7cfa870e @catalina:default+clang
+[       OK ] (2/4) HelloMultiLangTest %lang=cpp /71bf65a3 @catalina:default+clang
+[       OK ] (3/4) HelloMultiLangTest %lang=cpp /71bf65a3 @catalina:default+gnu
+[       OK ] (4/4) HelloMultiLangTest %lang=c /7cfa870e @catalina:default+gnu
 [----------] all spawned checks have finished
 
 [  PASSED  ] Ran 4/4 test case(s) from 2 check(s) (0 failure(s), 0 skipped)
-[==========] Finished on Sat Jan 22 13:21:54 2022
-Run report saved in '/home/user/.reframe/reports/run-report.json'
-Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-iehz9eub.log'
+[==========] Finished on Sat Oct  1 20:06:26 2022 
+Run report saved in '/home/user/.reframe/reports/run-report-105.json'
+Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-48ioicki.log'

--- a/docs/listings/hello2_list_verbose.txt
+++ b/docs/listings/hello2_list_verbose.txt
@@ -1,25 +1,27 @@
 Loading user configuration
 Loading configuration file: 'tutorials/config/settings.py'
-Detecting system
-Looking for a matching configuration entry for system 'host'
-Configuration found: picking system 'generic'
-Selecting subconfig for 'generic'
+Detecting system using method: 'hostname'
+Using standard hostname...
+Retrieved hostname: 'tresa.local'
+Looking for a matching configuration entry
+Configuration found: picking system 'catalina'
 Initializing runtime
-Selecting subconfig for 'generic:default'
 Initializing system partition 'default'
-Selecting subconfig for 'generic'
-Initializing system 'generic'
+Initializing system 'catalina'
 Initializing modules system 'nomod'
-detecting topology info for generic:default
-> found topology file '/home/user/.reframe/topology/generic-default/processor.json'; loading...
+detecting topology info for catalina:default
+> found topology file '/home/user/.reframe/topology/catalina-default/processor.json'; loading...
 > device auto-detection is not supported
 [ReFrame Environment]
+  RFM_AUTODETECT_FQDN=<not set>
+  RFM_AUTODETECT_METHOD=<not set>
+  RFM_AUTODETECT_XTHOSTNAME=<not set>
   RFM_CHECK_SEARCH_PATH=<not set>
   RFM_CHECK_SEARCH_RECURSIVE=<not set>
   RFM_CLEAN_STAGEDIR=<not set>
   RFM_COLORIZE=n
-  RFM_COMPACT_TEST_NAMES=n
-  RFM_CONFIG_FILE=<not set>
+  RFM_COMPRESS_REPORT=<not set>
+  RFM_CONFIG_FILE=/home/user/Repositories/reframe/tutorials/config/settings.py
   RFM_DUMP_PIPELINE_PROGRESS=<not set>
   RFM_GIT_TIMEOUT=<not set>
   RFM_GRAYLOG_ADDRESS=<not set>
@@ -52,31 +54,46 @@ detecting topology info for generic:default
   RFM_USE_LOGIN_SHELL=<not set>
   RFM_VERBOSE=<not set>
 [ReFrame Setup]
-  version:           3.10.0-dev.3+149af549
+  version:           4.0.0-dev.1+36ffa085
   command:           './bin/reframe -C tutorials/config/settings.py -c tutorials/basics/hello/hello2.py -l -vv'
-  launched by:       user@host
+  launched by:       user@tresa.local
   working directory: '/home/user/Repositories/reframe'
   settings file:     'tutorials/config/settings.py'
   check search path: '/home/user/Repositories/reframe/tutorials/basics/hello/hello2.py'
   stage directory:   '/home/user/Repositories/reframe/stage'
   output directory:  '/home/user/Repositories/reframe/output'
+  log files:         '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-gnl0vln_.log'
 
 Looking for tests in '/home/user/Repositories/reframe/tutorials/basics/hello/hello2.py'
 Validating '/home/user/Repositories/reframe/tutorials/basics/hello/hello2.py': OK
   > Loaded 2 test(s)
 Loaded 2 test(s)
-Generated 2 test case(s)
-Filtering test cases(s) by name: 2 remaining
-Filtering test cases(s) by tags: 2 remaining
-Filtering test cases(s) by other attributes: 2 remaining
+Generated 4 test case(s)
+Filtering test cases(s) by name: 4 remaining
+Filtering test cases(s) by tags: 4 remaining
+Filtering test cases(s) by other attributes: 4 remaining
 Building and validating the full test DAG
 Full test DAG:
-  ('HelloMultiLangTest_cpp', 'generic:default', 'builtin') -> []
-  ('HelloMultiLangTest_c', 'generic:default', 'builtin') -> []
-Final number of test cases: 2
+  ('HelloMultiLangTest_1', 'catalina:default', 'gnu') -> []
+  ('HelloMultiLangTest_1', 'catalina:default', 'clang') -> []
+  ('HelloMultiLangTest_0', 'catalina:default', 'gnu') -> []
+  ('HelloMultiLangTest_0', 'catalina:default', 'clang') -> []
+Final number of test cases: 4
 [List of matched checks]
-- HelloMultiLangTest %lang=cpp
-- HelloMultiLangTest %lang=c
+- HelloMultiLangTest %lang=cpp /71bf65a3
+- HelloMultiLangTest %lang=c /7cfa870e
 Found 2 check(s)
 
-Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-fs1arce0.log'
+Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-gnl0vln_.log'
+>>> profiler report [start] <<<
+main: 0.046616 s
+    test processing: 0.011215 s
+        RegressionCheckLoader.load_all: 0.007729 s
+            TestRegistry.instantiate_all: 0.002678 s
+        generate_testcases: 0.000049 s
+        main.<locals>._sort_testcases: 0.000012 s
+        build_deps: 0.000105 s
+        validate_deps: 0.000117 s
+        toposort: 0.000092 s
+        list_checks: 0.001067 s
+>>> profiler report [ end ] <<<

--- a/docs/listings/hello2_print_stdout.txt
+++ b/docs/listings/hello2_print_stdout.txt
@@ -1,32 +1,33 @@
 [ReFrame Setup]
-  version:           3.10.0-dev.3+149af549
+  version:           4.0.0-dev.1+36ffa085
   command:           './bin/reframe -C tutorials/config/settings.py -c tutorials/basics/hello/hello2.py -r'
-  launched by:       user@host
+  launched by:       user@tresa.local
   working directory: '/home/user/Repositories/reframe'
   settings file:     'tutorials/config/settings.py'
   check search path: '/home/user/Repositories/reframe/tutorials/basics/hello/hello2.py'
   stage directory:   '/home/user/Repositories/reframe/stage'
   output directory:  '/home/user/Repositories/reframe/output'
+  log files:         '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-182q8lvb.log'
 
 [==========] Running 2 check(s)
-[==========] Started on Sun Jan 23 00:11:07 2022
+[==========] Started on Sat Oct  1 20:06:33 2022 
 
 [----------] start processing checks
-[ RUN      ] HelloMultiLangTest %lang=cpp @catalina:default+gnu
-[ RUN      ] HelloMultiLangTest %lang=cpp @catalina:default+clang
-[ RUN      ] HelloMultiLangTest %lang=c @catalina:default+gnu
-[ RUN      ] HelloMultiLangTest %lang=c @catalina:default+clang
-rfm_HelloMultiLangTest_cpp_job.out
-[       OK ] (1/4) HelloMultiLangTest %lang=cpp @catalina:default+gnu
-rfm_HelloMultiLangTest_cpp_job.out
-[       OK ] (2/4) HelloMultiLangTest %lang=cpp @catalina:default+clang
-rfm_HelloMultiLangTest_c_job.out
-[       OK ] (3/4) HelloMultiLangTest %lang=c @catalina:default+gnu
-rfm_HelloMultiLangTest_c_job.out
-[       OK ] (4/4) HelloMultiLangTest %lang=c @catalina:default+clang
+[ RUN      ] HelloMultiLangTest %lang=cpp /71bf65a3 @catalina:default+gnu
+[ RUN      ] HelloMultiLangTest %lang=cpp /71bf65a3 @catalina:default+clang
+[ RUN      ] HelloMultiLangTest %lang=c /7cfa870e @catalina:default+gnu
+[ RUN      ] HelloMultiLangTest %lang=c /7cfa870e @catalina:default+clang
+rfm_job.out
+[       OK ] (1/4) HelloMultiLangTest %lang=c /7cfa870e @catalina:default+gnu
+rfm_job.out
+[       OK ] (2/4) HelloMultiLangTest %lang=c /7cfa870e @catalina:default+clang
+rfm_job.out
+[       OK ] (3/4) HelloMultiLangTest %lang=cpp /71bf65a3 @catalina:default+gnu
+rfm_job.out
+[       OK ] (4/4) HelloMultiLangTest %lang=cpp /71bf65a3 @catalina:default+clang
 [----------] all spawned checks have finished
 
 [  PASSED  ] Ran 4/4 test case(s) from 2 check(s) (0 failure(s), 0 skipped)
-[==========] Finished on Sun Jan 23 00:11:10 2022
-Run report saved in '/home/user/.reframe/reports/run-report.json'
-Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-jumlrg66.log'
+[==========] Finished on Sat Oct  1 20:06:34 2022 
+Run report saved in '/home/user/.reframe/reports/run-report-108.json'
+Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-182q8lvb.log'

--- a/docs/listings/hello2_typo.txt
+++ b/docs/listings/hello2_typo.txt
@@ -1,18 +1,19 @@
 [ReFrame Setup]
-  version:           3.10.0-dev.3+149af549
+  version:           4.0.0-dev.1+36ffa085
   command:           './bin/reframe -c tutorials/basics/hello -R -l'
-  launched by:       user@host
+  launched by:       user@tresa.local
   working directory: '/home/user/Repositories/reframe'
-  settings file:     '<builtin>'
+  settings file:     '/home/user/Repositories/reframe/tutorials/config/settings.py'
   check search path: (R) '/home/user/Repositories/reframe/tutorials/basics/hello'
   stage directory:   '/home/user/Repositories/reframe/stage'
   output directory:  '/home/user/Repositories/reframe/output'
+  log files:         '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-x9_02v7a.log'
 
-./bin/reframe: skipping test file '/home/user/Repositories/reframe/tutorials/basics/hello/hello2.py': name error: tutorials/basics/hello/hello2.py:13: name 'paramter' is not defined
+WARNING: skipping test file '/home/user/Repositories/reframe/tutorials/basics/hello/hello2.py': name error: tutorials/basics/hello/hello2.py:13: name 'paramter' is not defined
     lang = paramter(['c', 'cpp'])
  (rerun with '-v' for more information)
 [List of matched checks]
-- HelloTest
+- HelloTest /2b3e4546
 Found 1 check(s)
 
-Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-bzqy3nc7.log'
+Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-x9_02v7a.log'

--- a/docs/listings/hello2_typo_stacktrace.txt
+++ b/docs/listings/hello2_typo_stacktrace.txt
@@ -1,29 +1,30 @@
 [ReFrame Setup]
-  version:           3.10.0-dev.3+149af549
+  version:           4.0.0-dev.1+36ffa085
   command:           './bin/reframe -c tutorials/basics/hello -R -l -v'
-  launched by:       user@host
+  launched by:       user@tresa.local
   working directory: '/home/user/Repositories/reframe'
-  settings file:     '<builtin>'
+  settings file:     '/home/user/Repositories/reframe/tutorials/config/settings.py'
   check search path: (R) '/home/user/Repositories/reframe/tutorials/basics/hello'
   stage directory:   '/home/user/Repositories/reframe/stage'
   output directory:  '/home/user/Repositories/reframe/output'
+  log files:         '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-p_ouuc8x.log'
 
-./bin/reframe: skipping test file '/home/user/Repositories/reframe/tutorials/basics/hello/hello2.py': name error: tutorials/basics/hello/hello2.py:13: name 'paramter' is not defined
+WARNING: skipping test file '/home/user/Repositories/reframe/tutorials/basics/hello/hello2.py': name error: tutorials/basics/hello/hello2.py:13: name 'paramter' is not defined
     lang = paramter(['c', 'cpp'])
  (rerun with '-v' for more information)
 Traceback (most recent call last):
-  File "/home/user/Repositories/reframe/reframe/frontend/loader.py", line 237, in load_from_file
+  File "/home/user/Repositories/reframe/reframe/frontend/loader.py", line 205, in load_from_file
     util.import_module_from_file(filename, force)
   File "/home/user/Repositories/reframe/reframe/utility/__init__.py", line 109, in import_module_from_file
     return importlib.import_module(module_name)
-  File "/usr/local/Cellar/python@3.9/3.9.1_6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/importlib/__init__.py", line 127, in import_module
+  File "/usr/local/Cellar/python@3.10/3.10.6_2/Frameworks/Python.framework/Versions/3.10/lib/python3.10/importlib/__init__.py", line 126, in import_module
     return _bootstrap._gcd_import(name[level:], package, level)
-  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
-  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
-  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
-  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
-  File "<frozen importlib._bootstrap_external>", line 790, in exec_module
-  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
+  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
+  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
+  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
+  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
+  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
+  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
   File "/home/user/Repositories/reframe/tutorials/basics/hello/hello2.py", line 12, in <module>
     class HelloMultiLangTest(rfm.RegressionTest):
   File "/home/user/Repositories/reframe/tutorials/basics/hello/hello2.py", line 13, in HelloMultiLangTest
@@ -31,13 +32,13 @@ Traceback (most recent call last):
 NameError: name 'paramter' is not defined
 
 Loaded 1 test(s)
-Generated 1 test case(s)
-Filtering test cases(s) by name: 1 remaining
-Filtering test cases(s) by tags: 1 remaining
-Filtering test cases(s) by other attributes: 1 remaining
-Final number of test cases: 1
+Generated 2 test case(s)
+Filtering test cases(s) by name: 2 remaining
+Filtering test cases(s) by tags: 2 remaining
+Filtering test cases(s) by other attributes: 2 remaining
+Final number of test cases: 2
 [List of matched checks]
-- HelloTest
+- HelloTest /2b3e4546
 Found 1 check(s)
 
-Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-l21cjjas.log'
+Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-p_ouuc8x.log'

--- a/docs/listings/hellomp1.txt
+++ b/docs/listings/hellomp1.txt
@@ -1,24 +1,25 @@
 [ReFrame Setup]
-  version:           3.10.0-dev.3+c22440c1
+  version:           4.0.0-dev.1+36ffa085
   command:           './bin/reframe -c tutorials/basics/hellomp/hellomp1.py -r'
-  launched by:       user@host
-  working directory: '/path/to/reframe'
-  settings file:     '/path/to/reframe/tutorials/config/settings.py'
-  check search path: '/path/to/reframe/tutorials/basics/hellomp/hellomp1.py'
-  stage directory:   '/path/to/reframe/stage'
-  output directory:  '/path/to/reframe/output'
+  launched by:       user@tresa.local
+  working directory: '/home/user/Repositories/reframe'
+  settings file:     '/home/user/Repositories/reframe/tutorials/config/settings.py'
+  check search path: '/home/user/Repositories/reframe/tutorials/basics/hellomp/hellomp1.py'
+  stage directory:   '/home/user/Repositories/reframe/stage'
+  output directory:  '/home/user/Repositories/reframe/output'
+  log files:         '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-3iqaepaz.log'
 
 [==========] Running 1 check(s)
-[==========] Started on Sat Jan 22 13:21:54 2022
+[==========] Started on Sat Oct  1 20:06:27 2022 
 
 [----------] start processing checks
-[ RUN      ] HelloThreadedTest @catalina:default+gnu
-[ RUN      ] HelloThreadedTest @catalina:default+clang
-[       OK ] (1/2) HelloThreadedTest @catalina:default+gnu
-[       OK ] (2/2) HelloThreadedTest @catalina:default+clang
+[ RUN      ] HelloThreadedTest /a6fa300f @catalina:default+gnu
+[ RUN      ] HelloThreadedTest /a6fa300f @catalina:default+clang
+[       OK ] (1/2) HelloThreadedTest /a6fa300f @catalina:default+gnu
+[       OK ] (2/2) HelloThreadedTest /a6fa300f @catalina:default+clang
 [----------] all spawned checks have finished
 
 [  PASSED  ] Ran 2/2 test case(s) from 1 check(s) (0 failure(s), 0 skipped)
-[==========] Finished on Sat Jan 22 13:21:56 2022
-Run report saved in '/home/user/.reframe/reports/run-report.json'
-Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-chq08zds.log'
+[==========] Finished on Sat Oct  1 20:06:28 2022 
+Run report saved in '/home/user/.reframe/reports/run-report-106.json'
+Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-3iqaepaz.log'

--- a/docs/listings/hellomp2.txt
+++ b/docs/listings/hellomp2.txt
@@ -1,60 +1,45 @@
 [ReFrame Setup]
-  version:           3.10.0-dev.3+c22440c1
+  version:           4.0.0-dev.1+36ffa085
   command:           './bin/reframe -c tutorials/basics/hellomp/hellomp2.py -r'
-  launched by:       user@host
-  working directory: '/path/to/reframe'
-  settings file:     '/path/to/reframe/tutorials/config/settings.py'
-  check search path: '/path/to/reframe/tutorials/basics/hellomp/hellomp2.py'
-  stage directory:   '/path/to/reframe/stage'
-  output directory:  '/path/to/reframe/output'
+  launched by:       user@tresa.local
+  working directory: '/home/user/Repositories/reframe'
+  settings file:     '/home/user/Repositories/reframe/tutorials/config/settings.py'
+  check search path: '/home/user/Repositories/reframe/tutorials/basics/hellomp/hellomp2.py'
+  stage directory:   '/home/user/Repositories/reframe/stage'
+  output directory:  '/home/user/Repositories/reframe/output'
+  log files:         '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-xspkjmaz.log'
 
 [==========] Running 1 check(s)
-[==========] Started on Sat Jan 22 13:21:56 2022
+[==========] Started on Sat Oct  1 20:06:29 2022 
 
 [----------] start processing checks
-[ RUN      ] HelloThreadedExtendedTest @catalina:default+gnu
-[ RUN      ] HelloThreadedExtendedTest @catalina:default+clang
-[     FAIL ] (1/2) HelloThreadedExtendedTest @catalina:default+clang
-==> test failed during 'sanity': test staged in '/path/to/reframe/stage/catalina/default/clang/HelloThreadedExtendedTest'
-[     FAIL ] (2/2) HelloThreadedExtendedTest @catalina:default+gnu
-==> test failed during 'sanity': test staged in '/path/to/reframe/stage/catalina/default/gnu/HelloThreadedExtendedTest'
+[ RUN      ] HelloThreadedExtendedTest /4733a67d @catalina:default+gnu
+[ RUN      ] HelloThreadedExtendedTest /4733a67d @catalina:default+clang
+[     FAIL ] (1/2) HelloThreadedExtendedTest /4733a67d @catalina:default+gnu
+==> test failed during 'sanity': test staged in '/home/user/Repositories/reframe/stage/catalina/default/gnu/HelloThreadedExtendedTest'
+[       OK ] (2/2) HelloThreadedExtendedTest /4733a67d @catalina:default+clang
 [----------] all spawned checks have finished
 
-[  FAILED  ] Ran 2/2 test case(s) from 1 check(s) (2 failure(s), 0 skipped)
-[==========] Finished on Sat Jan 22 13:21:58 2022
+[  FAILED  ] Ran 2/2 test case(s) from 1 check(s) (1 failure(s), 0 skipped)
+[==========] Finished on Sat Oct  1 20:06:31 2022 
 
-==============================================================================
+================================================================================
 SUMMARY OF FAILURES
-------------------------------------------------------------------------------
-FAILURE INFO for HelloThreadedExtendedTest
+--------------------------------------------------------------------------------
+FAILURE INFO for HelloThreadedExtendedTest 
   * Expanded name: HelloThreadedExtendedTest
-  * Description: HelloThreadedExtendedTest
+  * Description: 
   * System partition: catalina:default
   * Environment: gnu
-  * Stage directory: /path/to/reframe/stage/catalina/default/gnu/HelloThreadedExtendedTest
+  * Stage directory: /home/user/Repositories/reframe/stage/catalina/default/gnu/HelloThreadedExtendedTest
   * Node list: tresa.localNone
-  * Job type: local (id=43387)
+  * Job type: local (id=91939)
   * Dependencies (conceptual): []
   * Dependencies (actual): []
   * Maintainers: []
   * Failing phase: sanity
-  * Rerun with '-n HelloThreadedExtendedTest -p gnu --system catalina:default -r'
-  * Reason: sanity error: 7 != 16
-------------------------------------------------------------------------------
-FAILURE INFO for HelloThreadedExtendedTest
-  * Expanded name: HelloThreadedExtendedTest
-  * Description: HelloThreadedExtendedTest
-  * System partition: catalina:default
-  * Environment: clang
-  * Stage directory: /path/to/reframe/stage/catalina/default/clang/HelloThreadedExtendedTest
-  * Node list: tresa.localNone
-  * Job type: local (id=43384)
-  * Dependencies (conceptual): []
-  * Dependencies (actual): []
-  * Maintainers: []
-  * Failing phase: sanity
-  * Rerun with '-n HelloThreadedExtendedTest -p clang --system catalina:default -r'
-  * Reason: sanity error: 11 != 16
-------------------------------------------------------------------------------
-Run report saved in '/home/user/.reframe/reports/run-report.json'
-Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-31lkxfie.log'
+  * Rerun with '-n /4733a67d -p gnu --system catalina:default -r'
+  * Reason: sanity error: 12 != 16
+--------------------------------------------------------------------------------
+Run report saved in '/home/user/.reframe/reports/run-report-107.json'
+Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-xspkjmaz.log'

--- a/docs/listings/hellomp2.txt
+++ b/docs/listings/hellomp2.txt
@@ -1,27 +1,28 @@
 [ReFrame Setup]
-  version:           4.0.0-dev.1+36ffa085
+  version:           4.0.0-dev.1+6c51b548
   command:           './bin/reframe -c tutorials/basics/hellomp/hellomp2.py -r'
-  launched by:       user@tresa.local
+  launched by:       user@host
   working directory: '/home/user/Repositories/reframe'
   settings file:     '/home/user/Repositories/reframe/tutorials/config/settings.py'
   check search path: '/home/user/Repositories/reframe/tutorials/basics/hellomp/hellomp2.py'
   stage directory:   '/home/user/Repositories/reframe/stage'
   output directory:  '/home/user/Repositories/reframe/output'
-  log files:         '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-xspkjmaz.log'
+  log files:         '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-vyh6_pki.log'
 
 [==========] Running 1 check(s)
-[==========] Started on Sat Oct  1 20:06:29 2022 
+[==========] Started on Wed Oct  5 22:28:03 2022 
 
 [----------] start processing checks
 [ RUN      ] HelloThreadedExtendedTest /4733a67d @catalina:default+gnu
 [ RUN      ] HelloThreadedExtendedTest /4733a67d @catalina:default+clang
 [     FAIL ] (1/2) HelloThreadedExtendedTest /4733a67d @catalina:default+gnu
 ==> test failed during 'sanity': test staged in '/home/user/Repositories/reframe/stage/catalina/default/gnu/HelloThreadedExtendedTest'
-[       OK ] (2/2) HelloThreadedExtendedTest /4733a67d @catalina:default+clang
+[     FAIL ] (2/2) HelloThreadedExtendedTest /4733a67d @catalina:default+clang
+==> test failed during 'sanity': test staged in '/home/user/Repositories/reframe/stage/catalina/default/clang/HelloThreadedExtendedTest'
 [----------] all spawned checks have finished
 
-[  FAILED  ] Ran 2/2 test case(s) from 1 check(s) (1 failure(s), 0 skipped)
-[==========] Finished on Sat Oct  1 20:06:31 2022 
+[  FAILED  ] Ran 2/2 test case(s) from 1 check(s) (2 failure(s), 0 skipped)
+[==========] Finished on Wed Oct  5 22:28:04 2022 
 
 ================================================================================
 SUMMARY OF FAILURES
@@ -32,8 +33,8 @@ FAILURE INFO for HelloThreadedExtendedTest
   * System partition: catalina:default
   * Environment: gnu
   * Stage directory: /home/user/Repositories/reframe/stage/catalina/default/gnu/HelloThreadedExtendedTest
-  * Node list: tresa.localNone
-  * Job type: local (id=91939)
+  * Node list: hostNone
+  * Job type: local (id=91535)
   * Dependencies (conceptual): []
   * Dependencies (actual): []
   * Maintainers: []
@@ -41,5 +42,20 @@ FAILURE INFO for HelloThreadedExtendedTest
   * Rerun with '-n /4733a67d -p gnu --system catalina:default -r'
   * Reason: sanity error: 12 != 16
 --------------------------------------------------------------------------------
-Run report saved in '/home/user/.reframe/reports/run-report-107.json'
-Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-xspkjmaz.log'
+FAILURE INFO for HelloThreadedExtendedTest 
+  * Expanded name: HelloThreadedExtendedTest
+  * Description: 
+  * System partition: catalina:default
+  * Environment: clang
+  * Stage directory: /home/user/Repositories/reframe/stage/catalina/default/clang/HelloThreadedExtendedTest
+  * Node list: hostNone
+  * Job type: local (id=91536)
+  * Dependencies (conceptual): []
+  * Dependencies (actual): []
+  * Maintainers: []
+  * Failing phase: sanity
+  * Rerun with '-n /4733a67d -p clang --system catalina:default -r'
+  * Reason: sanity error: 12 != 16
+--------------------------------------------------------------------------------
+Run report saved in '/home/user/.reframe/reports/run-report-119.json'
+Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-vyh6_pki.log'

--- a/docs/listings/maketest_mixin.txt
+++ b/docs/listings/maketest_mixin.txt
@@ -1,18 +1,19 @@
 [ReFrame Setup]
-  version:           3.10.0-dev.3+4fc5b12c
+  version:           4.0.0-dev.1+36ffa085
   command:           './bin/reframe -c tutorials/advanced/makefiles/maketest_mixin.py -l'
-  launched by:       user@host
+  launched by:       user@tresa.local
   working directory: '/home/user/Repositories/reframe'
   settings file:     '/home/user/Repositories/reframe/tutorials/config/settings.py'
   check search path: '/home/user/Repositories/reframe/tutorials/advanced/makefiles/maketest_mixin.py'
   stage directory:   '/home/user/Repositories/reframe/stage'
   output directory:  '/home/user/Repositories/reframe/output'
+  log files:         '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-h0xbgysl.log'
 
 [List of matched checks]
-- MakeOnlyTestAlt %elem_type=double
-- MakeOnlyTestAlt %elem_type=float
-- MakefileTestAlt %elem_type=double
-- MakefileTestAlt %elem_type=float
+- MakeOnlyTestAlt %elem_type=double /8b62380e
+- MakeOnlyTestAlt %elem_type=float /da39ec20
+- MakefileTestAlt %elem_type=double /89aac4a2
+- MakefileTestAlt %elem_type=float /a998ce67
 Found 4 check(s)
 
-Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-4w95t2wt.log'
+Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-h0xbgysl.log'

--- a/docs/listings/osu_bandwidth_concretized_daint.txt
+++ b/docs/listings/osu_bandwidth_concretized_daint.txt
@@ -1,23 +1,24 @@
 [ReFrame Setup]
-  version:           3.10.0-dev.3+605af31a
+  version:           4.0.0-dev.1+6c51b548
   command:           './bin/reframe -c tutorials/fixtures/osu_benchmarks.py -n osu_bandwidth_test -lC'
-  launched by:       user@host
+  launched by:       user@daint104
   working directory: '/home/user/Devel/reframe'
   settings file:     '/home/user/Devel/reframe/tutorials/config/settings.py'
   check search path: '/home/user/Devel/reframe/tutorials/fixtures/osu_benchmarks.py'
   stage directory:   '/home/user/Devel/reframe/stage'
   output directory:  '/home/user/Devel/reframe/output'
+  log files:         '/tmp/rfm-29dsnhwp.log'
 
 [List of matched checks]
-- osu_bandwidth_test @daint:gpu+gnu
-    ^build_osu_benchmarks ~daint:gpu+gnu @daint:gpu+gnu
-      ^fetch_osu_benchmarks ~daint @daint:gpu+gnu
-- osu_bandwidth_test @daint:gpu+intel
-    ^build_osu_benchmarks ~daint:gpu+intel @daint:gpu+intel
-      ^fetch_osu_benchmarks ~daint @daint:gpu+gnu
-- osu_bandwidth_test @daint:gpu+nvidia
-    ^build_osu_benchmarks ~daint:gpu+nvidia @daint:gpu+nvidia
-      ^fetch_osu_benchmarks ~daint @daint:gpu+gnu
+- osu_bandwidth_test /026711a1 @daint:gpu+gnu
+    ^build_osu_benchmarks ~daint:gpu+gnu /f3269d42 @daint:gpu+gnu
+      ^fetch_osu_benchmarks ~daint /79cd6023 @daint:gpu+gnu
+- osu_bandwidth_test /026711a1 @daint:gpu+intel
+    ^build_osu_benchmarks ~daint:gpu+intel /4d450880 @daint:gpu+intel
+      ^fetch_osu_benchmarks ~daint /79cd6023 @daint:gpu+gnu
+- osu_bandwidth_test /026711a1 @daint:gpu+nvidia
+    ^build_osu_benchmarks ~daint:gpu+nvidia /e9b8d152 @daint:gpu+nvidia
+      ^fetch_osu_benchmarks ~daint /79cd6023 @daint:gpu+gnu
 Concretized 7 test case(s)
 
-Log file(s) saved in '/tmp/rfm-uza91jj1.log'
+Log file(s) saved in '/tmp/rfm-29dsnhwp.log'

--- a/docs/listings/osu_bench_deps.txt
+++ b/docs/listings/osu_bench_deps.txt
@@ -1,64 +1,83 @@
 [ReFrame Setup]
-  version:           3.10.0-dev.3+605af31a
+  version:           4.0.0-dev.1+6c51b548
   command:           './bin/reframe -c tutorials/deps/osu_benchmarks.py -r'
-  launched by:       user@host
+  launched by:       user@daint104
   working directory: '/home/user/Devel/reframe'
   settings file:     '/home/user/Devel/reframe/tutorials/config/settings.py'
   check search path: '/home/user/Devel/reframe/tutorials/deps/osu_benchmarks.py'
   stage directory:   '/home/user/Devel/reframe/stage'
   output directory:  '/home/user/Devel/reframe/output'
+  log files:         '/tmp/rfm-bcp1443i.log'
 
 [==========] Running 8 check(s)
-[==========] Started on Sat Jan 22 22:49:00 2022
+[==========] Started on Wed Oct  5 15:11:25 2022
 
 [----------] start processing checks
-[ RUN      ] OSUDownloadTest @daint:login+builtin
-[       OK ] ( 1/22) OSUDownloadTest @daint:login+builtin
-[ RUN      ] OSUBuildTest @daint:gpu+gnu
-[ RUN      ] OSUBuildTest @daint:gpu+intel
-[ RUN      ] OSUBuildTest @daint:gpu+nvidia
-[       OK ] ( 2/22) OSUBuildTest @daint:gpu+gnu
-[ RUN      ] OSUAllreduceTest %mpi_tasks=16 @daint:gpu+gnu
-[ RUN      ] OSUAllreduceTest %mpi_tasks=8 @daint:gpu+gnu
-[ RUN      ] OSUAllreduceTest %mpi_tasks=4 @daint:gpu+gnu
-[ RUN      ] OSUAllreduceTest %mpi_tasks=2 @daint:gpu+gnu
-[ RUN      ] OSUBandwidthTest @daint:gpu+gnu
-[ RUN      ] OSULatencyTest @daint:gpu+gnu
-[       OK ] ( 3/22) OSUBuildTest @daint:gpu+intel
-[       OK ] ( 4/22) OSUBuildTest @daint:gpu+nvidia
-[ RUN      ] OSUAllreduceTest %mpi_tasks=16 @daint:gpu+intel
-[ RUN      ] OSUAllreduceTest %mpi_tasks=16 @daint:gpu+nvidia
-[ RUN      ] OSUAllreduceTest %mpi_tasks=8 @daint:gpu+intel
-[ RUN      ] OSUAllreduceTest %mpi_tasks=8 @daint:gpu+nvidia
-[ RUN      ] OSUAllreduceTest %mpi_tasks=4 @daint:gpu+intel
-[ RUN      ] OSUAllreduceTest %mpi_tasks=4 @daint:gpu+nvidia
-[ RUN      ] OSUAllreduceTest %mpi_tasks=2 @daint:gpu+intel
-[ RUN      ] OSUAllreduceTest %mpi_tasks=2 @daint:gpu+nvidia
-[ RUN      ] OSUBandwidthTest @daint:gpu+intel
-[ RUN      ] OSUBandwidthTest @daint:gpu+nvidia
-[ RUN      ] OSULatencyTest @daint:gpu+intel
-[ RUN      ] OSULatencyTest @daint:gpu+nvidia
-[       OK ] ( 5/22) OSUAllreduceTest %mpi_tasks=8 @daint:gpu+gnu
-[       OK ] ( 6/22) OSUAllreduceTest %mpi_tasks=16 @daint:gpu+gnu
-[       OK ] ( 7/22) OSUAllreduceTest %mpi_tasks=4 @daint:gpu+gnu
-[       OK ] ( 8/22) OSULatencyTest @daint:gpu+gnu
-[       OK ] ( 9/22) OSUAllreduceTest %mpi_tasks=2 @daint:gpu+gnu
-[       OK ] (10/22) OSUAllreduceTest %mpi_tasks=16 @daint:gpu+intel
-[       OK ] (11/22) OSUAllreduceTest %mpi_tasks=16 @daint:gpu+nvidia
-[       OK ] (12/22) OSUAllreduceTest %mpi_tasks=8 @daint:gpu+intel
-[       OK ] (13/22) OSUAllreduceTest %mpi_tasks=8 @daint:gpu+nvidia
-[       OK ] (14/22) OSUBandwidthTest @daint:gpu+gnu
-[       OK ] (15/22) OSUAllreduceTest %mpi_tasks=4 @daint:gpu+intel
-[       OK ] (16/22) OSUAllreduceTest %mpi_tasks=2 @daint:gpu+nvidia
-[       OK ] (17/22) OSUAllreduceTest %mpi_tasks=2 @daint:gpu+intel
-[       OK ] (18/22) OSULatencyTest @daint:gpu+nvidia
-[       OK ] (19/22) OSULatencyTest @daint:gpu+intel
-[       OK ] (20/22) OSUAllreduceTest %mpi_tasks=4 @daint:gpu+nvidia
-[       OK ] (21/22) OSUBandwidthTest @daint:gpu+intel
-[       OK ] (22/22) OSUBandwidthTest @daint:gpu+nvidia
+[ RUN      ] OSUDownloadTest /7de668df @daint:login+builtin
+[       OK ] ( 1/22) OSUDownloadTest /7de668df @daint:login+builtin
+[ RUN      ] OSUBuildTest /19b4fb56 @daint:gpu+gnu
+[ RUN      ] OSUBuildTest /19b4fb56 @daint:gpu+intel
+[ RUN      ] OSUBuildTest /19b4fb56 @daint:gpu+nvidia
+[       OK ] ( 2/22) OSUBuildTest /19b4fb56 @daint:gpu+gnu
+[ RUN      ] OSUAllreduceTest %mpi_tasks=16 /7f033d39 @daint:gpu+gnu
+[ RUN      ] OSUAllreduceTest %mpi_tasks=8 /005fca19 @daint:gpu+gnu
+[ RUN      ] OSUAllreduceTest %mpi_tasks=4 /84b85d90 @daint:gpu+gnu
+[ RUN      ] OSUAllreduceTest %mpi_tasks=2 /9d550c4f @daint:gpu+gnu
+[ RUN      ] OSUBandwidthTest /764cdb0b @daint:gpu+gnu
+[ RUN      ] OSULatencyTest /14f35a43 @daint:gpu+gnu
+[       OK ] ( 3/22) OSUBuildTest /19b4fb56 @daint:gpu+intel
+[ RUN      ] OSUAllreduceTest %mpi_tasks=16 /7f033d39 @daint:gpu+intel
+[ RUN      ] OSUAllreduceTest %mpi_tasks=8 /005fca19 @daint:gpu+intel
+[ RUN      ] OSUAllreduceTest %mpi_tasks=4 /84b85d90 @daint:gpu+intel
+[ RUN      ] OSUAllreduceTest %mpi_tasks=2 /9d550c4f @daint:gpu+intel
+[ RUN      ] OSUBandwidthTest /764cdb0b @daint:gpu+intel
+[       OK ] ( 4/22) OSUBuildTest /19b4fb56 @daint:gpu+nvidia
+[ RUN      ] OSUAllreduceTest %mpi_tasks=16 /7f033d39 @daint:gpu+nvidia
+[ RUN      ] OSUAllreduceTest %mpi_tasks=8 /005fca19 @daint:gpu+nvidia
+[ RUN      ] OSUAllreduceTest %mpi_tasks=4 /84b85d90 @daint:gpu+nvidia
+[ RUN      ] OSUAllreduceTest %mpi_tasks=2 /9d550c4f @daint:gpu+nvidia
+[ RUN      ] OSUBandwidthTest /764cdb0b @daint:gpu+nvidia
+[ RUN      ] OSULatencyTest /14f35a43 @daint:gpu+intel
+[ RUN      ] OSULatencyTest /14f35a43 @daint:gpu+nvidia
+[       OK ] ( 5/22) OSUAllreduceTest %mpi_tasks=16 /7f033d39 @daint:gpu+gnu
+P: latency: 12.25 us (r:0, l:None, u:None)
+[       OK ] ( 6/22) OSUAllreduceTest %mpi_tasks=8 /005fca19 @daint:gpu+gnu
+P: latency: 8.9 us (r:0, l:None, u:None)
+[       OK ] ( 7/22) OSUAllreduceTest %mpi_tasks=8 /005fca19 @daint:gpu+intel
+P: latency: 8.97 us (r:0, l:None, u:None)
+[       OK ] ( 8/22) OSULatencyTest /14f35a43 @daint:gpu+gnu
+P: latency: 1.15 us (r:0, l:None, u:None)
+[       OK ] ( 9/22) OSUAllreduceTest %mpi_tasks=4 /84b85d90 @daint:gpu+gnu
+P: latency: 3.33 us (r:0, l:None, u:None)
+[       OK ] (10/22) OSUAllreduceTest %mpi_tasks=2 /9d550c4f @daint:gpu+gnu
+P: latency: 1.73 us (r:0, l:None, u:None)
+[       OK ] (11/22) OSUAllreduceTest %mpi_tasks=2 /9d550c4f @daint:gpu+intel
+P: latency: 1.7 us (r:0, l:None, u:None)
+[       OK ] (12/22) OSUAllreduceTest %mpi_tasks=4 /84b85d90 @daint:gpu+intel
+P: latency: 4.66 us (r:0, l:None, u:None)
+[       OK ] (13/22) OSUAllreduceTest %mpi_tasks=16 /7f033d39 @daint:gpu+intel
+P: latency: 14.28 us (r:0, l:None, u:None)
+[       OK ] (14/22) OSUBandwidthTest /764cdb0b @daint:gpu+gnu
+P: bandwidth: 9711.67 MB/s (r:0, l:None, u:None)
+[       OK ] (15/22) OSULatencyTest /14f35a43 @daint:gpu+intel
+P: latency: 1.17 us (r:0, l:None, u:None)
+[       OK ] (16/22) OSUAllreduceTest %mpi_tasks=2 /9d550c4f @daint:gpu+nvidia
+P: latency: 1.66 us (r:0, l:None, u:None)
+[       OK ] (17/22) OSUAllreduceTest %mpi_tasks=8 /005fca19 @daint:gpu+nvidia
+P: latency: 7.84 us (r:0, l:None, u:None)
+[       OK ] (18/22) OSULatencyTest /14f35a43 @daint:gpu+nvidia
+P: latency: 1.15 us (r:0, l:None, u:None)
+[       OK ] (19/22) OSUAllreduceTest %mpi_tasks=4 /84b85d90 @daint:gpu+nvidia
+P: latency: 4.18 us (r:0, l:None, u:None)
+[       OK ] (20/22) OSUAllreduceTest %mpi_tasks=16 /7f033d39 @daint:gpu+nvidia
+P: latency: 13.2 us (r:0, l:None, u:None)
+[       OK ] (21/22) OSUBandwidthTest /764cdb0b @daint:gpu+intel
+P: bandwidth: 9508.26 MB/s (r:0, l:None, u:None)
+[       OK ] (22/22) OSUBandwidthTest /764cdb0b @daint:gpu+nvidia
+P: bandwidth: 9298.19 MB/s (r:0, l:None, u:None)
 [----------] all spawned checks have finished
 
 [  PASSED  ] Ran 22/22 test case(s) from 8 check(s) (0 failure(s), 0 skipped)
-[==========] Finished on Sat Jan 22 22:54:26 2022
-Run report saved in '/home/user/.reframe/reports/run-report.json'
-Log file(s) saved in '/tmp/rfm-15ghvao1.log'
+[==========] Finished on Wed Oct  5 15:24:10 2022
+Run report saved in '/home/user/.reframe/reports/run-report-65.json'
+Log file(s) saved in '/tmp/rfm-bcp1443i.log'

--- a/docs/listings/osu_bench_fixtures_list.txt
+++ b/docs/listings/osu_bench_fixtures_list.txt
@@ -1,56 +1,57 @@
 [ReFrame Setup]
-  version:           3.10.0-dev.3+605af31a
+  version:           4.0.0-dev.1+6c51b548
   command:           './bin/reframe -c tutorials/fixtures/osu_benchmarks.py -l'
-  launched by:       user@host
+  launched by:       user@daint104
   working directory: '/home/user/Devel/reframe'
   settings file:     '/home/user/Devel/reframe/tutorials/config/settings.py'
   check search path: '/home/user/Devel/reframe/tutorials/fixtures/osu_benchmarks.py'
   stage directory:   '/home/user/Devel/reframe/stage'
   output directory:  '/home/user/Devel/reframe/output'
+  log files:         '/tmp/rfm-i3lzbixe.log'
 
 [List of matched checks]
-- osu_allreduce_test %mpi_tasks=16
-    ^build_osu_benchmarks ~daint:gpu+gnu
-      ^fetch_osu_benchmarks ~daint
-    ^build_osu_benchmarks ~daint:gpu+intel
-      ^fetch_osu_benchmarks ~daint
-    ^build_osu_benchmarks ~daint:gpu+nvidia
-      ^fetch_osu_benchmarks ~daint
-- osu_allreduce_test %mpi_tasks=8
-    ^build_osu_benchmarks ~daint:gpu+gnu
-      ^fetch_osu_benchmarks ~daint
-    ^build_osu_benchmarks ~daint:gpu+intel
-      ^fetch_osu_benchmarks ~daint
-    ^build_osu_benchmarks ~daint:gpu+nvidia
-      ^fetch_osu_benchmarks ~daint
-- osu_allreduce_test %mpi_tasks=4
-    ^build_osu_benchmarks ~daint:gpu+gnu
-      ^fetch_osu_benchmarks ~daint
-    ^build_osu_benchmarks ~daint:gpu+intel
-      ^fetch_osu_benchmarks ~daint
-    ^build_osu_benchmarks ~daint:gpu+nvidia
-      ^fetch_osu_benchmarks ~daint
-- osu_allreduce_test %mpi_tasks=2
-    ^build_osu_benchmarks ~daint:gpu+gnu
-      ^fetch_osu_benchmarks ~daint
-    ^build_osu_benchmarks ~daint:gpu+intel
-      ^fetch_osu_benchmarks ~daint
-    ^build_osu_benchmarks ~daint:gpu+nvidia
-      ^fetch_osu_benchmarks ~daint
-- osu_bandwidth_test
-    ^build_osu_benchmarks ~daint:gpu+gnu
-      ^fetch_osu_benchmarks ~daint
-    ^build_osu_benchmarks ~daint:gpu+intel
-      ^fetch_osu_benchmarks ~daint
-    ^build_osu_benchmarks ~daint:gpu+nvidia
-      ^fetch_osu_benchmarks ~daint
-- osu_latency_test
-    ^build_osu_benchmarks ~daint:gpu+gnu
-      ^fetch_osu_benchmarks ~daint
-    ^build_osu_benchmarks ~daint:gpu+intel
-      ^fetch_osu_benchmarks ~daint
-    ^build_osu_benchmarks ~daint:gpu+nvidia
-      ^fetch_osu_benchmarks ~daint
+- osu_allreduce_test %mpi_tasks=16 /1fe48834
+    ^build_osu_benchmarks ~daint:gpu+gnu /f3269d42
+      ^fetch_osu_benchmarks ~daint /79cd6023
+    ^build_osu_benchmarks ~daint:gpu+intel /4d450880
+      ^fetch_osu_benchmarks ~daint /79cd6023
+    ^build_osu_benchmarks ~daint:gpu+nvidia /e9b8d152
+      ^fetch_osu_benchmarks ~daint /79cd6023
+- osu_allreduce_test %mpi_tasks=8 /ae01c137
+    ^build_osu_benchmarks ~daint:gpu+gnu /f3269d42
+      ^fetch_osu_benchmarks ~daint /79cd6023
+    ^build_osu_benchmarks ~daint:gpu+intel /4d450880
+      ^fetch_osu_benchmarks ~daint /79cd6023
+    ^build_osu_benchmarks ~daint:gpu+nvidia /e9b8d152
+      ^fetch_osu_benchmarks ~daint /79cd6023
+- osu_allreduce_test %mpi_tasks=4 /2129dc34
+    ^build_osu_benchmarks ~daint:gpu+gnu /f3269d42
+      ^fetch_osu_benchmarks ~daint /79cd6023
+    ^build_osu_benchmarks ~daint:gpu+intel /4d450880
+      ^fetch_osu_benchmarks ~daint /79cd6023
+    ^build_osu_benchmarks ~daint:gpu+nvidia /e9b8d152
+      ^fetch_osu_benchmarks ~daint /79cd6023
+- osu_allreduce_test %mpi_tasks=2 /9f29c081
+    ^build_osu_benchmarks ~daint:gpu+gnu /f3269d42
+      ^fetch_osu_benchmarks ~daint /79cd6023
+    ^build_osu_benchmarks ~daint:gpu+intel /4d450880
+      ^fetch_osu_benchmarks ~daint /79cd6023
+    ^build_osu_benchmarks ~daint:gpu+nvidia /e9b8d152
+      ^fetch_osu_benchmarks ~daint /79cd6023
+- osu_bandwidth_test /026711a1
+    ^build_osu_benchmarks ~daint:gpu+gnu /f3269d42
+      ^fetch_osu_benchmarks ~daint /79cd6023
+    ^build_osu_benchmarks ~daint:gpu+intel /4d450880
+      ^fetch_osu_benchmarks ~daint /79cd6023
+    ^build_osu_benchmarks ~daint:gpu+nvidia /e9b8d152
+      ^fetch_osu_benchmarks ~daint /79cd6023
+- osu_latency_test /d2c978ad
+    ^build_osu_benchmarks ~daint:gpu+gnu /f3269d42
+      ^fetch_osu_benchmarks ~daint /79cd6023
+    ^build_osu_benchmarks ~daint:gpu+intel /4d450880
+      ^fetch_osu_benchmarks ~daint /79cd6023
+    ^build_osu_benchmarks ~daint:gpu+nvidia /e9b8d152
+      ^fetch_osu_benchmarks ~daint /79cd6023
 Found 6 check(s)
 
-Log file(s) saved in '/tmp/rfm-eopdze64.log'
+Log file(s) saved in '/tmp/rfm-i3lzbixe.log'

--- a/docs/listings/osu_bench_fixtures_run.txt
+++ b/docs/listings/osu_bench_fixtures_run.txt
@@ -1,64 +1,83 @@
 [ReFrame Setup]
-  version:           3.10.0-dev.3+76e02667
+  version:           4.0.0-dev.1+6c51b548
   command:           './bin/reframe -c tutorials/fixtures/osu_benchmarks.py -r'
-  launched by:       user@host
+  launched by:       user@daint104
   working directory: '/home/user/Devel/reframe'
   settings file:     '/home/user/Devel/reframe/tutorials/config/settings.py'
   check search path: '/home/user/Devel/reframe/tutorials/fixtures/osu_benchmarks.py'
   stage directory:   '/home/user/Devel/reframe/stage'
   output directory:  '/home/user/Devel/reframe/output'
+  log files:         '/tmp/rfm-n_metrl9.log'
 
 [==========] Running 10 check(s)
-[==========] Started on Sat Jan 22 23:08:13 2022
+[==========] Started on Wed Oct  5 15:24:14 2022
 
 [----------] start processing checks
-[ RUN      ] fetch_osu_benchmarks ~daint @daint:gpu+gnu
-[       OK ] ( 1/22) fetch_osu_benchmarks ~daint @daint:gpu+gnu
-[ RUN      ] build_osu_benchmarks ~daint:gpu+gnu @daint:gpu+gnu
-[ RUN      ] build_osu_benchmarks ~daint:gpu+intel @daint:gpu+intel
-[ RUN      ] build_osu_benchmarks ~daint:gpu+nvidia @daint:gpu+nvidia
-[       OK ] ( 2/22) build_osu_benchmarks ~daint:gpu+gnu @daint:gpu+gnu
-[ RUN      ] osu_allreduce_test %mpi_tasks=16 @daint:gpu+gnu
-[ RUN      ] osu_allreduce_test %mpi_tasks=8 @daint:gpu+gnu
-[ RUN      ] osu_allreduce_test %mpi_tasks=4 @daint:gpu+gnu
-[ RUN      ] osu_allreduce_test %mpi_tasks=2 @daint:gpu+gnu
-[ RUN      ] osu_bandwidth_test @daint:gpu+gnu
-[ RUN      ] osu_latency_test @daint:gpu+gnu
-[       OK ] ( 3/22) build_osu_benchmarks ~daint:gpu+intel @daint:gpu+intel
-[       OK ] ( 4/22) build_osu_benchmarks ~daint:gpu+nvidia @daint:gpu+nvidia
-[ RUN      ] osu_allreduce_test %mpi_tasks=16 @daint:gpu+intel
-[ RUN      ] osu_allreduce_test %mpi_tasks=16 @daint:gpu+nvidia
-[ RUN      ] osu_allreduce_test %mpi_tasks=8 @daint:gpu+intel
-[ RUN      ] osu_allreduce_test %mpi_tasks=8 @daint:gpu+nvidia
-[ RUN      ] osu_allreduce_test %mpi_tasks=4 @daint:gpu+intel
-[ RUN      ] osu_allreduce_test %mpi_tasks=4 @daint:gpu+nvidia
-[ RUN      ] osu_allreduce_test %mpi_tasks=2 @daint:gpu+intel
-[ RUN      ] osu_allreduce_test %mpi_tasks=2 @daint:gpu+nvidia
-[ RUN      ] osu_bandwidth_test @daint:gpu+intel
-[ RUN      ] osu_bandwidth_test @daint:gpu+nvidia
-[ RUN      ] osu_latency_test @daint:gpu+intel
-[ RUN      ] osu_latency_test @daint:gpu+nvidia
-[       OK ] ( 5/22) osu_allreduce_test %mpi_tasks=16 @daint:gpu+gnu
-[       OK ] ( 6/22) osu_allreduce_test %mpi_tasks=4 @daint:gpu+gnu
-[       OK ] ( 7/22) osu_allreduce_test %mpi_tasks=2 @daint:gpu+gnu
-[       OK ] ( 8/22) osu_allreduce_test %mpi_tasks=8 @daint:gpu+gnu
-[       OK ] ( 9/22) osu_bandwidth_test @daint:gpu+gnu
-[       OK ] (10/22) osu_allreduce_test %mpi_tasks=4 @daint:gpu+nvidia
-[       OK ] (11/22) osu_allreduce_test %mpi_tasks=2 @daint:gpu+intel
-[       OK ] (12/22) osu_allreduce_test %mpi_tasks=4 @daint:gpu+intel
-[       OK ] (13/22) osu_allreduce_test %mpi_tasks=2 @daint:gpu+nvidia
-[       OK ] (14/22) osu_latency_test @daint:gpu+intel
-[       OK ] (15/22) osu_latency_test @daint:gpu+nvidia
-[       OK ] (16/22) osu_allreduce_test %mpi_tasks=16 @daint:gpu+intel
-[       OK ] (17/22) osu_allreduce_test %mpi_tasks=16 @daint:gpu+nvidia
-[       OK ] (18/22) osu_allreduce_test %mpi_tasks=8 @daint:gpu+nvidia
-[       OK ] (19/22) osu_latency_test @daint:gpu+gnu
-[       OK ] (20/22) osu_bandwidth_test @daint:gpu+intel
-[       OK ] (21/22) osu_bandwidth_test @daint:gpu+nvidia
-[       OK ] (22/22) osu_allreduce_test %mpi_tasks=8 @daint:gpu+intel
+[ RUN      ] fetch_osu_benchmarks ~daint /79cd6023 @daint:gpu+gnu
+[       OK ] ( 1/22) fetch_osu_benchmarks ~daint /79cd6023 @daint:gpu+gnu
+[ RUN      ] build_osu_benchmarks ~daint:gpu+gnu /f3269d42 @daint:gpu+gnu
+[ RUN      ] build_osu_benchmarks ~daint:gpu+intel /4d450880 @daint:gpu+intel
+[ RUN      ] build_osu_benchmarks ~daint:gpu+nvidia /e9b8d152 @daint:gpu+nvidia
+[       OK ] ( 2/22) build_osu_benchmarks ~daint:gpu+gnu /f3269d42 @daint:gpu+gnu
+[ RUN      ] osu_allreduce_test %mpi_tasks=16 /1fe48834 @daint:gpu+gnu
+[ RUN      ] osu_allreduce_test %mpi_tasks=8 /ae01c137 @daint:gpu+gnu
+[ RUN      ] osu_allreduce_test %mpi_tasks=4 /2129dc34 @daint:gpu+gnu
+[ RUN      ] osu_allreduce_test %mpi_tasks=2 /9f29c081 @daint:gpu+gnu
+[ RUN      ] osu_bandwidth_test /026711a1 @daint:gpu+gnu
+[ RUN      ] osu_latency_test /d2c978ad @daint:gpu+gnu
+[       OK ] ( 3/22) build_osu_benchmarks ~daint:gpu+intel /4d450880 @daint:gpu+intel
+[ RUN      ] osu_allreduce_test %mpi_tasks=16 /1fe48834 @daint:gpu+intel
+[ RUN      ] osu_allreduce_test %mpi_tasks=8 /ae01c137 @daint:gpu+intel
+[ RUN      ] osu_allreduce_test %mpi_tasks=4 /2129dc34 @daint:gpu+intel
+[ RUN      ] osu_allreduce_test %mpi_tasks=2 /9f29c081 @daint:gpu+intel
+[ RUN      ] osu_bandwidth_test /026711a1 @daint:gpu+intel
+[       OK ] ( 4/22) build_osu_benchmarks ~daint:gpu+nvidia /e9b8d152 @daint:gpu+nvidia
+[ RUN      ] osu_allreduce_test %mpi_tasks=16 /1fe48834 @daint:gpu+nvidia
+[ RUN      ] osu_allreduce_test %mpi_tasks=8 /ae01c137 @daint:gpu+nvidia
+[ RUN      ] osu_allreduce_test %mpi_tasks=4 /2129dc34 @daint:gpu+nvidia
+[ RUN      ] osu_allreduce_test %mpi_tasks=2 /9f29c081 @daint:gpu+nvidia
+[ RUN      ] osu_bandwidth_test /026711a1 @daint:gpu+nvidia
+[ RUN      ] osu_latency_test /d2c978ad @daint:gpu+intel
+[ RUN      ] osu_latency_test /d2c978ad @daint:gpu+nvidia
+[       OK ] ( 5/22) osu_allreduce_test %mpi_tasks=8 /ae01c137 @daint:gpu+intel
+P: latency: 9.26 us (r:0, l:None, u:None)
+[       OK ] ( 6/22) osu_allreduce_test %mpi_tasks=16 /1fe48834 @daint:gpu+intel
+P: latency: 20.63 us (r:0, l:None, u:None)
+[       OK ] ( 7/22) osu_allreduce_test %mpi_tasks=8 /ae01c137 @daint:gpu+gnu
+P: latency: 8.21 us (r:0, l:None, u:None)
+[       OK ] ( 8/22) osu_allreduce_test %mpi_tasks=4 /2129dc34 @daint:gpu+gnu
+P: latency: 4.56 us (r:0, l:None, u:None)
+[       OK ] ( 9/22) osu_allreduce_test %mpi_tasks=4 /2129dc34 @daint:gpu+intel
+P: latency: 3.26 us (r:0, l:None, u:None)
+[       OK ] (10/22) osu_latency_test /d2c978ad @daint:gpu+gnu
+P: latency: 1.18 us (r:0, l:None, u:None)
+[       OK ] (11/22) osu_allreduce_test %mpi_tasks=2 /9f29c081 @daint:gpu+gnu
+P: latency: 1.73 us (r:0, l:None, u:None)
+[       OK ] (12/22) osu_allreduce_test %mpi_tasks=16 /1fe48834 @daint:gpu+gnu
+P: latency: 13.15 us (r:0, l:None, u:None)
+[       OK ] (13/22) osu_allreduce_test %mpi_tasks=2 /9f29c081 @daint:gpu+intel
+P: latency: 1.69 us (r:0, l:None, u:None)
+[       OK ] (14/22) osu_bandwidth_test /026711a1 @daint:gpu+gnu
+P: bandwidth: 9711.54 MB/s (r:0, l:None, u:None)
+[       OK ] (15/22) osu_allreduce_test %mpi_tasks=16 /1fe48834 @daint:gpu+nvidia
+P: latency: 13.41 us (r:0, l:None, u:None)
+[       OK ] (16/22) osu_allreduce_test %mpi_tasks=2 /9f29c081 @daint:gpu+nvidia
+P: latency: 1.65 us (r:0, l:None, u:None)
+[       OK ] (17/22) osu_latency_test /d2c978ad @daint:gpu+intel
+P: latency: 1.17 us (r:0, l:None, u:None)
+[       OK ] (18/22) osu_latency_test /d2c978ad @daint:gpu+nvidia
+P: latency: 1.18 us (r:0, l:None, u:None)
+[       OK ] (19/22) osu_allreduce_test %mpi_tasks=4 /2129dc34 @daint:gpu+nvidia
+P: latency: 4.79 us (r:0, l:None, u:None)
+[       OK ] (20/22) osu_allreduce_test %mpi_tasks=8 /ae01c137 @daint:gpu+nvidia
+P: latency: 7.57 us (r:0, l:None, u:None)
+[       OK ] (21/22) osu_bandwidth_test /026711a1 @daint:gpu+intel
+P: bandwidth: 9843.72 MB/s (r:0, l:None, u:None)
+[       OK ] (22/22) osu_bandwidth_test /026711a1 @daint:gpu+nvidia
+P: bandwidth: 9785.8 MB/s (r:0, l:None, u:None)
 [----------] all spawned checks have finished
 
 [  PASSED  ] Ran 22/22 test case(s) from 10 check(s) (0 failure(s), 0 skipped)
-[==========] Finished on Sat Jan 22 23:13:40 2022
-Run report saved in '/home/user/.reframe/reports/run-report.json'
-Log file(s) saved in '/tmp/rfm-6gbw7qzs.log'
+[==========] Finished on Wed Oct  5 15:31:53 2022
+Run report saved in '/home/user/.reframe/reports/run-report-66.json'
+Log file(s) saved in '/tmp/rfm-n_metrl9.log'

--- a/docs/listings/osu_bench_list_concretized.txt
+++ b/docs/listings/osu_bench_list_concretized.txt
@@ -1,68 +1,69 @@
 [ReFrame Setup]
-  version:           3.10.0-dev.3+605af31a
+  version:           4.0.0-dev.1+6c51b548
   command:           './bin/reframe -c tutorials/deps/osu_benchmarks.py -lC'
-  launched by:       user@host
+  launched by:       user@daint104
   working directory: '/home/user/Devel/reframe'
   settings file:     '/home/user/Devel/reframe/tutorials/config/settings.py'
   check search path: '/home/user/Devel/reframe/tutorials/deps/osu_benchmarks.py'
   stage directory:   '/home/user/Devel/reframe/stage'
   output directory:  '/home/user/Devel/reframe/output'
+  log files:         '/tmp/rfm-ry5fdbm2.log'
 
 [List of matched checks]
-- OSUAllreduceTest %mpi_tasks=16 @daint:gpu+gnu
-    ^OSUBuildTest @daint:gpu+gnu
-      ^OSUDownloadTest @daint:login+builtin
-- OSUAllreduceTest %mpi_tasks=16 @daint:gpu+intel
-    ^OSUBuildTest @daint:gpu+intel
-      ^OSUDownloadTest @daint:login+builtin
-- OSUAllreduceTest %mpi_tasks=16 @daint:gpu+nvidia
-    ^OSUBuildTest @daint:gpu+nvidia
-      ^OSUDownloadTest @daint:login+builtin
-- OSUAllreduceTest %mpi_tasks=8 @daint:gpu+gnu
-    ^OSUBuildTest @daint:gpu+gnu
-      ^OSUDownloadTest @daint:login+builtin
-- OSUAllreduceTest %mpi_tasks=8 @daint:gpu+intel
-    ^OSUBuildTest @daint:gpu+intel
-      ^OSUDownloadTest @daint:login+builtin
-- OSUAllreduceTest %mpi_tasks=8 @daint:gpu+nvidia
-    ^OSUBuildTest @daint:gpu+nvidia
-      ^OSUDownloadTest @daint:login+builtin
-- OSUAllreduceTest %mpi_tasks=4 @daint:gpu+gnu
-    ^OSUBuildTest @daint:gpu+gnu
-      ^OSUDownloadTest @daint:login+builtin
-- OSUAllreduceTest %mpi_tasks=4 @daint:gpu+intel
-    ^OSUBuildTest @daint:gpu+intel
-      ^OSUDownloadTest @daint:login+builtin
-- OSUAllreduceTest %mpi_tasks=4 @daint:gpu+nvidia
-    ^OSUBuildTest @daint:gpu+nvidia
-      ^OSUDownloadTest @daint:login+builtin
-- OSUAllreduceTest %mpi_tasks=2 @daint:gpu+gnu
-    ^OSUBuildTest @daint:gpu+gnu
-      ^OSUDownloadTest @daint:login+builtin
-- OSUAllreduceTest %mpi_tasks=2 @daint:gpu+intel
-    ^OSUBuildTest @daint:gpu+intel
-      ^OSUDownloadTest @daint:login+builtin
-- OSUAllreduceTest %mpi_tasks=2 @daint:gpu+nvidia
-    ^OSUBuildTest @daint:gpu+nvidia
-      ^OSUDownloadTest @daint:login+builtin
-- OSUBandwidthTest @daint:gpu+gnu
-    ^OSUBuildTest @daint:gpu+gnu
-      ^OSUDownloadTest @daint:login+builtin
-- OSUBandwidthTest @daint:gpu+intel
-    ^OSUBuildTest @daint:gpu+intel
-      ^OSUDownloadTest @daint:login+builtin
-- OSUBandwidthTest @daint:gpu+nvidia
-    ^OSUBuildTest @daint:gpu+nvidia
-      ^OSUDownloadTest @daint:login+builtin
-- OSULatencyTest @daint:gpu+gnu
-    ^OSUBuildTest @daint:gpu+gnu
-      ^OSUDownloadTest @daint:login+builtin
-- OSULatencyTest @daint:gpu+intel
-    ^OSUBuildTest @daint:gpu+intel
-      ^OSUDownloadTest @daint:login+builtin
-- OSULatencyTest @daint:gpu+nvidia
-    ^OSUBuildTest @daint:gpu+nvidia
-      ^OSUDownloadTest @daint:login+builtin
+- OSUAllreduceTest %mpi_tasks=16 /7f033d39 @daint:gpu+gnu
+    ^OSUBuildTest /19b4fb56 @daint:gpu+gnu
+      ^OSUDownloadTest /7de668df @daint:login+builtin
+- OSUAllreduceTest %mpi_tasks=16 /7f033d39 @daint:gpu+intel
+    ^OSUBuildTest /19b4fb56 @daint:gpu+intel
+      ^OSUDownloadTest /7de668df @daint:login+builtin
+- OSUAllreduceTest %mpi_tasks=16 /7f033d39 @daint:gpu+nvidia
+    ^OSUBuildTest /19b4fb56 @daint:gpu+nvidia
+      ^OSUDownloadTest /7de668df @daint:login+builtin
+- OSUAllreduceTest %mpi_tasks=8 /005fca19 @daint:gpu+gnu
+    ^OSUBuildTest /19b4fb56 @daint:gpu+gnu
+      ^OSUDownloadTest /7de668df @daint:login+builtin
+- OSUAllreduceTest %mpi_tasks=8 /005fca19 @daint:gpu+intel
+    ^OSUBuildTest /19b4fb56 @daint:gpu+intel
+      ^OSUDownloadTest /7de668df @daint:login+builtin
+- OSUAllreduceTest %mpi_tasks=8 /005fca19 @daint:gpu+nvidia
+    ^OSUBuildTest /19b4fb56 @daint:gpu+nvidia
+      ^OSUDownloadTest /7de668df @daint:login+builtin
+- OSUAllreduceTest %mpi_tasks=4 /84b85d90 @daint:gpu+gnu
+    ^OSUBuildTest /19b4fb56 @daint:gpu+gnu
+      ^OSUDownloadTest /7de668df @daint:login+builtin
+- OSUAllreduceTest %mpi_tasks=4 /84b85d90 @daint:gpu+intel
+    ^OSUBuildTest /19b4fb56 @daint:gpu+intel
+      ^OSUDownloadTest /7de668df @daint:login+builtin
+- OSUAllreduceTest %mpi_tasks=4 /84b85d90 @daint:gpu+nvidia
+    ^OSUBuildTest /19b4fb56 @daint:gpu+nvidia
+      ^OSUDownloadTest /7de668df @daint:login+builtin
+- OSUAllreduceTest %mpi_tasks=2 /9d550c4f @daint:gpu+gnu
+    ^OSUBuildTest /19b4fb56 @daint:gpu+gnu
+      ^OSUDownloadTest /7de668df @daint:login+builtin
+- OSUAllreduceTest %mpi_tasks=2 /9d550c4f @daint:gpu+intel
+    ^OSUBuildTest /19b4fb56 @daint:gpu+intel
+      ^OSUDownloadTest /7de668df @daint:login+builtin
+- OSUAllreduceTest %mpi_tasks=2 /9d550c4f @daint:gpu+nvidia
+    ^OSUBuildTest /19b4fb56 @daint:gpu+nvidia
+      ^OSUDownloadTest /7de668df @daint:login+builtin
+- OSUBandwidthTest /764cdb0b @daint:gpu+gnu
+    ^OSUBuildTest /19b4fb56 @daint:gpu+gnu
+      ^OSUDownloadTest /7de668df @daint:login+builtin
+- OSUBandwidthTest /764cdb0b @daint:gpu+intel
+    ^OSUBuildTest /19b4fb56 @daint:gpu+intel
+      ^OSUDownloadTest /7de668df @daint:login+builtin
+- OSUBandwidthTest /764cdb0b @daint:gpu+nvidia
+    ^OSUBuildTest /19b4fb56 @daint:gpu+nvidia
+      ^OSUDownloadTest /7de668df @daint:login+builtin
+- OSULatencyTest /14f35a43 @daint:gpu+gnu
+    ^OSUBuildTest /19b4fb56 @daint:gpu+gnu
+      ^OSUDownloadTest /7de668df @daint:login+builtin
+- OSULatencyTest /14f35a43 @daint:gpu+intel
+    ^OSUBuildTest /19b4fb56 @daint:gpu+intel
+      ^OSUDownloadTest /7de668df @daint:login+builtin
+- OSULatencyTest /14f35a43 @daint:gpu+nvidia
+    ^OSUBuildTest /19b4fb56 @daint:gpu+nvidia
+      ^OSUDownloadTest /7de668df @daint:login+builtin
 Concretized 22 test case(s)
 
-Log file(s) saved in '/tmp/rfm-l3eamaiy.log'
+Log file(s) saved in '/tmp/rfm-ry5fdbm2.log'

--- a/docs/listings/osu_bench_list_concretized_gnu.txt
+++ b/docs/listings/osu_bench_list_concretized_gnu.txt
@@ -1,17 +1,18 @@
 [ReFrame Setup]
-  version:           3.10.0-dev.3+605af31a
+  version:           4.0.0-dev.1+6c51b548
   command:           './bin/reframe -c tutorials/deps/osu_benchmarks.py -n OSULatencyTest -L -p builtin -p gnu'
-  launched by:       user@host
+  launched by:       user@daint104
   working directory: '/home/user/Devel/reframe'
   settings file:     '/home/user/Devel/reframe/tutorials/config/settings.py'
   check search path: '/home/user/Devel/reframe/tutorials/deps/osu_benchmarks.py'
   stage directory:   '/home/user/Devel/reframe/stage'
   output directory:  '/home/user/Devel/reframe/output'
+  log files:         '/tmp/rfm-o4x9lxoo.log'
 
 [List of matched checks]
-- OSULatencyTest [id: OSULatencyTest, file: '/home/user/Devel/reframe/tutorials/deps/osu_benchmarks.py']
-    ^OSUBuildTest [id: OSUBuildTest, file: '/home/user/Devel/reframe/tutorials/deps/osu_benchmarks.py']
-      ^OSUDownloadTest [id: OSUDownloadTest, file: '/home/user/Devel/reframe/tutorials/deps/osu_benchmarks.py']
+- OSULatencyTest /14f35a43 [variant: 0, file: '/home/user/Devel/reframe/tutorials/deps/osu_benchmarks.py']
+    ^OSUBuildTest /19b4fb56 [variant: 0, file: '/home/user/Devel/reframe/tutorials/deps/osu_benchmarks.py']
+      ^OSUDownloadTest /7de668df [variant: 0, file: '/home/user/Devel/reframe/tutorials/deps/osu_benchmarks.py']
 Found 3 check(s)
 
-Log file(s) saved in '/tmp/rfm-klltwsex.log'
+Log file(s) saved in '/tmp/rfm-o4x9lxoo.log'

--- a/docs/listings/osu_latency_list.txt
+++ b/docs/listings/osu_latency_list.txt
@@ -1,17 +1,18 @@
 [ReFrame Setup]
-  version:           3.10.0-dev.3+605af31a
+  version:           4.0.0-dev.1+6c51b548
   command:           './bin/reframe -c tutorials/deps/osu_benchmarks.py -n OSULatencyTest -l'
-  launched by:       user@host
+  launched by:       user@daint104
   working directory: '/home/user/Devel/reframe'
   settings file:     '/home/user/Devel/reframe/tutorials/config/settings.py'
   check search path: '/home/user/Devel/reframe/tutorials/deps/osu_benchmarks.py'
   stage directory:   '/home/user/Devel/reframe/stage'
   output directory:  '/home/user/Devel/reframe/output'
+  log files:         '/tmp/rfm-4_7t2oj3.log'
 
 [List of matched checks]
-- OSULatencyTest
-    ^OSUBuildTest
-      ^OSUDownloadTest
+- OSULatencyTest /14f35a43
+    ^OSUBuildTest /19b4fb56
+      ^OSUDownloadTest /7de668df
 Found 3 check(s)
 
-Log file(s) saved in '/tmp/rfm-zc483csf.log'
+Log file(s) saved in '/tmp/rfm-4_7t2oj3.log'

--- a/docs/listings/osu_latency_unresolved_deps.txt
+++ b/docs/listings/osu_latency_unresolved_deps.txt
@@ -1,40 +1,41 @@
 [ReFrame Setup]
-  version:           3.10.0-dev.3+605af31a
+  version:           4.0.0-dev.1+6c51b548
   command:           './bin/reframe -c tutorials/deps/osu_benchmarks.py -n OSULatencyTest --system=daint:gpu -l'
-  launched by:       user@host
+  launched by:       user@daint104
   working directory: '/home/user/Devel/reframe'
   settings file:     '/home/user/Devel/reframe/tutorials/config/settings.py'
   check search path: '/home/user/Devel/reframe/tutorials/deps/osu_benchmarks.py'
   stage directory:   '/home/user/Devel/reframe/stage'
   output directory:  '/home/user/Devel/reframe/output'
+  log files:         '/tmp/rfm-es6fy9jr.log'
 
-./bin/reframe: could not resolve dependency: ('OSUBuildTest', 'daint:gpu', 'gnu') -> 'OSUDownloadTest'
-./bin/reframe: could not resolve dependency: ('OSUBuildTest', 'daint:gpu', 'intel') -> 'OSUDownloadTest'
-./bin/reframe: could not resolve dependency: ('OSUBuildTest', 'daint:gpu', 'nvidia') -> 'OSUDownloadTest'
-./bin/reframe: skipping all dependent test cases
-  - ('OSUBuildTest', 'daint:gpu', 'nvidia')
-  - ('OSUBuildTest', 'daint:gpu', 'intel')
-  - ('OSUAllreduceTest_8', 'daint:gpu', 'nvidia')
-  - ('OSUAllreduceTest_16', 'daint:gpu', 'nvidia')
+WARNING: could not resolve dependency: ('OSUBuildTest', 'daint:gpu', 'gnu') -> 'OSUDownloadTest'
+WARNING: could not resolve dependency: ('OSUBuildTest', 'daint:gpu', 'intel') -> 'OSUDownloadTest'
+WARNING: could not resolve dependency: ('OSUBuildTest', 'daint:gpu', 'nvidia') -> 'OSUDownloadTest'
+WARNING: skipping all dependent test cases
   - ('OSUBuildTest', 'daint:gpu', 'gnu')
-  - ('OSUAllreduceTest_4', 'daint:gpu', 'intel')
-  - ('OSUAllreduceTest_8', 'daint:gpu', 'intel')
-  - ('OSUAllreduceTest_4', 'daint:gpu', 'nvidia')
-  - ('OSUAllreduceTest_16', 'daint:gpu', 'intel')
-  - ('OSULatencyTest', 'daint:gpu', 'nvidia')
-  - ('OSUAllreduceTest_8', 'daint:gpu', 'gnu')
+  - ('OSUBuildTest', 'daint:gpu', 'nvidia')
+  - ('OSUAllreduceTest_1', 'daint:gpu', 'gnu')
   - ('OSUAllreduceTest_2', 'daint:gpu', 'nvidia')
+  - ('OSUAllreduceTest_0', 'daint:gpu', 'nvidia')
   - ('OSUBandwidthTest', 'daint:gpu', 'nvidia')
-  - ('OSUAllreduceTest_16', 'daint:gpu', 'gnu')
-  - ('OSUBandwidthTest', 'daint:gpu', 'intel')
-  - ('OSULatencyTest', 'daint:gpu', 'intel')
-  - ('OSUAllreduceTest_2', 'daint:gpu', 'intel')
-  - ('OSUAllreduceTest_4', 'daint:gpu', 'gnu')
-  - ('OSUAllreduceTest_2', 'daint:gpu', 'gnu')
+  - ('OSUAllreduceTest_3', 'daint:gpu', 'gnu')
+  - ('OSUAllreduceTest_0', 'daint:gpu', 'gnu')
   - ('OSUBandwidthTest', 'daint:gpu', 'gnu')
+  - ('OSUAllreduceTest_1', 'daint:gpu', 'nvidia')
+  - ('OSUBuildTest', 'daint:gpu', 'intel')
+  - ('OSUBandwidthTest', 'daint:gpu', 'intel')
+  - ('OSUAllreduceTest_0', 'daint:gpu', 'intel')
+  - ('OSUAllreduceTest_1', 'daint:gpu', 'intel')
+  - ('OSUAllreduceTest_2', 'daint:gpu', 'intel')
   - ('OSULatencyTest', 'daint:gpu', 'gnu')
+  - ('OSUAllreduceTest_2', 'daint:gpu', 'gnu')
+  - ('OSULatencyTest', 'daint:gpu', 'nvidia')
+  - ('OSUAllreduceTest_3', 'daint:gpu', 'nvidia')
+  - ('OSULatencyTest', 'daint:gpu', 'intel')
+  - ('OSUAllreduceTest_3', 'daint:gpu', 'intel')
 
 [List of matched checks]
 Found 0 check(s)
 
-Log file(s) saved in '/tmp/rfm-k1w20m9z.log'
+Log file(s) saved in '/tmp/rfm-es6fy9jr.log'

--- a/docs/listings/param_deps_list.txt
+++ b/docs/listings/param_deps_list.txt
@@ -1,25 +1,26 @@
 [ReFrame Setup]
-  version:           3.10.0-dev.3+605af31a
+  version:           4.0.0-dev.1+36ffa085
   command:           './bin/reframe -c tutorials/deps/parameterized.py -l'
-  launched by:       user@host
-  working directory: '/home/user/Devel/reframe'
-  settings file:     '/home/user/Devel/reframe/tutorials/config/settings.py'
-  check search path: '/home/user/Devel/reframe/tutorials/deps/parameterized.py'
-  stage directory:   '/home/user/Devel/reframe/stage'
-  output directory:  '/home/user/Devel/reframe/output'
+  launched by:       user@tresa.local
+  working directory: '/home/user/Repositories/reframe'
+  settings file:     '/home/user/Repositories/reframe/tutorials/config/settings.py'
+  check search path: '/home/user/Repositories/reframe/tutorials/deps/parameterized.py'
+  stage directory:   '/home/user/Repositories/reframe/stage'
+  output directory:  '/home/user/Repositories/reframe/output'
+  log files:         '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-h8cf94kw.log'
 
 [List of matched checks]
-- TestB
-    ^TestA %z=9
-    ^TestA %z=8
-    ^TestA %z=7
-    ^TestA %z=6
-- TestA %z=5
-- TestA %z=4
-- TestA %z=3
-- TestA %z=2
-- TestA %z=1
-- TestA %z=0
+- TestB /cc291487
+    ^TestA %z=9 /034f091a
+    ^TestA %z=8 /a093d19f
+    ^TestA %z=7 /77b4b8e6
+    ^TestA %z=6 /40ce4759
+- TestA %z=5 /aa0cffc9
+- TestA %z=4 /83cd5dec
+- TestA %z=3 /1c51609b
+- TestA %z=2 /707b752c
+- TestA %z=1 /c65657d5
+- TestA %z=0 /1b9f44df
 Found 11 check(s)
 
-Log file(s) saved in '/tmp/rfm-iey58chw.log'
+Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-h8cf94kw.log'

--- a/docs/listings/stream1.txt
+++ b/docs/listings/stream1.txt
@@ -1,37 +1,40 @@
 [ReFrame Setup]
-  version:           3.10.0-dev.2+bf404ae1
+  version:           4.0.0-dev.1+36ffa085
   command:           './bin/reframe -c tutorials/basics/stream/stream1.py -r --performance-report'
   launched by:       user@host
-  working directory: '/Users/user/Repositories/reframe'
-  settings file:     'tutorials/config/mysettings.py'
-  check search path: '/Users/user/Repositories/reframe/tutorials/basics/stream/stream1.py'
-  stage directory:   '/Users/user/Repositories/reframe/stage'
-  output directory:  '/Users/user/Repositories/reframe/output'
+  working directory: '/home/user/Repositories/reframe'
+  settings file:     '/home/user/Repositories/reframe/tutorials/config/settings.py'
+  check search path: '/home/user/Repositories/reframe/tutorials/basics/stream/stream1.py'
+  stage directory:   '/home/user/Repositories/reframe/stage'
+  output directory:  '/home/user/Repositories/reframe/output'
+  log files:         '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-t4ivj216.log'
 
 [==========] Running 1 check(s)
-[==========] Started on Wed Jan 19 17:13:35 2022
+[==========] Started on Sat Oct  1 23:42:24 2022 
 
-[----------] started processing StreamTest (StreamTest)
-[ RUN      ] StreamTest on catalina:default using gnu
-[----------] finished processing StreamTest (StreamTest)
-
-[----------] waiting for spawned checks to finish
-[       OK ] (1/1) StreamTest @catalina:default+gnu
+[----------] start processing checks
+[ RUN      ] StreamTest /cdf4820d @catalina:default+gnu
+[       OK ] (1/1) StreamTest /cdf4820d @catalina:default+gnu
+P: Copy: 25169.9 MB/s (r:0, l:None, u:None)
+P: Scale: 16884.2 MB/s (r:0, l:None, u:None)
+P: Add: 18613.3 MB/s (r:0, l:None, u:None)
+P: Triad: 18902.1 MB/s (r:0, l:None, u:None)
 [----------] all spawned checks have finished
 
 [  PASSED  ] Ran 1/1 test case(s) from 1 check(s) (0 failure(s), 0 skipped)
-[==========] Finished on Wed Jan 19 17:13:39 2022
-==============================================================================
+[==========] Finished on Sat Oct  1 23:42:28 2022 
+
+================================================================================
 PERFORMANCE REPORT
-------------------------------------------------------------------------------
-StreamTest
-- catalina:default
-   - gnu
-      * num_tasks: 1
-      * Copy: 23864.2 MB/s
-      * Scale: 16472.6 MB/s
-      * Add: 18265.5 MB/s
-      * Triad: 18632.3 MB/s
-------------------------------------------------------------------------------
-Run report saved in '/Users/user/.reframe/reports/run-report.json'
-Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-o1wls55_.log'
+--------------------------------------------------------------------------------
+[StreamTest /cdf4820d @catalina:default:gnu]
+  num_gpus_per_node: 0
+  num_tasks: 1
+  performance:
+    - Copy: 25169.9 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Scale: 16884.2 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Add: 18613.3 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Triad: 18902.1 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+--------------------------------------------------------------------------------
+Run report saved in '/home/user/.reframe/reports/run-report-115.json'
+Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-t4ivj216.log'

--- a/docs/listings/stream3_failure_only.txt
+++ b/docs/listings/stream3_failure_only.txt
@@ -1,14 +1,14 @@
-FAILURE INFO for StreamWithRefTest 
+FAILURE INFO for StreamWithRefTest
   * Expanded name: StreamWithRefTest
-  * Description: StreamWithRefTest
+  * Description:
   * System partition: catalina:default
   * Environment: gnu
   * Stage directory: /Users/user/Repositories/reframe/stage/catalina/default/gnu/StreamWithRefTest
-  * Node list: vpn-39
-  * Job type: local (id=34622)
+  * Node list: tresa.localNone
+  * Job type: local (id=4576)
   * Dependencies (conceptual): []
   * Dependencies (actual): []
   * Maintainers: []
   * Failing phase: performance
-  * Rerun with '-n StreamWithRefTest -p gnu --system catalina:default -r'
-  * Reason: performance error: failed to meet reference: Copy=24584.3, expected 55200 (l=52440.0, u=57960.0)
+  * Rerun with '-n /f925207b -p gnu --system catalina:default -r'
+  * Reason: performance error: failed to meet reference: Add=19585.3, expected 18500 (l=17575.0, u=19425.0)

--- a/docs/listings/stream4_daint.txt
+++ b/docs/listings/stream4_daint.txt
@@ -1,5 +1,5 @@
 [ReFrame Setup]
-  version:           4.0.0-dev.1+6c51b548
+  version:           4.0.0-dev.1+a4a2a15f
   command:           './bin/reframe -c tutorials/basics/stream/stream4.py -r --performance-report'
   launched by:       user@daint104
   working directory: '/home/user/Devel/reframe'
@@ -7,10 +7,10 @@
   check search path: '/home/user/Devel/reframe/tutorials/basics/stream/stream4.py'
   stage directory:   '/home/user/Devel/reframe/stage'
   output directory:  '/home/user/Devel/reframe/output'
-  log files:         '/tmp/rfm-_6x826vd.log'
+  log files:         '/tmp/rfm-c9f_ne8m.log'
 
 [==========] Running 1 check(s)
-[==========] Started on Wed Oct  5 15:02:21 2022
+[==========] Started on Fri Oct  7 11:22:15 2022
 
 [----------] start processing checks
 [ RUN      ] StreamMultiSysTest /eec1c676 @daint:login+gnu
@@ -26,82 +26,181 @@
 [ RUN      ] StreamMultiSysTest /eec1c676 @daint:mc+nvidia
 [ RUN      ] StreamMultiSysTest /eec1c676 @daint:mc+cray
 [       OK ] ( 1/12) StreamMultiSysTest /eec1c676 @daint:login+gnu
-P: Copy: 94272.8 MB/s (r:0, l:None, u:None)
-P: Scale: 72207.8 MB/s (r:0, l:None, u:None)
-P: Add: 77800.3 MB/s (r:0, l:None, u:None)
-P: Triad: 77800.3 MB/s (r:0, l:None, u:None)
+P: Copy: 90564.7 MB/s (r:0, l:None, u:None)
+P: Scale: 69209.5 MB/s (r:0, l:None, u:None)
+P: Add: 74898.5 MB/s (r:0, l:None, u:None)
+P: Triad: 74036.6 MB/s (r:0, l:None, u:None)
 [       OK ] ( 2/12) StreamMultiSysTest /eec1c676 @daint:login+intel
-P: Copy: 101564.7 MB/s (r:0, l:None, u:None)
-P: Scale: 91429.0 MB/s (r:0, l:None, u:None)
-P: Add: 102027.9 MB/s (r:0, l:None, u:None)
-P: Triad: 102993.5 MB/s (r:0, l:None, u:None)
+P: Copy: 83611.7 MB/s (r:0, l:None, u:None)
+P: Scale: 72885.0 MB/s (r:0, l:None, u:None)
+P: Add: 79780.7 MB/s (r:0, l:None, u:None)
+P: Triad: 99212.3 MB/s (r:0, l:None, u:None)
 [       OK ] ( 3/12) StreamMultiSysTest /eec1c676 @daint:login+nvidia
-P: Copy: 102911.2 MB/s (r:0, l:None, u:None)
-P: Scale: 70791.3 MB/s (r:0, l:None, u:None)
-P: Add: 80034.6 MB/s (r:0, l:None, u:None)
-P: Triad: 78169.4 MB/s (r:0, l:None, u:None)
+P: Copy: 98383.4 MB/s (r:0, l:None, u:None)
+P: Scale: 70538.5 MB/s (r:0, l:None, u:None)
+P: Add: 79402.4 MB/s (r:0, l:None, u:None)
+P: Triad: 79138.3 MB/s (r:0, l:None, u:None)
 [       OK ] ( 4/12) StreamMultiSysTest /eec1c676 @daint:login+cray
-P: Copy: 100347.6 MB/s (r:0, l:None, u:None)
-P: Scale: 73706.3 MB/s (r:0, l:None, u:None)
-P: Add: 75572.2 MB/s (r:0, l:None, u:None)
-P: Triad: 79932.3 MB/s (r:0, l:None, u:None)
-[       OK ] ( 5/12) StreamMultiSysTest /eec1c676 @daint:mc+gnu
-P: Copy: 48696.0 MB/s (r:0, l:None, u:None)
-P: Scale: 38771.3 MB/s (r:0, l:None, u:None)
-P: Add: 43728.8 MB/s (r:0, l:None, u:None)
-P: Triad: 44155.2 MB/s (r:0, l:None, u:None)
+P: Copy: 63243.9 MB/s (r:0, l:None, u:None)
+P: Scale: 49733.9 MB/s (r:0, l:None, u:None)
+P: Add: 40884.8 MB/s (r:0, l:None, u:None)
+P: Triad: 56149.9 MB/s (r:0, l:None, u:None)
+[       OK ] ( 5/12) StreamMultiSysTest /eec1c676 @daint:mc+cray
+P: Copy: 47068.4 MB/s (r:0, l:None, u:None)
+P: Scale: 40086.2 MB/s (r:0, l:None, u:None)
+P: Add: 43688.6 MB/s (r:0, l:None, u:None)
+P: Triad: 44106.8 MB/s (r:0, l:None, u:None)
 [       OK ] ( 6/12) StreamMultiSysTest /eec1c676 @daint:mc+nvidia
-P: Copy: 46899.8 MB/s (r:0, l:None, u:None)
-P: Scale: 40478.9 MB/s (r:0, l:None, u:None)
-P: Add: 44157.6 MB/s (r:0, l:None, u:None)
-P: Triad: 44607.8 MB/s (r:0, l:None, u:None)
-[       OK ] ( 7/12) StreamMultiSysTest /eec1c676 @daint:mc+cray
-P: Copy: 46815.0 MB/s (r:0, l:None, u:None)
-P: Scale: 39939.7 MB/s (r:0, l:None, u:None)
-P: Add: 43610.2 MB/s (r:0, l:None, u:None)
-P: Triad: 43938.7 MB/s (r:0, l:None, u:None)
-[       OK ] ( 8/12) StreamMultiSysTest /eec1c676 @daint:mc+intel
-P: Copy: 52644.7 MB/s (r:0, l:None, u:None)
-P: Scale: 49774.8 MB/s (r:0, l:None, u:None)
-P: Add: 57252.0 MB/s (r:0, l:None, u:None)
-P: Triad: 56787.7 MB/s (r:0, l:None, u:None)
+P: Copy: 46798.4 MB/s (r:0, l:None, u:None)
+P: Scale: 40481.8 MB/s (r:0, l:None, u:None)
+P: Add: 44143.7 MB/s (r:0, l:None, u:None)
+P: Triad: 44570.7 MB/s (r:0, l:None, u:None)
+[       OK ] ( 7/12) StreamMultiSysTest /eec1c676 @daint:mc+intel
+P: Copy: 52240.0 MB/s (r:0, l:None, u:None)
+P: Scale: 49426.5 MB/s (r:0, l:None, u:None)
+P: Add: 56988.6 MB/s (r:0, l:None, u:None)
+P: Triad: 56457.3 MB/s (r:0, l:None, u:None)
+[       OK ] ( 8/12) StreamMultiSysTest /eec1c676 @daint:mc+gnu
+P: Copy: 48686.5 MB/s (r:0, l:None, u:None)
+P: Scale: 38562.8 MB/s (r:0, l:None, u:None)
+P: Add: 43707.3 MB/s (r:0, l:None, u:None)
+P: Triad: 44041.8 MB/s (r:0, l:None, u:None)
 [       OK ] ( 9/12) StreamMultiSysTest /eec1c676 @daint:gpu+gnu
-P: Copy: 42697.1 MB/s (r:0, l:None, u:None)
-P: Scale: 38615.1 MB/s (r:0, l:None, u:None)
-P: Add: 43790.6 MB/s (r:0, l:None, u:None)
-P: Triad: 43878.2 MB/s (r:0, l:None, u:None)
+P: Copy: 42724.6 MB/s (r:0, l:None, u:None)
+P: Scale: 38443.7 MB/s (r:0, l:None, u:None)
+P: Add: 43619.8 MB/s (r:0, l:None, u:None)
+P: Triad: 43258.9 MB/s (r:0, l:None, u:None)
 [       OK ] (10/12) StreamMultiSysTest /eec1c676 @daint:gpu+intel
-P: Copy: 52219.7 MB/s (r:0, l:None, u:None)
-P: Scale: 54339.2 MB/s (r:0, l:None, u:None)
-P: Add: 57969.1 MB/s (r:0, l:None, u:None)
-P: Triad: 57456.2 MB/s (r:0, l:None, u:None)
+P: Copy: 52316.4 MB/s (r:0, l:None, u:None)
+P: Scale: 54141.9 MB/s (r:0, l:None, u:None)
+P: Add: 57550.7 MB/s (r:0, l:None, u:None)
+P: Triad: 57150.4 MB/s (r:0, l:None, u:None)
 [       OK ] (11/12) StreamMultiSysTest /eec1c676 @daint:gpu+nvidia
-P: Copy: 51503.8 MB/s (r:0, l:None, u:None)
-P: Scale: 39551.1 MB/s (r:0, l:None, u:None)
-P: Add: 43970.2 MB/s (r:0, l:None, u:None)
-P: Triad: 44303.5 MB/s (r:0, l:None, u:None)
+P: Copy: 51687.1 MB/s (r:0, l:None, u:None)
+P: Scale: 39685.6 MB/s (r:0, l:None, u:None)
+P: Add: 44116.6 MB/s (r:0, l:None, u:None)
+P: Triad: 44475.0 MB/s (r:0, l:None, u:None)
 [       OK ] (12/12) StreamMultiSysTest /eec1c676 @daint:gpu+cray
-P: Copy: 51257.6 MB/s (r:0, l:None, u:None)
-P: Scale: 38929.5 MB/s (r:0, l:None, u:None)
-P: Add: 43589.4 MB/s (r:0, l:None, u:None)
-P: Triad: 43053.3 MB/s (r:0, l:None, u:None)
+P: Copy: 51184.2 MB/s (r:0, l:None, u:None)
+P: Scale: 39397.4 MB/s (r:0, l:None, u:None)
+P: Add: 43648.0 MB/s (r:0, l:None, u:None)
+P: Triad: 43898.2 MB/s (r:0, l:None, u:None)
 [----------] all spawned checks have finished
 
 [  PASSED  ] Ran 12/12 test case(s) from 1 check(s) (0 failure(s), 0 skipped)
-[==========] Finished on Wed Oct  5 15:11:25 2022
+[==========] Finished on Fri Oct  7 11:25:31 2022
 
 ================================================================================
 PERFORMANCE REPORT
 --------------------------------------------------------------------------------
-[StreamMultiSysTest /eec1c676 @daint:mc:cray]
-  num_cpus_per_task: 36
+[StreamMultiSysTest /eec1c676 @daint:login:gnu]
   num_tasks: 1
   num_gpus_per_node: 0
+  num_cpus_per_task: 10
   performance:
-    - Copy: 46815.0 MB/s (r: 0 MB/s l: -inf% u: +inf%)
-    - Scale: 39939.7 MB/s (r: 0 MB/s l: -inf% u: +inf%)
-    - Add: 43610.2 MB/s (r: 0 MB/s l: -inf% u: +inf%)
-    - Triad: 43938.7 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Copy: 90564.7 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Scale: 69209.5 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Add: 74898.5 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Triad: 74036.6 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+[StreamMultiSysTest /eec1c676 @daint:login:intel]
+  num_tasks: 1
+  num_gpus_per_node: 0
+  num_cpus_per_task: 10
+  performance:
+    - Copy: 83611.7 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Scale: 72885.0 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Add: 79780.7 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Triad: 99212.3 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+[StreamMultiSysTest /eec1c676 @daint:login:nvidia]
+  num_tasks: 1
+  num_gpus_per_node: 0
+  num_cpus_per_task: 10
+  performance:
+    - Copy: 98383.4 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Scale: 70538.5 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Add: 79402.4 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Triad: 79138.3 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+[StreamMultiSysTest /eec1c676 @daint:login:cray]
+  num_tasks: 1
+  num_gpus_per_node: 0
+  num_cpus_per_task: 10
+  performance:
+    - Copy: 63243.9 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Scale: 49733.9 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Add: 40884.8 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Triad: 56149.9 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+[StreamMultiSysTest /eec1c676 @daint:gpu:gnu]
+  num_tasks: 1
+  num_gpus_per_node: 0
+  num_cpus_per_task: 12
+  performance:
+    - Copy: 42724.6 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Scale: 38443.7 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Add: 43619.8 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Triad: 43258.9 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+[StreamMultiSysTest /eec1c676 @daint:gpu:intel]
+  num_tasks: 1
+  num_gpus_per_node: 0
+  num_cpus_per_task: 12
+  performance:
+    - Copy: 52316.4 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Scale: 54141.9 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Add: 57550.7 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Triad: 57150.4 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+[StreamMultiSysTest /eec1c676 @daint:gpu:nvidia]
+  num_tasks: 1
+  num_gpus_per_node: 0
+  num_cpus_per_task: 12
+  performance:
+    - Copy: 51687.1 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Scale: 39685.6 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Add: 44116.6 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Triad: 44475.0 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+[StreamMultiSysTest /eec1c676 @daint:gpu:cray]
+  num_tasks: 1
+  num_gpus_per_node: 0
+  num_cpus_per_task: 12
+  performance:
+    - Copy: 51184.2 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Scale: 39397.4 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Add: 43648.0 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Triad: 43898.2 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+[StreamMultiSysTest /eec1c676 @daint:mc:gnu]
+  num_tasks: 1
+  num_gpus_per_node: 0
+  num_cpus_per_task: 36
+  performance:
+    - Copy: 48686.5 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Scale: 38562.8 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Add: 43707.3 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Triad: 44041.8 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+[StreamMultiSysTest /eec1c676 @daint:mc:intel]
+  num_tasks: 1
+  num_gpus_per_node: 0
+  num_cpus_per_task: 36
+  performance:
+    - Copy: 52240.0 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Scale: 49426.5 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Add: 56988.6 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Triad: 56457.3 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+[StreamMultiSysTest /eec1c676 @daint:mc:nvidia]
+  num_tasks: 1
+  num_gpus_per_node: 0
+  num_cpus_per_task: 36
+  performance:
+    - Copy: 46798.4 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Scale: 40481.8 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Add: 44143.7 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Triad: 44570.7 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+[StreamMultiSysTest /eec1c676 @daint:mc:cray]
+  num_tasks: 1
+  num_gpus_per_node: 0
+  num_cpus_per_task: 36
+  performance:
+    - Copy: 47068.4 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Scale: 40086.2 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Add: 43688.6 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Triad: 44106.8 MB/s (r: 0 MB/s l: -inf% u: +inf%)
 --------------------------------------------------------------------------------
-Run report saved in '/home/user/.reframe/reports/run-report-64.json'
-Log file(s) saved in '/tmp/rfm-_6x826vd.log'
+Run report saved in '/home/user/.reframe/reports/run-report-71.json'
+Log file(s) saved in '/tmp/rfm-c9f_ne8m.log'

--- a/docs/listings/stream4_daint.txt
+++ b/docs/listings/stream4_daint.txt
@@ -1,124 +1,107 @@
 [ReFrame Setup]
-  version:           3.10.0-dev.3+605af31a
+  version:           4.0.0-dev.1+6c51b548
   command:           './bin/reframe -c tutorials/basics/stream/stream4.py -r --performance-report'
-  launched by:       user@host
+  launched by:       user@daint104
   working directory: '/home/user/Devel/reframe'
   settings file:     '/home/user/Devel/reframe/tutorials/config/settings.py'
   check search path: '/home/user/Devel/reframe/tutorials/basics/stream/stream4.py'
   stage directory:   '/home/user/Devel/reframe/stage'
   output directory:  '/home/user/Devel/reframe/output'
+  log files:         '/tmp/rfm-_6x826vd.log'
 
 [==========] Running 1 check(s)
-[==========] Started on Sat Jan 22 22:47:28 2022
+[==========] Started on Wed Oct  5 15:02:21 2022
 
 [----------] start processing checks
-[ RUN      ] StreamMultiSysTest @daint:login+gnu
-[ RUN      ] StreamMultiSysTest @daint:login+intel
-[ RUN      ] StreamMultiSysTest @daint:login+nvidia
-[ RUN      ] StreamMultiSysTest @daint:login+cray
-[ RUN      ] StreamMultiSysTest @daint:gpu+gnu
-[ RUN      ] StreamMultiSysTest @daint:gpu+intel
-[ RUN      ] StreamMultiSysTest @daint:gpu+nvidia
-[ RUN      ] StreamMultiSysTest @daint:gpu+cray
-[ RUN      ] StreamMultiSysTest @daint:mc+gnu
-[ RUN      ] StreamMultiSysTest @daint:mc+intel
-[ RUN      ] StreamMultiSysTest @daint:mc+nvidia
-[ RUN      ] StreamMultiSysTest @daint:mc+cray
-[       OK ] ( 1/12) StreamMultiSysTest @daint:login+gnu
-[       OK ] ( 2/12) StreamMultiSysTest @daint:login+intel
-[       OK ] ( 3/12) StreamMultiSysTest @daint:login+nvidia
-[       OK ] ( 4/12) StreamMultiSysTest @daint:login+cray
-[       OK ] ( 5/12) StreamMultiSysTest @daint:gpu+gnu
-[       OK ] ( 6/12) StreamMultiSysTest @daint:gpu+nvidia
-[       OK ] ( 7/12) StreamMultiSysTest @daint:gpu+cray
-[       OK ] ( 8/12) StreamMultiSysTest @daint:gpu+intel
-[       OK ] ( 9/12) StreamMultiSysTest @daint:mc+gnu
-[       OK ] (10/12) StreamMultiSysTest @daint:mc+cray
-[       OK ] (11/12) StreamMultiSysTest @daint:mc+nvidia
-[       OK ] (12/12) StreamMultiSysTest @daint:mc+intel
+[ RUN      ] StreamMultiSysTest /eec1c676 @daint:login+gnu
+[ RUN      ] StreamMultiSysTest /eec1c676 @daint:login+intel
+[ RUN      ] StreamMultiSysTest /eec1c676 @daint:login+nvidia
+[ RUN      ] StreamMultiSysTest /eec1c676 @daint:login+cray
+[ RUN      ] StreamMultiSysTest /eec1c676 @daint:gpu+gnu
+[ RUN      ] StreamMultiSysTest /eec1c676 @daint:gpu+intel
+[ RUN      ] StreamMultiSysTest /eec1c676 @daint:gpu+nvidia
+[ RUN      ] StreamMultiSysTest /eec1c676 @daint:gpu+cray
+[ RUN      ] StreamMultiSysTest /eec1c676 @daint:mc+gnu
+[ RUN      ] StreamMultiSysTest /eec1c676 @daint:mc+intel
+[ RUN      ] StreamMultiSysTest /eec1c676 @daint:mc+nvidia
+[ RUN      ] StreamMultiSysTest /eec1c676 @daint:mc+cray
+[       OK ] ( 1/12) StreamMultiSysTest /eec1c676 @daint:login+gnu
+P: Copy: 94272.8 MB/s (r:0, l:None, u:None)
+P: Scale: 72207.8 MB/s (r:0, l:None, u:None)
+P: Add: 77800.3 MB/s (r:0, l:None, u:None)
+P: Triad: 77800.3 MB/s (r:0, l:None, u:None)
+[       OK ] ( 2/12) StreamMultiSysTest /eec1c676 @daint:login+intel
+P: Copy: 101564.7 MB/s (r:0, l:None, u:None)
+P: Scale: 91429.0 MB/s (r:0, l:None, u:None)
+P: Add: 102027.9 MB/s (r:0, l:None, u:None)
+P: Triad: 102993.5 MB/s (r:0, l:None, u:None)
+[       OK ] ( 3/12) StreamMultiSysTest /eec1c676 @daint:login+nvidia
+P: Copy: 102911.2 MB/s (r:0, l:None, u:None)
+P: Scale: 70791.3 MB/s (r:0, l:None, u:None)
+P: Add: 80034.6 MB/s (r:0, l:None, u:None)
+P: Triad: 78169.4 MB/s (r:0, l:None, u:None)
+[       OK ] ( 4/12) StreamMultiSysTest /eec1c676 @daint:login+cray
+P: Copy: 100347.6 MB/s (r:0, l:None, u:None)
+P: Scale: 73706.3 MB/s (r:0, l:None, u:None)
+P: Add: 75572.2 MB/s (r:0, l:None, u:None)
+P: Triad: 79932.3 MB/s (r:0, l:None, u:None)
+[       OK ] ( 5/12) StreamMultiSysTest /eec1c676 @daint:mc+gnu
+P: Copy: 48696.0 MB/s (r:0, l:None, u:None)
+P: Scale: 38771.3 MB/s (r:0, l:None, u:None)
+P: Add: 43728.8 MB/s (r:0, l:None, u:None)
+P: Triad: 44155.2 MB/s (r:0, l:None, u:None)
+[       OK ] ( 6/12) StreamMultiSysTest /eec1c676 @daint:mc+nvidia
+P: Copy: 46899.8 MB/s (r:0, l:None, u:None)
+P: Scale: 40478.9 MB/s (r:0, l:None, u:None)
+P: Add: 44157.6 MB/s (r:0, l:None, u:None)
+P: Triad: 44607.8 MB/s (r:0, l:None, u:None)
+[       OK ] ( 7/12) StreamMultiSysTest /eec1c676 @daint:mc+cray
+P: Copy: 46815.0 MB/s (r:0, l:None, u:None)
+P: Scale: 39939.7 MB/s (r:0, l:None, u:None)
+P: Add: 43610.2 MB/s (r:0, l:None, u:None)
+P: Triad: 43938.7 MB/s (r:0, l:None, u:None)
+[       OK ] ( 8/12) StreamMultiSysTest /eec1c676 @daint:mc+intel
+P: Copy: 52644.7 MB/s (r:0, l:None, u:None)
+P: Scale: 49774.8 MB/s (r:0, l:None, u:None)
+P: Add: 57252.0 MB/s (r:0, l:None, u:None)
+P: Triad: 56787.7 MB/s (r:0, l:None, u:None)
+[       OK ] ( 9/12) StreamMultiSysTest /eec1c676 @daint:gpu+gnu
+P: Copy: 42697.1 MB/s (r:0, l:None, u:None)
+P: Scale: 38615.1 MB/s (r:0, l:None, u:None)
+P: Add: 43790.6 MB/s (r:0, l:None, u:None)
+P: Triad: 43878.2 MB/s (r:0, l:None, u:None)
+[       OK ] (10/12) StreamMultiSysTest /eec1c676 @daint:gpu+intel
+P: Copy: 52219.7 MB/s (r:0, l:None, u:None)
+P: Scale: 54339.2 MB/s (r:0, l:None, u:None)
+P: Add: 57969.1 MB/s (r:0, l:None, u:None)
+P: Triad: 57456.2 MB/s (r:0, l:None, u:None)
+[       OK ] (11/12) StreamMultiSysTest /eec1c676 @daint:gpu+nvidia
+P: Copy: 51503.8 MB/s (r:0, l:None, u:None)
+P: Scale: 39551.1 MB/s (r:0, l:None, u:None)
+P: Add: 43970.2 MB/s (r:0, l:None, u:None)
+P: Triad: 44303.5 MB/s (r:0, l:None, u:None)
+[       OK ] (12/12) StreamMultiSysTest /eec1c676 @daint:gpu+cray
+P: Copy: 51257.6 MB/s (r:0, l:None, u:None)
+P: Scale: 38929.5 MB/s (r:0, l:None, u:None)
+P: Add: 43589.4 MB/s (r:0, l:None, u:None)
+P: Triad: 43053.3 MB/s (r:0, l:None, u:None)
 [----------] all spawned checks have finished
 
 [  PASSED  ] Ran 12/12 test case(s) from 1 check(s) (0 failure(s), 0 skipped)
-[==========] Finished on Sat Jan 22 22:48:59 2022
-==============================================================================
+[==========] Finished on Wed Oct  5 15:11:25 2022
+
+================================================================================
 PERFORMANCE REPORT
-------------------------------------------------------------------------------
-StreamMultiSysTest
-- daint:login
-   - gnu
-      * num_tasks: 1
-      * Copy: 108525.7 MB/s
-      * Scale: 76882.1 MB/s
-      * Add: 81155.7 MB/s
-      * Triad: 82433.2 MB/s
-   - intel
-      * num_tasks: 1
-      * Copy: 82341.7 MB/s
-      * Scale: 81330.6 MB/s
-      * Add: 72076.0 MB/s
-      * Triad: 101808.5 MB/s
-   - nvidia
-      * num_tasks: 1
-      * Copy: 94336.0 MB/s
-      * Scale: 69096.9 MB/s
-      * Add: 73484.2 MB/s
-      * Triad: 73243.6 MB/s
-   - cray
-      * num_tasks: 1
-      * Copy: 114374.2 MB/s
-      * Scale: 76205.6 MB/s
-      * Add: 82184.5 MB/s
-      * Triad: 76086.3 MB/s
-- daint:gpu
-   - gnu
-      * num_tasks: 1
-      * Copy: 42963.4 MB/s
-      * Scale: 38504.8 MB/s
-      * Add: 43650.2 MB/s
-      * Triad: 43876.5 MB/s
-   - intel
-      * num_tasks: 1
-      * Copy: 52505.4 MB/s
-      * Scale: 54131.1 MB/s
-      * Add: 58918.8 MB/s
-      * Triad: 59048.6 MB/s
-   - nvidia
-      * num_tasks: 1
-      * Copy: 50472.9 MB/s
-      * Scale: 39545.5 MB/s
-      * Add: 43881.6 MB/s
-      * Triad: 43972.4 MB/s
-   - cray
-      * num_tasks: 1
-      * Copy: 50610.2 MB/s
-      * Scale: 38990.9 MB/s
-      * Add: 43158.9 MB/s
-      * Triad: 43792.9 MB/s
-- daint:mc
-   - gnu
-      * num_tasks: 1
-      * Copy: 48650.7 MB/s
-      * Scale: 38618.4 MB/s
-      * Add: 43504.1 MB/s
-      * Triad: 44044.1 MB/s
-   - intel
-      * num_tasks: 1
-      * Copy: 52500.5 MB/s
-      * Scale: 48545.9 MB/s
-      * Add: 57150.3 MB/s
-      * Triad: 57272.4 MB/s
-   - nvidia
-      * num_tasks: 1
-      * Copy: 46123.6 MB/s
-      * Scale: 40552.5 MB/s
-      * Add: 44147.7 MB/s
-      * Triad: 44521.9 MB/s
-   - cray
-      * num_tasks: 1
-      * Copy: 47094.0 MB/s
-      * Scale: 40080.4 MB/s
-      * Add: 43659.8 MB/s
-      * Triad: 44078.0 MB/s
-------------------------------------------------------------------------------
-Run report saved in '/home/user/.reframe/reports/run-report.json'
-Log file(s) saved in '/tmp/rfm-sua0bogo.log'
+--------------------------------------------------------------------------------
+[StreamMultiSysTest /eec1c676 @daint:mc:cray]
+  num_cpus_per_task: 36
+  num_tasks: 1
+  num_gpus_per_node: 0
+  performance:
+    - Copy: 46815.0 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Scale: 39939.7 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Add: 43610.2 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+    - Triad: 43938.7 MB/s (r: 0 MB/s l: -inf% u: +inf%)
+--------------------------------------------------------------------------------
+Run report saved in '/home/user/.reframe/reports/run-report-64.json'
+Log file(s) saved in '/tmp/rfm-_6x826vd.log'

--- a/docs/listings/stream_params.txt
+++ b/docs/listings/stream_params.txt
@@ -1,25 +1,26 @@
 [ReFrame Setup]
-  version:           3.10.0-dev.3+4fc5b12c
+  version:           4.0.0-dev.1+36ffa085
   command:           './bin/reframe -c tutorials/advanced/parameterized/stream.py -l'
-  launched by:       user@host
+  launched by:       user@tresa.local
   working directory: '/home/user/Repositories/reframe'
   settings file:     '/home/user/Repositories/reframe/tutorials/config/settings.py'
   check search path: '/home/user/Repositories/reframe/tutorials/advanced/parameterized/stream.py'
   stage directory:   '/home/user/Repositories/reframe/stage'
   output directory:  '/home/user/Repositories/reframe/output'
+  log files:         '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-1yfa3c8v.log'
 
 [List of matched checks]
-- StreamMultiSysTest %num_bytes=536870912
-- StreamMultiSysTest %num_bytes=268435456
-- StreamMultiSysTest %num_bytes=134217728
-- StreamMultiSysTest %num_bytes=67108864
-- StreamMultiSysTest %num_bytes=33554432
-- StreamMultiSysTest %num_bytes=16777216
-- StreamMultiSysTest %num_bytes=8388608
-- StreamMultiSysTest %num_bytes=4194304
-- StreamMultiSysTest %num_bytes=2097152
-- StreamMultiSysTest %num_bytes=1048576
-- StreamMultiSysTest %num_bytes=524288
+- StreamMultiSysTest %num_bytes=536870912 /cf10843f
+- StreamMultiSysTest %num_bytes=268435456 /97fb363f
+- StreamMultiSysTest %num_bytes=134217728 /7b4d01d3
+- StreamMultiSysTest %num_bytes=67108864 /530b0154
+- StreamMultiSysTest %num_bytes=33554432 /7199fc93
+- StreamMultiSysTest %num_bytes=16777216 /9d1b9ea8
+- StreamMultiSysTest %num_bytes=8388608 /3f29039f
+- StreamMultiSysTest %num_bytes=4194304 /e30054cd
+- StreamMultiSysTest %num_bytes=2097152 /45efaec5
+- StreamMultiSysTest %num_bytes=1048576 /92327981
+- StreamMultiSysTest %num_bytes=524288 /eb104cd0
 Found 11 check(s)
 
-Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-ka9llk6d.log'
+Log file(s) saved in '/var/folders/h7/k7cgrdl13r996m4dmsvjq7v80000gp/T/rfm-1yfa3c8v.log'

--- a/docs/tutorial_basics.rst
+++ b/docs/tutorial_basics.rst
@@ -459,7 +459,9 @@ Let's run the test now:
 
    ./bin/reframe -c tutorials/basics/stream/stream1.py -r --performance-report
 
-The :option:`--performance-report` will generate a short report at the end for each performance test that has run.
+The :option:`--performance-report` will generate a short report at the end of the run for each performance test that has run.
+Additionally, as soon as a performance test finishes, the obtained performance for each of the metrics is immediately reported.
+This is especially useful if you run long suites of performance exploration tests and you do not want to wait until the end of the run to have an overview of the obtained performance.
 
 
 .. literalinclude:: listings/stream1.txt

--- a/docs/tutorial_tips_tricks.rst
+++ b/docs/tutorial_tips_tricks.rst
@@ -343,10 +343,13 @@ If we tried to run :class:`T6` without restoring the session, we would have to r
 Implementing test workarounds efficiently
 -----------------------------------------
 
-Sometimes you may need to add a quick workaround for a test because something in the system/environment is not setup correctly.
-Hooks are the best way to implement this because they are easy to disable from the command-line and you wouldn't need to update the test every time you want to check if the system is working properly.
-Let's use one example we saw in a previous tutorial and let's assume that there is something wrong with one of the environments, like an undefined variable.
-Instead of adding another flag in the ``set_compilation_flags`` hook, it would be better to add one more hook with the workaround, in this case ``prgenv_nvidia_workaround``.
+.. versionadded:: 3.2
+
+Sometimes you may need to add a quick workaround in a test, because something in a system or an environment broken.
+The best way to implement this is through hooks, because you can easily disable any hook from the command-line and you don't need to update the test every time you want to check if the system is fixed and the workaround is not needed anymore.
+
+Let's use one example from the `previous tutorial <tutorial_basics.html>`__ and let's assume that there is something wrong with one of the environments and a special macro needs to be defined in order for the compilation to succeed.
+Instead of adding another flag in the :func:`set_compilation_flags` hook, it is better to add another hook containing just the workaround as shown below:
 
 .. code-block:: python
    :emphasize-lines: 27-33
@@ -378,15 +381,15 @@ Instead of adding another flag in the ``set_compilation_flags`` hook, it would b
            return sn.assert_eq(num_messages, 16)
 
        @run_before('compile')
-       def prgenv_nvidia_workaround(self):
+       def fooenv_workaround(self):
            ce = self.current_environ.name
-           if ce == 'nvidia':
+           if ce == 'foo':
                self.build_system.cppflags += [
                    '-D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL'
                ]
 
-In this way the test will be passing and we can make sure that new issues haven't appeared while waiting for the system to be fixed.
-By running with ``--disable-hook=prgenv_nvidia_workaround`` we can run the test without this hook at any time we want to check if the issue is resolved.
+This way the test will start passing again allowing us to catch any new issues while waiting for the original issue to be fixed.
+Then we can run the test anytime using ``--disable-hook=fooenv_workaround`` to check if the workaround is not needed anymore.
 
 
 .. _generate-ci-pipeline:

--- a/docs/tutorial_tips_tricks.rst
+++ b/docs/tutorial_tips_tricks.rst
@@ -151,10 +151,6 @@ Let's try loading the ``tutorials/basics/hello/hello2.py`` file:
    :language: console
 
 You can see all the different phases ReFrame's frontend goes through when loading a test.
-The first "strange" thing to notice in this log is that ReFrame picked the generic system configuration.
-This happened because it couldn't find a system entry with a matching hostname pattern.
-However, it did not impact the test loading, because these tests are valid for any system, but it will affect the tests when running (see :doc:`tutorial_basics`) since the generic system does not define any C++ compiler.
-
 After loading the configuration, ReFrame will print out its relevant environment variables and will start examining the given files in order to find and load ReFrame tests.
 Before attempting to load a file, it will validate it and check if it looks like a ReFrame test.
 If it does, it will load that file by importing it.

--- a/docs/tutorial_tips_tricks.rst
+++ b/docs/tutorial_tips_tricks.rst
@@ -340,6 +340,55 @@ If we tried to run :class:`T6` without restoring the session, we would have to r
    :language: console
 
 
+Implementing test workarounds efficiently
+-----------------------------------------
+
+Sometimes you may need to add a quick workaround for a test because something in the system/environment is not setup correctly.
+Hooks are the best way to implement this because they are easy to disable from the command-line and you wouldn't need to update the test every time you want to check if the system is working properly.
+Let's use one example we saw in a previous tutorial and let's assume that there is something wrong with one of the environments, like an undefined variable.
+Instead of adding another flag in the ``set_compilation_flags`` hook, it would be better to add one more hook with the workaround, in this case ``prgenv_nvidia_workaround``.
+
+.. code-block:: python
+   :emphasize-lines: 27-33
+
+   import reframe as rfm
+   import reframe.utility.sanity as sn
+
+
+   @rfm.simple_test
+   class HelloThreadedExtended2Test(rfm.RegressionTest):
+       valid_systems = ['*']
+       valid_prog_environs = ['*']
+       sourcepath = 'hello_threads.cpp'
+       build_system = 'SingleSource'
+       executable_opts = ['16']
+
+       @run_before('compile')
+       def set_compilation_flags(self):
+           self.build_system.cppflags = ['-DSYNC_MESSAGES']
+           self.build_system.cxxflags = ['-std=c++11', '-Wall']
+           environ = self.current_environ.name
+           if environ in {'clang', 'gnu'}:
+               self.build_system.cxxflags += ['-pthread']
+
+       @sanity_function
+       def assert_num_messages(self):
+           num_messages = sn.len(sn.findall(r'\[\s?\d+\] Hello, World\!',
+                                         self.stdout))
+           return sn.assert_eq(num_messages, 16)
+
+       @run_before('compile')
+       def prgenv_nvidia_workaround(self):
+           ce = self.current_environ.name
+           if ce == 'nvidia':
+               self.build_system.cppflags += [
+                   '-D__GCC_ATOMIC_TEST_AND_SET_TRUEVAL'
+               ]
+
+In this way the test will be passing and we can make sure that new issues haven't appeared while waiting for the system to be fixed.
+By running with ``--disable-hook=prgenv_nvidia_workaround`` we can run the test without this hook at any time we want to check if the issue is resolved.
+
+
 .. _generate-ci-pipeline:
 
 Integrating into a CI pipeline

--- a/reframe/core/config.py
+++ b/reframe/core/config.py
@@ -352,7 +352,7 @@ class _SiteConfig:
         # First look for the current subconfig in the cache; if not found,
         # generate it and cache it
         system_fullname = system_fullname or self._detect_system()
-        getlogger().debug(f'Selecting subconfig for {system_fullname!r}')
+        getlogger().debug2(f'Selecting subconfig for {system_fullname!r}')
 
         self._local_system = system_fullname
         if system_fullname in self._subconfigs:

--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -630,14 +630,14 @@ class LoggerAdapter(logging.LoggerAdapter):
 
             _WARN_ONCE.add(message)
 
-        message = f'{sys.argv[0]}: {message}'
+        message = f'WARNING: {message}'
         if self.colorize:
             message = color.colorize(message, color.YELLOW)
 
         super().warning(message, *args, **kwargs)
 
     def error(self, message, *args, **kwargs):
-        message = f'{sys.argv[0]}: {message}'
+        message = f'ERROR: {message}'
         if self.colorize:
             message = color.colorize(message, color.RED)
 

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -951,6 +951,8 @@ def main():
                    f"{':'.join(loader.load_path)!r}")
     print_infoline('stage directory', repr(session_info['prefix_stage']))
     print_infoline('output directory', repr(session_info['prefix_output']))
+    print_infoline('log files',
+                   ', '.join(repr(s) for s in logging.log_files()))
     printer.info('')
     try:
         logging.getprofiler().enter_region('test processing')
@@ -1394,7 +1396,6 @@ def main():
             log_files = logging.log_files()
             if site_config.get('general/0/save_log_files'):
                 log_files = logging.save_log_files(rt.output_prefix)
-
         except OSError as e:
             printer.error(f'could not save log file: {e}')
             sys.exit(1)

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -769,7 +769,7 @@ def main():
         logging.configure_logging(site_config)
     except (OSError, errors.ConfigError) as e:
         printer.error(f'failed to load configuration: {e}')
-        printer.error(logfiles_message())
+        printer.info(logfiles_message())
         sys.exit(1)
 
     printer.colorize = site_config.get('general/0/colorize')
@@ -781,7 +781,7 @@ def main():
         runtime.init_runtime(site_config)
     except errors.ConfigError as e:
         printer.error(f'failed to initialize runtime: {e}')
-        printer.error(logfiles_message())
+        printer.info(logfiles_message())
         sys.exit(1)
 
     if site_config.get('general/0/ignore_check_conflicts'):
@@ -810,7 +810,7 @@ def main():
         printer.error("stage and output refer to the same directory; "
                       "if this is on purpose, please use the "
                       "'--keep-stage-files' option.")
-        printer.error(logfiles_message())
+        printer.info(logfiles_message())
         sys.exit(1)
 
     # Show configuration after everything is set up

--- a/reframe/frontend/executors/policies.py
+++ b/reframe/frontend/executors/policies.py
@@ -46,7 +46,8 @@ def _print_perf(task):
     for key, info in perfvars.items():
         name = key.split(':')[-1]
         getlogger().info(
-            f'P: {name}: {info[0]} {info[4]} (r:{info[1]}, l:{info[2]}, u:{info[3]})'
+            f'P: {name}: {info[0]} {info[4]} '
+            f'(r:{info[1]}, l:{info[2]}, u:{info[3]})'
         )
 
 

--- a/reframe/frontend/executors/policies.py
+++ b/reframe/frontend/executors/policies.py
@@ -85,12 +85,8 @@ class SerialExecutionPolicy(ExecutionPolicy, TaskEventListener):
     def runcase(self, case):
         super().runcase(case)
         check, partition, environ = case
-
-        self.printer.status(
-            'RUN',
-            f'{check.name} @{partition.fullname}+{environ.name}'
-        )
         task = RegressionTask(case, self.task_listeners)
+        self.printer.status('RUN', task.info())
         self._task_index[case] = task
         self.stats.add_task(task)
         try:

--- a/reframe/frontend/statistics.py
+++ b/reframe/frontend/statistics.py
@@ -254,11 +254,7 @@ class TestStats:
             printer.info(f"  * Maintainers: {r['maintainers']}")
             printer.info(f"  * Failing phase: {r['fail_phase']}")
             if rerun_info and not r['fixture']:
-                cls = r['display_name'].split(' ')[0]
-                variant = r['unique_name'].replace(cls, '')
-                variant = variant.replace('_', '@')
-                nameoptarg = cls + variant
-                printer.info(f"  * Rerun with '-n {nameoptarg}"
+                printer.info(f"  * Rerun with '-n /{r['hash']}"
                              f" -p {r['environment']} --system "
                              f"{r['system']} -r'")
 

--- a/tools/gendoclistings.py
+++ b/tools/gendoclistings.py
@@ -95,6 +95,17 @@ LISTINGS = {
         },
         xfail=True
     ),
+    'stream1': ListingInfo(
+        './bin/reframe -c tutorials/basics/stream/stream1.py -r --performance-report',  # noqa: E501
+        {'local', 'tutorial-basics'},
+        DEFAULT_FILTERS,
+        env={
+            'RFM_CONFIG_FILE': os.path.join(os.getcwd(),
+                                            'tutorials/config/settings.py'),
+            'RFM_COLORIZE': 'n'
+        },
+        xfail=False
+    ),
     'alltests_daint': ListingInfo(
         './bin/reframe -c tutorials/basics/ -R -n "HelloMultiLangTest|HelloThreadedExtended2Test|StreamWithRefTest" --performance-report -r',   # noqa: E501
         {'remote', 'tutorial-basics'},

--- a/tutorials/config/settings.py
+++ b/tutorials/config/settings.py
@@ -117,8 +117,8 @@ site_configuration = {
     'environments': [
         {
             'name': 'gnu',
-            'cc': 'gcc-9',
-            'cxx': 'g++-9',
+            'cc': 'gcc-12',
+            'cxx': 'g++-12',
             'ftn': 'gfortran-9'
         },
         {

--- a/tutorials/cscs-webinar-2022/config/mysettings.py
+++ b/tutorials/cscs-webinar-2022/config/mysettings.py
@@ -67,8 +67,8 @@ site_configuration = {
     'environments': [
         {
             'name': 'gnu',
-            'cc': 'gcc-9',
-            'cxx': 'g++-9',
+            'cc': 'gcc-12',
+            'cxx': 'g++-12',
             'ftn': '',
             'features': ['openmp'],
             'extras': {'ompflag': '-fopenmp'}

--- a/unittests/test_logging.py
+++ b/unittests/test_logging.py
@@ -467,10 +467,10 @@ def test_logging_context_check(default_exec_ctx, logfile, fake_check):
 
     rlog.getlogger().error('error outside context')
     assert _found_in_logfile(
-        f'_FakeCheck %param=10: {sys.argv[0]}: error from context', logfile
+        f'_FakeCheck %param=10: ERROR: error from context', logfile
     )
     assert _found_in_logfile(
-        f'reframe: {sys.argv[0]}: error outside context', logfile
+        f'reframe: ERROR: error outside context', logfile
     )
 
 


### PR DESCRIPTION
This PR introduces several small improvements that imo enhance the daily experience.

1. The log files are printed before the run start. Therefore it is easy to inspect the logs live for long runs, especially with the default log configuration, which creates a temporary log file.
2. The performance data of a  performance test is printed immediately after the test finishes (either successfully or not). This is especially useful for long performance exploration experiments, where you don't want to wait until the end of the run to see the performance in the performance report.
3. The performance report is modernised and improved. More information is listed but in a more compact and concise way.
4. All error and warning messages are prefixed with `ERROR` and `WARNING` always. This makes it easier spot errors and warnings, even when no colors are used.
5. Some debug messages where moved to debug2.
6. A warning when building the docs was fixed.
7. The docs and local run listings are updated.

TODOS

- [x] Update the remote run listings (@ekouts Could you do that on Daint?)