### PR TITLE
[feat] Add `perflog_ignore` attribute in httpjson handler

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -1179,9 +1179,9 @@ The additional properties for the ``httpjson`` handler are the following:
    A set of optional key/value pairs to be passed with each log record to the server.
    These may depend on the server configuration.
 
-.. js:attribute:: .logging[].handlers[].perflog_ignore
+.. js:attribute:: .logging[].handlers[].ignore_keys
 
-.. object:: .logging[].handlers_perflog[].perflog_ignore
+.. object:: .logging[].handlers_perflog[].ignore_keys
 
    :required: No
    :default: ``[]``
@@ -1203,7 +1203,7 @@ An example configuration of this handler for performance logging is shown here:
            'facility': 'reframe',
            'data-version': '1.0'
        },
-       'perflog_ignore': ['check_perfvalues']
+       'ignore_keys': ['check_perfvalues']
    }
 
 

--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -1179,6 +1179,15 @@ The additional properties for the ``httpjson`` handler are the following:
    A set of optional key/value pairs to be passed with each log record to the server.
    These may depend on the server configuration.
 
+.. js:attribute:: .logging[].handlers[].perflog_ignore
+
+.. object:: .logging[].handlers_perflog[].perflog_ignore
+
+   :required: No
+   :default: ``[]``
+
+   These keys will be excluded from the log record that will be sent to the server.
+
 
 The ``httpjson`` handler sends log messages in JSON format using an HTTP POST request to the specified URL.
 
@@ -1193,7 +1202,8 @@ An example configuration of this handler for performance logging is shown here:
        'extras': {
            'facility': 'reframe',
            'data-version': '1.0'
-       }
+       },
+       'perflog_ignore': ['check_perfvalues']
    }
 
 

--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -394,23 +394,18 @@ class HTTPJSONHandler(logging.Handler):
         self._perflog_ignore = perflog_ignore
 
     def _record_to_json(self, record):
-        def _log_record(key):
-            if key.startswith('_') or key in HTTPJSONHandler.LOG_ATTRS:
-                return False
-
-            if self._perflog_ignore and key in self._perflog_ignore:
-                return False
-
-            return True
+        def _can_send(key):
+            return not (
+                key.startswith('_') or key in HTTPJSONHandler.LOG_ATTRS
+                or (self._perflog_ignore and key in self._perflog_ignore)
+            )
 
         json_record = {
-            k: v for k, v in record.__dict__.items()
-            if _log_record(k)
+            k: v for k, v in record.__dict__.items() if _can_send(k)
         }
         if self._extras:
             json_record.update({
-                k: v for k, v in self._extras.items()
-                if _log_record(k)
+                k: v for k, v in self._extras.items() if _can_send(k)
             })
 
         return _xfmt(json_record).encode('utf-8')

--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -371,8 +371,8 @@ def _create_httpjson_handler(site_config, config_prefix):
         return None
 
     extras = site_config.get(f'{config_prefix}/extras')
-    perflog_ignore = site_config.get(f'{config_prefix}/perflog_ignore')
-    return HTTPJSONHandler(url, extras, perflog_ignore)
+    ignore_keys = site_config.get(f'{config_prefix}/ignore_keys')
+    return HTTPJSONHandler(url, extras, ignore_keys)
 
 
 class HTTPJSONHandler(logging.Handler):
@@ -387,17 +387,17 @@ class HTTPJSONHandler(logging.Handler):
         'stack_info', 'thread', 'threadName', 'exc_text'
     }
 
-    def __init__(self, url, extras=None, perflog_ignore=None):
+    def __init__(self, url, extras=None, ignore_keys=None):
         super().__init__()
         self._url = url
         self._extras = extras
-        self._perflog_ignore = perflog_ignore
+        self._ignore_keys = ignore_keys
 
     def _record_to_json(self, record):
         def _can_send(key):
             return not (
                 key.startswith('_') or key in HTTPJSONHandler.LOG_ATTRS
-                or (self._perflog_ignore and key in self._perflog_ignore)
+                or (self._ignore_keys and key in self._ignore_keys)
             )
 
         json_record = {

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -600,7 +600,7 @@ def main():
         envvar='RFM_IGNORE_REQNODENOTAVAIL',
         configvar='schedulers/ignore_reqnodenotavail',
         action='store_true',
-        help='Graylog server address'
+        help='Ignore ReqNodeNotAvail Slurm error'
     )
     argparser.add_argument(
         dest='dump_pipeline_progress',

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -147,7 +147,7 @@
                     "properties": {
                         "url": {"type": "string"},
                         "extras": {"type": "object"},
-                        "perflog_ignore": {
+                        "ignore_keys": {
                             "type": "array",
                             "items": {"type": "string"}
                         }
@@ -555,7 +555,7 @@
         "logging/handlers*/filelog_basedir": "./perflogs",
         "logging/handlers*/graylog_extras": {},
         "logging/handlers*/httpjson_extras": {},
-        "logging/handlers*/httpjson_perflog_ignore": [],
+        "logging/handlers*/httpjson_ignore_keys": [],
         "logging/handlers*/stream_name": "stdout",
         "logging/handlers*/syslog_socktype": "udp",
         "logging/handlers*/syslog_facility": "user",

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -146,7 +146,11 @@
                 {
                     "properties": {
                         "url": {"type": "string"},
-                        "extras": {"type": "object"}
+                        "extras": {"type": "object"},
+                        "perflog_ignore": {
+                            "type": "array",
+                            "items": {"type": "string"}
+                        }
                     },
                     "required": ["url"]
                 }
@@ -551,6 +555,7 @@
         "logging/handlers*/filelog_basedir": "./perflogs",
         "logging/handlers*/graylog_extras": {},
         "logging/handlers*/httpjson_extras": {},
+        "logging/handlers*/httpjson_perflog_ignore": [],
         "logging/handlers*/stream_name": "stdout",
         "logging/handlers*/syslog_socktype": "udp",
         "logging/handlers*/syslog_facility": "user",


### PR DESCRIPTION
Since Kibana rejects a record that includes a list of values of different types (for example `check_perfvalues`) I added the `perflog_ignore` in the configuration which will exclude these attributes from the json that we eventually send.
I don't think we should exclude the key  from all logs. What do you think?