### PR TITLE
[bugfix] Get performance info from within the changedir

### DIFF
--- a/reframe/frontend/executors/policies.py
+++ b/reframe/frontend/executors/policies.py
@@ -43,14 +43,15 @@ def _cleanup_all(tasks, *args, **kwargs):
 def _print_perf(task):
     '''Get performance info of the current task.'''
     
-    with change_dir(task.testcase.check.stagedir or '.'):
-        perfvars = task.testcase.check.perfvalues
-        for key, info in perfvars.items():
-            name = key.split(':')[-1]
-            getlogger().info(
-                f'P: {name}: {info[0]} {info[4]} '
-                f'(r:{info[1]}, l:{info[2]}, u:{info[3]})'
-            )
+    perfvars = task.testcase.check.perfvalues 
+    if perfvars:
+        with change_dir(task.testcase.check.stagedir):
+            for key, info in perfvars.items():
+                name = key.split(':')[-1]
+                getlogger().info(
+                    f'P: {name}: {info[0]} {info[4]} '
+                    f'(r:{info[1]}, l:{info[2]}, u:{info[3]})'
+                )
 
 
 class _PollController:

--- a/reframe/frontend/executors/policies.py
+++ b/reframe/frontend/executors/policies.py
@@ -43,7 +43,7 @@ def _cleanup_all(tasks, *args, **kwargs):
 def _print_perf(task):
     '''Get performance info of the current task.'''
     
-    with change_dir(task.testcase.check.stagedir):
+    with change_dir(task.testcase.check.stagedir or '.'):
         perfvars = task.testcase.check.perfvalues
         for key, info in perfvars.items():
             name = key.split(':')[-1]

--- a/reframe/frontend/executors/policies.py
+++ b/reframe/frontend/executors/policies.py
@@ -19,6 +19,7 @@ from reframe.core.pipeline import (CompileOnlyRegressionTest,
                                    RunOnlyRegressionTest)
 from reframe.frontend.executors import (ExecutionPolicy, RegressionTask,
                                         TaskEventListener, ABORT_REASONS)
+from reframe.utility.osext import change_dir
 
 
 def _get_partition_name(task, phase='run'):
@@ -41,14 +42,15 @@ def _cleanup_all(tasks, *args, **kwargs):
 
 def _print_perf(task):
     '''Get performance info of the current task.'''
-
-    perfvars = task.testcase.check.perfvalues
-    for key, info in perfvars.items():
-        name = key.split(':')[-1]
-        getlogger().info(
-            f'P: {name}: {info[0]} {info[4]} '
-            f'(r:{info[1]}, l:{info[2]}, u:{info[3]})'
-        )
+    
+    with change_dir(task.testcase.check.stagedir):
+        perfvars = task.testcase.check.perfvalues
+        for key, info in perfvars.items():
+            name = key.split(':')[-1]
+            getlogger().info(
+                f'P: {name}: {info[0]} {info[4]} '
+                f'(r:{info[1]}, l:{info[2]}, u:{info[3]})'
+            )
 
 
 class _PollController:


### PR DESCRIPTION
This allows performing more complicated performance queries such as:
```
def reference_meminfo(self):
        regex = 'memory from sysconf: total: \S+ \S+ avail: (?P<mem>\S+) GB'
        return sn.extractsingle(regex, self.stdout, 'mem', int)
```
If the above is executed outside the stagedir then `self.stdout` is not found.