### PR TITLE
[feat] Allow tests to require references

### DIFF
--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -676,8 +676,11 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #: Require that a reference is defined for each system that this test is
     #: run on.
     #:
+    #: If this is set and a reference is not found for the current system, the
+    #: test will fail.
+    #:
     #: :type: boolean
-    #: :default: :obj:`False`
+    #: :default: :const:`False`
     #:
     #: .. versionadded:: 4.0.0
     require_reference = variable(typ.Bool, value=False)

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -673,6 +673,15 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     # FIXME: There is not way currently to express tuples of `float`s or
     # `None`s, so we just use the very generic `object`
 
+    #: Require that a reference is defined for each system that this test is
+    #: run on.
+    #:
+    #: :type: boolean
+    #: :default: :obj:`False`
+    #:
+    #: .. versionadded:: 4.0.0
+    require_reference = variable(typ.Bool, value=False)
+
     #:
     #: Refer to the :doc:`ReFrame Tutorials </tutorials>` for concrete usage
     #: examples.
@@ -898,7 +907,8 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #: responsibility to check whether the build phase failed by adding an
     #: appropriate sanity check.
     #:
-    #: :type: boolean : :default: :class:`True`
+    #: :type: boolean
+    #: :default: :class:`True`
     build_locally = variable(typ.Bool, value=True, loggable=True)
 
     def __new__(cls, *args, **kwargs):
@@ -2110,6 +2120,13 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
                             # Pop the unit from the ref tuple (redundant)
                             ref = ref[:3]
                     except KeyError:
+                        if self.require_reference:
+                            raise PerformanceError(
+                                f'no reference value found for '
+                                f'performance variable {tag!r} on '
+                                f'system {self._current_partition.fullname!r}'
+                            ) from None
+
                         ref = (0, None, None)
 
                     self._perfvalues[key] = (value, *ref, unit)
@@ -2143,7 +2160,8 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
                     for var in variables:
                         name, unit = var
                         ref_tuple = (0, None, None, unit)
-                        self.reference.update({'*': {name: ref_tuple}})
+                        if not self.require_reference:
+                            self.reference.update({'*': {name: ref_tuple}})
 
                 # We first evaluate and log all performance values and then we
                 # check them against the reference. This way we always log them
@@ -2152,9 +2170,10 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
                     value = sn.evaluate(expr)
                     key = f'{self._current_partition.fullname}:{tag}'
                     if key not in self.reference:
-                        raise SanityError(
-                            f'tag {tag!r} not resolved in references for '
-                            f'{self._current_partition.fullname}'
+                        raise PerformanceError(
+                            f'no reference value found for '
+                            f'performance variable {tag!r} on '
+                            f'system {self._current_partition.fullname!r}'
                         )
 
                     self._perfvalues[key] = (value, *self.reference[key])
@@ -2181,7 +2200,7 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
                                  'expected {1} (l={2}, u={3})' % tag))
                     )
                 except SanityError as e:
-                    raise PerformanceError(e)
+                    raise PerformanceError(e) from None
 
     def _copy_job_files(self, job, dst):
         if job is None:


### PR DESCRIPTION
This PR adds a new boolean test variable, named `require_reference`, that if set to true, it will cause the test to fail if there is no reference defined for the current system.

I believe that this is probable better than introducing a global configuration parameter, since variables give you both the ability to set them globally, but also per test.