### PR TITLE
[feat] Change default value of `num_gpus_per_node` to `None`

### DIFF
--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -556,7 +556,7 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #: For more information on test resources, have a look at the
     #: :attr:`extra_resources` attribute.
     #:
-    #: :type: integral
+    #: :type: integral or :const:`None`
     #: :default: :const:`None`
     #:
     #: .. versionchanged:: 4.0.0

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -557,8 +557,11 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #: :attr:`extra_resources` attribute.
     #:
     #: :type: integral
-    #: :default: ``0``
-    num_gpus_per_node = variable(int, value=0, loggable=True)
+    #: :default: :const:`None`
+    #:
+    #: .. versionchanged:: 4.0.0
+    #:    The default value changed to :const:`None`.
+    num_gpus_per_node = variable(int, type(None), value=None, loggable=True)
 
     #: Number of CPUs per task required by this test.
     #:
@@ -1890,7 +1893,7 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
                 environs.insert(2, cp_env)
 
         # num_gpus_per_node is a managed resource
-        if self.num_gpus_per_node > 0:
+        if self.num_gpus_per_node:
             self.extra_resources.setdefault(
                 '_rfm_gpu', {'num_gpus_per_node': self.num_gpus_per_node}
             )


### PR DESCRIPTION
This is to match the rest of non-required resource-related variables that default to `None`. This will also make `num_gpus_per_node` disappear from the new performance report, if it is not set, as it happens with the rest of the variables.