### PR TITLE
[feat] Extend `cray_cdt_version()` utility function to recognise CPE versions too

### DIFF
--- a/reframe/utility/osext.py
+++ b/reframe/utility/osext.py
@@ -573,7 +573,7 @@ def unique_abs_paths(paths, prune_children=True):
 
 
 def cray_cdt_version():
-    '''Return eithe the Cray Development Toolkit (CDT) version, the Cray
+    '''Return either the Cray Development Toolkit (CDT) version, the Cray
     Programming Environment (CPE) version or :class:`None` if the version
     cannot be retrieved.'''
 

--- a/reframe/utility/osext.py
+++ b/reframe/utility/osext.py
@@ -573,21 +573,28 @@ def unique_abs_paths(paths, prune_children=True):
 
 
 def cray_cdt_version():
-    '''Return the Cray Development Toolkit (CDT) version or :class:`None` if
-    the version cannot be retrieved.'''
+    '''Return eithe the Cray Development Toolkit (CDT) version, the Cray
+    Programming Environment (CPE) version or :class:`None` if the version
+    cannot be retrieved.'''
 
-    rcfile = os.getenv('MODULERCFILE', '/opt/cray/pe/cdt/default/modulerc')
+    modulerc_path = '/opt/cray/pe/{cray_module}/default/modulerc'
+    cray_module = 'cdt' if os.path.exists(
+        modulerc_path.format(cray_module='cdt')
+    ) else 'cpe'
+
+    rcfile = os.getenv('MODULERCFILE',
+                       modulerc_path.format(cray_module=cray_module))
     try:
         with open(rcfile) as fp:
             header = fp.readline()
             if not header:
                 return None
 
-        match = re.search(r'^#%Module CDT (\S+)', header)
+        match = re.search(r'^#%Module (CDT|CPE) (\S+)', header)
         if not match:
             return None
 
-        return match.group(1)
+        return match.group(2)
     except OSError:
         return None
 


### PR DESCRIPTION
For this I guess with should change the name of the function since it has `cdt`. Maybe `cray_pe_version` and deprecate `cray_cdt_version `?