### PR TITLE
[feat] Introduce variable aliases

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,16 @@ sys.path = [prefix, external] + sys.path
 import reframe                           # noqa: F401, F403
 import reframe.utility.osext as osext    # noqa: F401, F403
 
+# Sphinx erroneously uses `repr()` to display values and not the
+# human-readable `str()`. For this reason we define the following variable in
+# the `reframe` module so that objects can redirect to their `str()` method
+# from `repr()` if they are invoked in the context of Sphinx when building the
+# documentation. See discussion and the related workaround here:
+#
+# https://github.com/sphinx-doc/sphinx/issues/3857
+
+reframe.__build_docs__ = True
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/reframe/core/meta.py
+++ b/reframe/core/meta.py
@@ -140,11 +140,9 @@ class RegressionTestMeta(type):
                         # available in the current class' namespace.
                         for b in self['_rfm_bases']:
                             if key in b._rfm_var_space:
-                                # Store a deep-copy of the variable's
-                                # value and return.
-                                v = b._rfm_var_space[key].default_value
+                                v = variables.ShadowVar(b._rfm_var_space[key])
                                 self._namespace[key] = v
-                                return self._namespace[key]
+                                return v
 
                         # If 'key' is neither a variable nor a parameter,
                         # raise the exception from the base __getitem__.

--- a/reframe/core/variables.py
+++ b/reframe/core/variables.py
@@ -158,6 +158,14 @@ class TestVar:
     from :class:`EchoBaseTest` to throw an error indicating that the variable
     ``what`` has not been set.
 
+    Finally, variables may alias each other. If a variable is an alias of
+    another one it behaves in the exact same way as its target. If a change is
+    made to the target variable, this is reflected to the alias and vice
+    versa. However, alias variables are independently loggable: an alias may
+    be logged but not its target and vice versa. Aliased variables are useful
+    when you want to rename a variable and you want to keep the old one for
+    compatibility reasons.
+
     :param `types`: the supported types for the variable.
     :param value: the default value assigned to the variable. If no value is
         provided, the variable is set as ``required``.
@@ -165,6 +173,9 @@ class TestVar:
         field argument is provided, it defaults to
         :attr:`reframe.core.fields.TypedField`. The provided field validator
         by this argument must derive from :attr:`reframe.core.fields.Field`.
+    :param alias: the target variable if this variable is an alias. This must
+        refer to an already declared variable and neither default value nor a
+        field can be specified for an alias variable.
     :param loggable: Mark this variable as loggable. If :obj:`True`, this
         variable will become a log record attribute under the name
         ``check_NAME``, where ``NAME`` is the name of the variable.
@@ -172,8 +183,11 @@ class TestVar:
         the field validator.
     :returns: A new test variable.
 
-    .. version added:: 3.10.2
+    .. versionadded:: 3.10.2
        The ``loggable`` argument is added.
+
+    .. versionadded:: 4.0.0
+       Alias variable are introduced.
 
     '''
 

--- a/reframe/core/variables.py
+++ b/reframe/core/variables.py
@@ -204,31 +204,30 @@ class TestVar:
 
     def __init__(self, *args, **kwargs):
         alias = kwargs.pop('alias', None)
-        if alias and 'field' in kwargs:
+        if alias is not None and 'field' in kwargs:
             raise ValueError(f"'field' cannot be set for an alias variable")
 
-        if alias and 'value' in kwargs:
+        if alias is not None and 'value' in kwargs:
             raise ValueError('alias variables do not accept default values')
 
-        if alias and not isinstance(alias, TestVar):
+        if alias is not None and not isinstance(alias, TestVar):
             raise TypeError(f"'alias' must refer to a variable; "
                             f"found {type(alias).__name__!r}")
 
         field_type = kwargs.pop('field', fields.TypedField)
-        if alias:
+        if alias is not None:
             self._p_default_value = alias._default_value
         else:
             self._p_default_value = kwargs.pop('value', Undefined)
 
         self._loggable = kwargs.pop('loggable', False)
-
         if not issubclass(field_type, fields.Field):
             raise TypeError(
                 f'field {field_type!r} is not derived from '
                 f'{fields.Field.__qualname__}'
             )
 
-        if alias:
+        if alias is not None:
             self._p_field = alias._field
         else:
             self._p_field = field_type(*args, **kwargs)

--- a/reframe/core/variables.py
+++ b/reframe/core/variables.py
@@ -346,6 +346,10 @@ class TestVar:
         return str(self._default_value)
 
     def __repr__(self):
+        import reframe
+        if hasattr(reframe, '__build_docs__'):
+            return str(self)
+
         try:
             name = self.name
         except AttributeError:

--- a/reframe/core/variables.py
+++ b/reframe/core/variables.py
@@ -177,10 +177,11 @@ class TestVar:
 
     '''
 
-    # NOTE: We can't use truly private fields in __slots__, because
-    # __setattr__() will be called with their mangled name and we cannot match
-    # them in the __slots__ with making implementation-defined assumptions
-    # about the mangled name. So we just add the `_p_` prefix for "private"
+    # NOTE: We can't use truly private fields in `__slots__`, because
+    # `__setattr__()` will be called with their mangled name and we cannot
+    # match them in the `__slots__` without making implementation-defined
+    # assumptions about the mangled name. So we just add the `_p_` prefix for
+    # to denote the "private" fields.
 
     __slots__ = ('_p_default_value', '_p_field',
                  '_loggable', '_name', '_target')
@@ -188,19 +189,18 @@ class TestVar:
     __mutable_props = ('_default_value',)
 
     def __init__(self, *args, **kwargs):
-        field_type = kwargs.pop('field', fields.TypedField)
         alias = kwargs.pop('alias', None)
-
-        if alias and not isinstance(alias, TestVar):
-            raise TypeError(f"'alias' must refer to a variable; "
-                            f"found {type(alias).__name__!r}")
-
         if alias and 'field' in kwargs:
             raise ValueError(f"'field' cannot be set for an alias variable")
 
         if alias and 'value' in kwargs:
             raise ValueError('alias variables do not accept default values')
 
+        if alias and not isinstance(alias, TestVar):
+            raise TypeError(f"'alias' must refer to a variable; "
+                            f"found {type(alias).__name__!r}")
+
+        field_type = kwargs.pop('field', fields.TypedField)
         if alias:
             self._p_default_value = alias._default_value
         else:

--- a/unittests/test_logging.py
+++ b/unittests/test_logging.py
@@ -29,6 +29,7 @@ def fake_check():
     class _FakeCheck(rfm.RegressionTest):
         param = parameter(range(3), loggable=True, fmt=lambda x: 10*x)
         custom = variable(str, value='hello extras', loggable=True)
+        custom2 = variable(alias=custom)
         custom_list = variable(list,
                                value=['custom', 3.0, ['hello', 'world']],
                                loggable=True)
@@ -161,13 +162,13 @@ def test_logger_levels(logfile, logger_with_check):
 
 def test_logger_loggable_attributes(logfile, logger_with_check):
     formatter = rlog.RFC3339Formatter(
-        '%(check_custom)s|%(check_custom_list)s|'
+        '%(check_custom)s|%(check_custom2)s|%(check_custom_list)s|'
         '%(check_foo)s|%(check_custom_dict)s|%(check_param)s|%(check_x)s'
     )
     logger_with_check.logger.handlers[0].setFormatter(formatter)
     logger_with_check.info('xxx')
     assert _pattern_in_logfile(
-        r'hello extras\|custom,3.0,\["hello", "world"\]\|null\|'
+        r'hello extras\|null\|custom,3.0,\["hello", "world"\]\|null\|'
         r'{"a": 1, "b": 2}\|10\|null', logfile
     )
 

--- a/unittests/test_variables.py
+++ b/unittests/test_variables.py
@@ -9,6 +9,7 @@ import math
 
 import reframe as rfm
 from reframe.core.exceptions import ReframeSyntaxError
+from reframe.core.warnings import ReframeDeprecationWarning
 
 
 @pytest.fixture
@@ -458,7 +459,6 @@ def test_other_numerical_operators():
 
 def test_var_deprecation():
     from reframe.core.variables import DEPRECATE_RD, DEPRECATE_WR
-    from reframe.core.warnings import ReframeDeprecationWarning
 
     # Check read deprecation
     class A(rfm.RegressionMixin):
@@ -544,3 +544,15 @@ def test_var_aliases():
 
     s.x = 3
     assert s.y == 3
+
+    # Test deprecated aliases
+    class S(T):
+        y = deprecate(variable(alias=x), f'y is deprecated')
+
+    with pytest.warns(ReframeDeprecationWarning):
+        class U(S):
+            y = 10
+
+    s = S()
+    with pytest.warns(ReframeDeprecationWarning):
+        s.y = 10

--- a/unittests/test_variables.py
+++ b/unittests/test_variables.py
@@ -508,13 +508,13 @@ def test_var_aliases():
             y = variable(alias=x, field=TypedField)
 
     class T(rfm.RegressionMixin):
-        x = variable(int, value=1)
+        x = variable(int, value=0)
         y = variable(alias=x)
         z = variable(alias=y)
 
     t = T()
-    assert t.y == 1
-    assert t.z == 1
+    assert t.y == 0
+    assert t.z == 0
 
     t.x = 4
     assert t.y == 4

--- a/unittests/test_variables.py
+++ b/unittests/test_variables.py
@@ -495,6 +495,18 @@ def test_var_aliases():
             x = variable(int, value=1)
             y = variable(alias=x, value=2)
 
+    with pytest.raises(TypeError, match=r"'alias' must refer to a variable"):
+        class T(rfm.RegressionMixin):
+            x = variable(int, value=1)
+            y = variable(alias=10)
+
+    with pytest.raises(ValueError, match=r"'field' cannot be set"):
+        from reframe.core.fields import TypedField
+
+        class T(rfm.RegressionMixin):
+            x = variable(int, value=1)
+            y = variable(alias=x, field=TypedField)
+
     class T(rfm.RegressionMixin):
         x = variable(int, value=1)
         y = variable(alias=x)


### PR DESCRIPTION
This practically extends on the field aliasing that we used to have and brings the same concept to variables. Users can now define a variable as an alias of another one. This is quite useful for transitional periods and deprecations when a variable is renamed. An aliased can be defined as follows:

```python
x = variable(int, value=3)
y = variable(alias=x)
```

The variable `y` may not have a default value, but it can be independently loggable. Any update of variable `x` will be visible to `y` and vice versa. Aliased variables can refer also to inherited variables.

This feature is useful for transitional periods when a variable is renamed and a deprecation is introduced and we want to keep both names for a while. The new variable can also be wrapped with `deprecate()` to mark a deprecation. This allows us to introduces variable aliases and deprecations effortlessly.

This commit also introduces implementation improvements on how variables are inherited. In particular, inherited variables are no more set redundantly as they are being inherited by classes lower in the hierarchy.