### PR TITLE
[feat] Deprecate `variables` in favour of the new `env_vars`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,16 @@ sys.path = [prefix, external] + sys.path
 import reframe                           # noqa: F401, F403
 import reframe.utility.osext as osext    # noqa: F401, F403
 
+# Sphinx erroneously uses `repr()` to display values and not the
+# human-readable `str()`. For this reason we define the following variable in
+# the `reframe` module so that objects can redirect to their `str()` method
+# from `repr()` if they are invoked in the context of Sphinx when building the
+# documentation. See discussion and the related workaround here:
+#
+# https://github.com/sphinx-doc/sphinx/issues/3857
+
+reframe.__build_docs__ = True
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -142,7 +142,7 @@ System Configuration
    These modules modify the ReFrame environment.
    This is useful in cases where a particular module is needed, for example, to submit jobs on a specific system.
 
-.. js:attribute:: .systems[].variables
+.. js:attribute:: .systems[].env_vars
 
    :required: No
    :default: ``[]``
@@ -153,6 +153,14 @@ System Configuration
    You may reference other environment variables when defining an environment variable here.
    ReFrame will expand its value.
    Variables are set after the environment modules are loaded.
+
+   .. versionadded:: 4.0.0
+
+.. js:attribute:: .systems[].variables
+
+   .. deprecated:: 4.0.0
+      Please use :js:attr:`env_vars` instead.
+      If specified in conjunction with :js:attr:`env_vars`, it will be ignored.
 
 .. js:attribute:: .systems[].prefix
 
@@ -374,7 +382,7 @@ System Partition Configuration
    When the value is ``null``, no time limit is applied.
 
 
-.. js:attribute:: .systems[].partitions[].variables
+.. js:attribute:: .systems[].partitions[].env_vars
 
    :required: No
    :default: ``[]``
@@ -385,6 +393,13 @@ System Partition Configuration
    ReFrame will expand its value.
    Variables are set after the environment modules are loaded.
 
+   .. versionadded:: 4.0.0
+
+.. js:attribute:: .systems[].partitions[].variables
+
+   .. deprecated:: 4.0.0
+      Please use :js:attr:`env_vars` instead.
+      If specified in conjunction with :js:attr:`env_vars`, it will be ignored.
 
 .. js:attribute:: .systems[].partitions[].max_jobs
 
@@ -500,7 +515,7 @@ ReFrame can launch containerized applications, but you need to configure properl
    A list of `environment module objects <#module-objects>`__ to be loaded when running containerized tests using this container platform.
 
 
-.. js:attribute:: .systems[].partitions[].container_platforms[].variables
+.. js:attribute:: .systems[].partitions[].container_platforms[].env_vars
 
    :required: No
    :default: ``[]``
@@ -510,6 +525,14 @@ ReFrame can launch containerized applications, but you need to configure properl
    You may reference other environment variables when defining an environment variable here.
    ReFrame will expand its value.
    Variables are set after the environment modules are loaded.
+
+   .. versionadded:: 4.0.0
+
+.. js:attribute:: .systems[].partitions[].container_platforms[].variables
+
+   .. deprecated:: 4.0.0
+      Please use :js:attr:`env_vars` instead.
+      If specified in conjunction with :js:attr:`env_vars`, it will be ignored.
 
 
 Custom Job Scheduler Resources
@@ -619,7 +642,7 @@ They are associated with `system partitions <#system-partition-configuration>`__
    A list of `environment module objects <#module-objects>`__ to be loaded when this environment is loaded.
 
 
-.. js:attribute:: .environments[].variables
+.. js:attribute:: .environments[].env_vars
 
    :required: No
    :default: ``[]``
@@ -629,6 +652,14 @@ They are associated with `system partitions <#system-partition-configuration>`__
    You may reference other environment variables when defining an environment variable here.
    ReFrame will expand its value.
    Variables are set after the environment modules are loaded.
+
+   .. versionadded:: 4.0.0
+
+.. js:attribute:: .environments[].variables
+
+   .. deprecated:: 4.0.0
+      Please use :js:attr:`env_vars` instead.
+      If specified in conjunction with :js:attr:`env_vars`, it will be ignored.
 
 
 .. js:attribute:: .environments[].features

--- a/reframe/core/config.py
+++ b/reframe/core/config.py
@@ -347,6 +347,45 @@ class _SiteConfig:
 
                 partition_names.add(partname)
 
+        def _warn_variables(config, opt_path):
+            opt_path = '/'.join(opt_path + ['variables'])
+            if 'env_vars' in config and 'variables' in config:
+                getlogger().warning(
+                    f"configuration option {opt_path!r}: "
+                    f"both 'env_vars' and 'variables' are defined; "
+                    f"'variables' will be ignored"
+                )
+            elif 'variables' in config:
+                getlogger().warning(
+                    f"configuration option {opt_path!r}: "
+                    f"'variables' is deprecated; please use 'env_vars' instead"
+                )
+                config['env_vars'] = config['variables']
+
+        # Warn about the deprecated `variables` and convert them internally to
+        # `env_vars`
+        for system in self._site_config['systems']:
+            sysname = system['name']
+            opt_path = ['systems', f'@{sysname}']
+            _warn_variables(system, opt_path)
+            for part in system['partitions']:
+                partname = part['name']
+                opt_path += ['partitions', f'@{partname}']
+                _warn_variables(part, opt_path)
+                for i, cp in enumerate(part.get('container_platforms', [])):
+                    opt_path += ['container_platforms', str(i)]
+                    _warn_variables(cp, opt_path)
+                    opt_path.pop()
+                    opt_path.pop()
+
+                opt_path.pop()
+                opt_path.pop()
+
+        for env in self._site_config['environments']:
+            envname = env['name']
+            opt_path = ['environments', f'@{envname}']
+            _warn_variables(env, opt_path)
+
     def select_subconfig(self, system_fullname=None,
                          ignore_resolve_errors=False):
         # First look for the current subconfig in the cache; if not found,

--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -20,6 +20,7 @@ import reframe.utility.color as color
 import reframe.utility.jsonext as jsonext
 import reframe.utility.osext as osext
 from reframe.core.exceptions import ConfigError, LoggingError
+from reframe.core.warnings import suppress_deprecations
 from reframe.utility.profile import TimeProfiler
 
 
@@ -396,8 +397,8 @@ class HTTPJSONHandler(logging.Handler):
     def _record_to_json(self, record):
         def _can_send(key):
             return not (
-                key.startswith('_') or key in HTTPJSONHandler.LOG_ATTRS
-                or (self._ignore_keys and key in self._ignore_keys)
+                key.startswith('_') or key in HTTPJSONHandler.LOG_ATTRS or
+                (self._ignore_keys and key in self._ignore_keys)
             )
 
         json_record = {
@@ -577,9 +578,11 @@ class LoggerAdapter(logging.LoggerAdapter):
         for attr, alt_name in check_type.loggable_attrs():
             extra_name  = alt_name or attr
 
-            # In case of AttributeError, i.e., the variable is undefined, we
-            # set the value to None
-            val = getattr(self.check, attr, None)
+            with suppress_deprecations():
+                # In case of AttributeError, i.e., the variable is undefined,
+                # we set the value to None
+                val = getattr(self.check, attr, None)
+
             if attr in check_type.raw_params:
                 # Attribute is parameter, so format it
                 val = check_type.raw_params[attr].format(val)

--- a/reframe/core/meta.py
+++ b/reframe/core/meta.py
@@ -140,11 +140,9 @@ class RegressionTestMeta(type):
                         # available in the current class' namespace.
                         for b in self['_rfm_bases']:
                             if key in b._rfm_var_space:
-                                # Store a deep-copy of the variable's
-                                # value and return.
-                                v = b._rfm_var_space[key].default_value
+                                v = variables.ShadowVar(b._rfm_var_space[key])
                                 self._namespace[key] = v
-                                return self._namespace[key]
+                                return v
 
                         # If 'key' is neither a variable nor a parameter,
                         # raise the exception from the base __getitem__.

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -783,9 +783,21 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #:
     #: These variables will be set during the :func:`setup` phase.
     #:
-    #: :type: :class:`Dict[str, str]`
+    #: :type: :class:`Dict[str, object]`
     #: :default: ``{}``
-    variables = variable(typ.Dict[str, str], value={}, loggable=True)
+    #:
+    #: .. versionadded:: 4.0.0
+    env_vars = variable(typ.Dict[str, object], value={}, loggable=True)
+
+    #: Environment variables to be set before running this test.
+    #:
+    #: This is an alias of :attr:`env_vars`.
+    #:
+    #: .. deprecated:: 4.0.0
+    #:    Please use :attr:`env_vars` instead.
+    variables = deprecate(variable(alias=env_vars, loggable=True),
+                          f"the use of 'variables' is deprecated; "
+                          f"please use 'env_vars' instead")
 
     #: Time limit for this test.
     #:
@@ -1746,7 +1758,7 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
             self.build_system.executable = self.executable
 
         user_environ = Environment(self.unique_name,
-                                   self.modules, self.variables.items())
+                                   self.modules, self.env_vars.items())
         environs = [self._current_partition.local_env, self._current_environ,
                     user_environ, self._cdt_environ]
         self._build_job.time_limit = (
@@ -1880,7 +1892,7 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
             *self.postrun_cmds
         ]
         user_environ = Environment(self.unique_name,
-                                   self.modules, self.variables.items())
+                                   self.modules, self.env_vars.items())
         environs = [
             self._current_partition.local_env,
             self._current_environ,

--- a/reframe/core/runtime.py
+++ b/reframe/core/runtime.py
@@ -235,7 +235,7 @@ def loadenv(*environs):
             else:
                 commands += modules_system.emit_load_commands(**mod)
 
-        for k, v in env.variables.items():
+        for k, v in env.env_vars.items():
             os.environ[k] = osext.expandvars(v)
             commands.append(f'export {k}={v}')
 
@@ -264,7 +264,7 @@ def is_env_loaded(environ):
     is_module_loaded = runtime().modules_system.is_module_loaded
     return (all(map(is_module_loaded, environ.modules)) and
             all(os.environ.get(k, None) == osext.expandvars(v)
-                for k, v in environ.variables.items()))
+                for k, v in environ.env_vars.items()))
 
 
 def _is_valid_part(part, valid_systems):

--- a/reframe/core/systems.py
+++ b/reframe/core/systems.py
@@ -432,13 +432,12 @@ class SystemPartition(jsonext.JSONSerializable):
                 {
                     'type': ctype,
                     'modules': [m for m in cpenv.modules],
-                    'variables': [[n, v] for n, v in cpenv.variables.items()]
+                    'env_vars': [[n, v] for n, v in cpenv.env_vars.items()]
                 }
                 for ctype, cpenv in self._container_environs.items()
             ],
             'modules': [m for m in self._local_env.modules],
-            'variables': [[n, v]
-                          for n, v in self._local_env.variables.items()],
+            'env_vars': [[n, v] for n, v in self._local_env.env_vars.items()],
             'environs': [e.name for e in self._environs],
             'max_jobs': self._max_jobs,
             'resources': [
@@ -513,8 +512,8 @@ class System(jsonext.JSONSerializable):
                     modules=site_config.get(
                         f'{partid}/container_platforms/{i}/modules'
                     ),
-                    variables=site_config.get(
-                        f'{partid}/container_platforms/{i}/variables'
+                    env_vars=site_config.get(
+                        f'{partid}/container_platforms/{i}/env_vars'
                     )
                 )
                 if p.get('default', None):
@@ -529,7 +528,7 @@ class System(jsonext.JSONSerializable):
                 ProgEnvironment(
                     name=e,
                     modules=site_config.get(f'environments/@{e}/modules'),
-                    variables=site_config.get(f'environments/@{e}/variables'),
+                    env_vars=site_config.get(f'environments/@{e}/env_vars'),
                     extras=site_config.get(f'environments/@{e}/extras'),
                     features=site_config.get(f'environments/@{e}/features'),
                     cc=site_config.get(f'environments/@{e}/cc'),
@@ -558,7 +557,7 @@ class System(jsonext.JSONSerializable):
                     local_env=Environment(
                         name=f'__rfm_env_{part_name}',
                         modules=site_config.get(f'{partid}/modules'),
-                        variables=site_config.get(f'{partid}/variables')
+                        env_vars=site_config.get(f'{partid}/env_vars')
                     ),
                     max_jobs=site_config.get(f'{partid}/max_jobs'),
                     prepare_cmds=site_config.get(f'{partid}/prepare_cmds'),
@@ -582,7 +581,7 @@ class System(jsonext.JSONSerializable):
             preload_env=Environment(
                 name=f'__rfm_env_{sysname}',
                 modules=site_config.get('systems/0/modules'),
-                variables=site_config.get('systems/0/variables')
+                env_vars=site_config.get('systems/0/env_vars')
             ),
             prefix=site_config.get('systems/0/prefix'),
             outputdir=site_config.get('systems/0/outputdir'),
@@ -696,9 +695,9 @@ class System(jsonext.JSONSerializable):
             'hostnames': self._hostnames,
             'modules_system': self._modules_system.name,
             'modules': [m for m in self._preload_env.modules],
-            'variables': [
+            'env_vars': [
                 [name, value]
-                for name, value in self._preload_env.variables.items()
+                for name, value in self._preload_env.env_vars.items()
             ],
             'prefix': self._prefix,
             'outputdir': self._outputdir,

--- a/reframe/core/variables.py
+++ b/reframe/core/variables.py
@@ -158,6 +158,14 @@ class TestVar:
     from :class:`EchoBaseTest` to throw an error indicating that the variable
     ``what`` has not been set.
 
+    Finally, variables may alias each other. If a variable is an alias of
+    another one it behaves in the exact same way as its target. If a change is
+    made to the target variable, this is reflected to the alias and vice
+    versa. However, alias variables are independently loggable: an alias may
+    be logged but not its target and vice versa. Aliased variables are useful
+    when you want to rename a variable and you want to keep the old one for
+    compatibility reasons.
+
     :param `types`: the supported types for the variable.
     :param value: the default value assigned to the variable. If no value is
         provided, the variable is set as ``required``.
@@ -165,6 +173,9 @@ class TestVar:
         field argument is provided, it defaults to
         :attr:`reframe.core.fields.TypedField`. The provided field validator
         by this argument must derive from :attr:`reframe.core.fields.Field`.
+    :param alias: the target variable if this variable is an alias. This must
+        refer to an already declared variable and neither default value nor a
+        field can be specified for an alias variable.
     :param loggable: Mark this variable as loggable. If :obj:`True`, this
         variable will become a log record attribute under the name
         ``check_NAME``, where ``NAME`` is the name of the variable.
@@ -172,8 +183,11 @@ class TestVar:
         the field validator.
     :returns: A new test variable.
 
-    .. version added:: 3.10.2
+    .. versionadded:: 3.10.2
        The ``loggable`` argument is added.
+
+    .. versionadded:: 4.0.0
+       Alias variable are introduced.
 
     '''
 

--- a/reframe/core/variables.py
+++ b/reframe/core/variables.py
@@ -204,31 +204,30 @@ class TestVar:
 
     def __init__(self, *args, **kwargs):
         alias = kwargs.pop('alias', None)
-        if alias and 'field' in kwargs:
+        if alias is not None and 'field' in kwargs:
             raise ValueError(f"'field' cannot be set for an alias variable")
 
-        if alias and 'value' in kwargs:
+        if alias is not None and 'value' in kwargs:
             raise ValueError('alias variables do not accept default values')
 
-        if alias and not isinstance(alias, TestVar):
+        if alias is not None and not isinstance(alias, TestVar):
             raise TypeError(f"'alias' must refer to a variable; "
                             f"found {type(alias).__name__!r}")
 
         field_type = kwargs.pop('field', fields.TypedField)
-        if alias:
+        if alias is not None:
             self._p_default_value = alias._default_value
         else:
             self._p_default_value = kwargs.pop('value', Undefined)
 
         self._loggable = kwargs.pop('loggable', False)
-
         if not issubclass(field_type, fields.Field):
             raise TypeError(
                 f'field {field_type!r} is not derived from '
                 f'{fields.Field.__qualname__}'
             )
 
-        if alias:
+        if alias is not None:
             self._p_field = alias._field
         else:
             self._p_field = field_type(*args, **kwargs)

--- a/reframe/core/variables.py
+++ b/reframe/core/variables.py
@@ -346,6 +346,10 @@ class TestVar:
         return str(self._default_value)
 
     def __repr__(self):
+        import reframe
+        if hasattr(reframe, '__build_docs__'):
+            return str(self)
+
         try:
             name = self.name
         except AttributeError:

--- a/reframe/core/variables.py
+++ b/reframe/core/variables.py
@@ -177,10 +177,11 @@ class TestVar:
 
     '''
 
-    # NOTE: We can't use truly private fields in __slots__, because
-    # __setattr__() will be called with their mangled name and we cannot match
-    # them in the __slots__ with making implementation-defined assumptions
-    # about the mangled name. So we just add the `_p_` prefix for "private"
+    # NOTE: We can't use truly private fields in `__slots__`, because
+    # `__setattr__()` will be called with their mangled name and we cannot
+    # match them in the `__slots__` without making implementation-defined
+    # assumptions about the mangled name. So we just add the `_p_` prefix for
+    # to denote the "private" fields.
 
     __slots__ = ('_p_default_value', '_p_field',
                  '_loggable', '_name', '_target')
@@ -188,19 +189,18 @@ class TestVar:
     __mutable_props = ('_default_value',)
 
     def __init__(self, *args, **kwargs):
-        field_type = kwargs.pop('field', fields.TypedField)
         alias = kwargs.pop('alias', None)
-
-        if alias and not isinstance(alias, TestVar):
-            raise TypeError(f"'alias' must refer to a variable; "
-                            f"found {type(alias).__name__!r}")
-
         if alias and 'field' in kwargs:
             raise ValueError(f"'field' cannot be set for an alias variable")
 
         if alias and 'value' in kwargs:
             raise ValueError('alias variables do not accept default values')
 
+        if alias and not isinstance(alias, TestVar):
+            raise TypeError(f"'alias' must refer to a variable; "
+                            f"found {type(alias).__name__!r}")
+
+        field_type = kwargs.pop('field', fields.TypedField)
         if alias:
             self._p_default_value = alias._default_value
         else:

--- a/reframe/frontend/autodetect.py
+++ b/reframe/frontend/autodetect.py
@@ -231,10 +231,10 @@ def detect_topology():
             # No topology found, try to auto-detect it
             getlogger().debug(f'> no topology file found; auto-detecting...')
             modules = list(rt.system.preload_environ.modules)
-            vars = dict(rt.system.preload_environ.variables.items())
+            vars = dict(rt.system.preload_environ.env_vars.items())
             if _is_part_local(part):
                 modules += part.local_env.modules
-                vars.update(part.local_env.variables)
+                vars.update(part.local_env.env_vars)
 
                 # Unconditionally detect the system for fully local partitions
                 with runtime.temp_environment(modules=modules, variables=vars):

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -155,8 +155,9 @@ def describe_checks(testcases, printer):
 
             # List all required variables
             required = []
-            for var in tc.check._rfm_var_space:
-                if not tc.check._rfm_var_space[var].is_defined():
+            var_space = type(tc.check).var_space
+            for var in var_space:
+                if not var_space[var].is_defined():
                     required.append(var)
 
             rec['@required'] = required

--- a/reframe/frontend/runreport.py
+++ b/reframe/frontend/runreport.py
@@ -13,7 +13,7 @@ import re
 import reframe as rfm
 import reframe.core.exceptions as errors
 import reframe.utility.jsonext as jsonext
-
+from reframe.core.warnings import suppress_deprecations
 
 # The schema data version
 # Major version bumps are expected to break the validation of previous schemas
@@ -46,7 +46,8 @@ class _RunReport:
         return self._report[key]
 
     def __getattr__(self, name):
-        return getattr(self._report, name)
+        with suppress_deprecations():
+            return getattr(self._report, name)
 
     def add_fallback(self, report):
         self._fallbacks.append(report)

--- a/reframe/frontend/statistics.py
+++ b/reframe/frontend/statistics.py
@@ -10,6 +10,12 @@ import traceback
 import reframe.core.runtime as rt
 import reframe.core.exceptions as errors
 import reframe.utility as util
+from reframe.core.warnings import suppress_deprecations
+
+
+def _getattr(obj, attr):
+    with suppress_deprecations():
+        return getattr(obj, attr)
 
 
 class TestStats:
@@ -199,7 +205,7 @@ class TestStats:
                 for name, var in test_cls.var_space.items():
                     if var.is_loggable():
                         try:
-                            entry['check_vars'][name] = getattr(check, name)
+                            entry['check_vars'][name] = _getattr(check, name)
                         except AttributeError:
                             entry['check_vars'][name] = '<undefined>'
 
@@ -207,7 +213,7 @@ class TestStats:
                 test_cls = type(check)
                 for name, param in test_cls.param_space.items():
                     if param.is_loggable():
-                        entry['check_params'][name] = getattr(check, name)
+                        entry['check_params'][name] = _getattr(check, name)
 
                 testcases.append(entry)
 

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -235,6 +235,7 @@
                                  "lmod", "nomod", "spack"]
                     },
                     "modules": {"$ref": "#/defs/modules_list"},
+                    "env_vars": {"$ref": "#/defs/envvar_list"},
                     "variables": {"$ref": "#/defs/envvar_list"},
                     "prefix": {"type": "string"},
                     "stagedir": {"type": "string"},
@@ -274,6 +275,9 @@
                                             "modules": {
                                                 "$ref": "#/defs/modules_list"
                                             },
+                                            "env_vars": {
+                                                "$ref": "#/defs/envvar_list"
+                                            },
                                             "variables": {
                                                 "$ref": "#/defs/envvar_list"
                                             },
@@ -283,8 +287,9 @@
                                     }
                                 },
                                 "modules": {"$ref": "#/defs/modules_list"},
-                                "time_limit": {"type": ["string", "null"]},
+                                "env_vars": {"$ref": "#/defs/envvar_list"},
                                 "variables": {"$ref": "#/defs/envvar_list"},
+                                "time_limit": {"type": ["string", "null"]},
                                 "max_jobs": {"type": "number"},
                                 "prepare_cmds": {
                                     "type": "array",
@@ -335,6 +340,7 @@
                 "properties": {
                     "name": {"$ref": "#/defs/alphanum_ext_string"},
                     "modules": {"$ref": "#/defs/modules_list"},
+                    "env_vars": {"$ref": "#/defs/envvar_list"},
                     "variables": {"$ref": "#/defs/envvar_list"},
                     "cc": {"type": "string"},
                     "cxx": {"type": "string"},
@@ -499,6 +505,7 @@
     "additionalProperties": false,
     "defaults": {
         "environments/modules": [],
+        "environments/env_vars": [],
         "environments/variables": [],
         "environments/cc": "cc",
         "environments/cxx": "CC",
@@ -565,6 +572,7 @@
         "systems/max_local_jobs": 8,
         "systems/modules_system": "nomod",
         "systems/modules": [],
+        "systems/env_vars": [],
         "systems/variables": [],
         "systems/prefix": ".",
         "systems/outputdir": "",
@@ -576,11 +584,13 @@
         "systems/partitions/container_runtime": null,
         "systems/partitions/container_platforms": [],
         "systems/partitions/container_platforms/*modules": [],
+        "systems/partitions/container_platforms/*env_vars": [],
         "systems/partitions/container_platforms/*variables": [],
         "systems/partitions/features": [],
         "systems/partitions/resources": [],
         "systems/partitions/resources/options": [],
         "systems/partitions/modules": [],
+        "systems/partitions/env_vars": [],
         "systems/partitions/variables": [],
         "systems/partitions/max_jobs": 8,
         "systems/partitions/prepare_cmds": [],

--- a/unittests/resources/settings.py
+++ b/unittests/resources/settings.py
@@ -51,7 +51,7 @@ site_configuration = {
             'prefix': '.rfm_testing',
             'resourcesdir': '.rfm_testing/resources',
             'modules': ['foo/1.0'],
-            'variables': [['FOO_CMD', 'foobar']],
+            'env_vars': [['FOO_CMD', 'foobar']],
             'partitions': [
                 {
                     'name': 'login',
@@ -76,7 +76,7 @@ site_configuration = {
                     'modules': [
                         {'name': 'foogpu', 'collection': False, 'path': '/foo'}
                     ],
-                    'variables': [['FOO_GPU', 'yes']],
+                    'env_vars': [['FOO_GPU', 'yes']],
                     'resources': [
                         {
                             'name': 'gpu',

--- a/unittests/test_config.py
+++ b/unittests/test_config.py
@@ -224,7 +224,7 @@ def test_select_subconfig():
     assert site_config.get('systems/0/modules') == [{'name': 'foo/1.0',
                                                      'collection': False,
                                                      'path': None}]
-    assert site_config.get('systems/0/variables') == [['FOO_CMD', 'foobar']]
+    assert site_config.get('systems/0/env_vars') == [['FOO_CMD', 'foobar']]
     assert site_config.get('systems/0/modules_system') == 'nomod'
     assert site_config.get('systems/0/outputdir') == ''
     assert site_config.get('systems/0/stagedir') == ''
@@ -255,7 +255,7 @@ def test_select_subconfig():
         {'type': 'Singularity'}
     ]
     assert site_config.get('systems/0/partitions/0/modules') == []
-    assert site_config.get('systems/0/partitions/0/variables') == []
+    assert site_config.get('systems/0/partitions/0/env_vars') == []
     assert site_config.get('systems/0/partitions/0/max_jobs') == 8
     assert len(site_config['environments']) == 7
     assert site_config.get('environments/@PrgEnv-gnu/cc') == 'gcc'
@@ -287,7 +287,7 @@ def test_select_subconfig():
     assert site_config.get('systems/0/partitions/0/modules') == [
         {'name': 'foogpu', 'collection': False, 'path': '/foo'}
     ]
-    assert (site_config.get('systems/0/partitions/0/variables') ==
+    assert (site_config.get('systems/0/partitions/0/env_vars') ==
             [['FOO_GPU', 'yes']])
     assert site_config.get('systems/0/partitions/0/max_jobs') == 10
     assert site_config.get('environments/@PrgEnv-gnu/cc') == 'cc'
@@ -347,7 +347,7 @@ def test_system_create():
     assert system.hostnames == ['testsys']
     assert system.modules_system.name == 'nomod'
     assert system.preload_environ.modules == ['foo/1.0']
-    assert system.preload_environ.variables == {'FOO_CMD': 'foobar'}
+    assert system.preload_environ.env_vars == {'FOO_CMD': 'foobar'}
     assert system.prefix == '.rfm_testing'
     assert system.stagedir == ''
     assert system.outputdir == ''
@@ -367,7 +367,7 @@ def test_system_create():
     assert partition.local_env.modules_detailed == [{
         'name': 'foogpu', 'collection': False, 'path': '/foo'
     }]
-    assert partition.local_env.variables == {'FOO_GPU': 'yes'}
+    assert partition.local_env.env_vars == {'FOO_GPU': 'yes'}
     assert partition.max_jobs == 10
     assert partition.time_limit is None
     assert len(partition.environs) == 2
@@ -403,6 +403,36 @@ def test_system_create():
     site_config.select_subconfig('testsys:login')
     system = System.create(site_config)
     assert system.partitions[0].container_runtime == 'Docker'
+
+
+def test_variables(tmp_path):
+    # Test that the old syntax using `variables` instead of `env_vars` still
+    # works
+    config_file = tmp_path / 'settings.py'
+    with open(config_file, 'w') as fout:
+        with open('unittests/resources/settings.py') as fin:
+            fout.write(fin.read().replace('env_vars', 'variables'))
+
+    site_config = config.load_config(config_file)
+    site_config.validate()
+    site_config.select_subconfig('testsys')
+    assert site_config.get('systems/0/variables') == [['FOO_CMD', 'foobar']]
+    assert site_config.get('systems/0/env_vars') == [['FOO_CMD', 'foobar']]
+
+    site_config.select_subconfig('testsys:login')
+    assert site_config.get('systems/0/partitions/0/variables') == []
+    assert site_config.get('systems/0/partitions/0/env_vars') == []
+
+    site_config.select_subconfig('testsys:gpu')
+    assert (site_config.get('systems/0/partitions/0/variables') ==
+            [['FOO_GPU', 'yes']])
+    assert (site_config.get('systems/0/partitions/0/env_vars') ==
+            [['FOO_GPU', 'yes']])
+
+    # Test that system is created correctly
+    system = System.create(site_config)
+    assert system.preload_environ.env_vars == {'FOO_CMD': 'foobar'}
+    assert system.partitions[0].local_env.env_vars == {'FOO_GPU': 'yes'}
 
 
 def test_hostname_autodetection():

--- a/unittests/test_environments.py
+++ b/unittests/test_environments.py
@@ -71,12 +71,12 @@ def assert_modules_loaded(modules):
 def test_env_construction(base_environ, env0):
     assert len(env0.modules) == 1
     assert 'testmod_foo' in env0.modules
-    assert len(env0.variables.keys()) == 3
-    assert env0.variables['_var0'] == 'val1'
+    assert len(env0.env_vars.keys()) == 3
+    assert env0.env_vars['_var0'] == 'val1'
 
     # No variable expansion, if environment is not loaded
-    assert env0.variables['_var2'] == '$_var0'
-    assert env0.variables['_var3'] == '${_var1}'
+    assert env0.env_vars['_var2'] == '$_var0'
+    assert env0.env_vars['_var3'] == '${_var1}'
 
     # Assert extras
     assert env0.extras == {'foo': 1, 'bar': 2}
@@ -85,11 +85,11 @@ def test_env_construction(base_environ, env0):
 def test_progenv_construction():
     environ = env.ProgEnvironment('myenv',
                                   modules=['modfoo'],
-                                  variables=[('var', 'val')],
+                                  env_vars=[('var', 'val')],
                                   extras={'foo': 'bar'})
     assert environ.name == 'myenv'
     assert environ.modules == ['modfoo']
-    assert environ.variables == {'var': 'val'}
+    assert environ.env_vars == {'var': 'val'}
     assert environ.extras == {'foo': 'bar'}
 
 
@@ -138,16 +138,16 @@ def test_env_load_already_present(base_environ, user_runtime,
 
 
 def test_env_load_non_overlapping(base_environ):
-    e0 = env.Environment(name='e0', variables=[('a', '1'), ('b', '2')])
-    e1 = env.Environment(name='e1', variables=[('c', '3'), ('d', '4')])
+    e0 = env.Environment(name='e0', env_vars=[('a', '1'), ('b', '2')])
+    e1 = env.Environment(name='e1', env_vars=[('c', '3'), ('d', '4')])
     rt.loadenv(e0, e1)
     assert rt.is_env_loaded(e0)
     assert rt.is_env_loaded(e1)
 
 
 def test_load_overlapping(base_environ):
-    e0 = env.Environment(name='e0', variables=[('a', '1'), ('b', '2')])
-    e1 = env.Environment(name='e1', variables=[('b', '3'), ('c', '4')])
+    e0 = env.Environment(name='e0', env_vars=[('a', '1'), ('b', '2')])
+    e1 = env.Environment(name='e1', env_vars=[('b', '3'), ('c', '4')])
     rt.loadenv(e0, e1)
     assert not rt.is_env_loaded(e0)
     assert rt.is_env_loaded(e1)
@@ -166,8 +166,8 @@ def test_env_not_equal(base_environ):
     assert env1 != env2
 
     # Variables are ordered, because they might depend on each other
-    env1 = env.Environment('env1', variables=[('a', 1), ('b', 2)])
-    env2 = env.Environment('env1', variables=[('b', 2), ('a', 1)])
+    env1 = env.Environment('env1', env_vars=[('a', 1), ('b', 2)])
+    env2 = env.Environment('env1', env_vars=[('b', 2), ('a', 1)])
     assert env1 != env2
 
 

--- a/unittests/test_logging.py
+++ b/unittests/test_logging.py
@@ -29,6 +29,7 @@ def fake_check():
     class _FakeCheck(rfm.RegressionTest):
         param = parameter(range(3), loggable=True, fmt=lambda x: 10*x)
         custom = variable(str, value='hello extras', loggable=True)
+        custom2 = variable(alias=custom)
         custom_list = variable(list,
                                value=['custom', 3.0, ['hello', 'world']],
                                loggable=True)
@@ -161,13 +162,13 @@ def test_logger_levels(logfile, logger_with_check):
 
 def test_logger_loggable_attributes(logfile, logger_with_check):
     formatter = rlog.RFC3339Formatter(
-        '%(check_custom)s|%(check_custom_list)s|'
+        '%(check_custom)s|%(check_custom2)s|%(check_custom_list)s|'
         '%(check_foo)s|%(check_custom_dict)s|%(check_param)s|%(check_x)s'
     )
     logger_with_check.logger.handlers[0].setFormatter(formatter)
     logger_with_check.info('xxx')
     assert _pattern_in_logfile(
-        r'hello extras\|custom,3.0,\["hello", "world"\]\|null\|'
+        r'hello extras\|null\|custom,3.0,\["hello", "world"\]\|null\|'
         r'{"a": 1, "b": 2}\|10\|null', logfile
     )
 

--- a/unittests/test_pipeline.py
+++ b/unittests/test_pipeline.py
@@ -20,6 +20,7 @@ from reframe.core.exceptions import (BuildError, PipelineError, ReframeError,
                                      PerformanceError, SanityError,
                                      SkipTestError, ReframeSyntaxError)
 from reframe.core.meta import make_test
+from reframe.core.warnings import ReframeDeprecationWarning
 
 
 def _run(test, partition, prgenv):
@@ -159,9 +160,9 @@ def test_eq():
 
 def test_environ_setup(hellotest, local_exec_ctx):
     # Use test environment for the regression check
-    hellotest.variables = {'_FOO_': '1', '_BAR_': '2'}
+    hellotest.env_vars = {'_FOO_': '1', '_BAR_': '2'}
     hellotest.setup(*local_exec_ctx)
-    for k in hellotest.variables.keys():
+    for k in hellotest.env_vars.keys():
         assert k not in os.environ
 
 
@@ -1889,3 +1890,18 @@ def test_set_var_default():
     x = _X()
     assert x.foo == 10
     assert x.bar == 100
+
+
+def _test_variables_deprecation():
+    with pytest.warns(ReframeDeprecationWarning):
+        class _X(rfm.RunOnlyRegressionTest):
+            variables = {'FOO': '1'}
+
+    test = _X()
+    print('===')
+    assert test.env_vars['FOO'] == '1'
+
+    with pytest.warns(ReframeDeprecationWarning):
+        test.variables['BAR'] == '2'
+
+    assert test.env_vars['BAR'] == '2'

--- a/unittests/test_variables.py
+++ b/unittests/test_variables.py
@@ -9,6 +9,7 @@ import math
 
 import reframe as rfm
 from reframe.core.exceptions import ReframeSyntaxError
+from reframe.core.warnings import ReframeDeprecationWarning
 
 
 @pytest.fixture
@@ -458,7 +459,6 @@ def test_other_numerical_operators():
 
 def test_var_deprecation():
     from reframe.core.variables import DEPRECATE_RD, DEPRECATE_WR
-    from reframe.core.warnings import ReframeDeprecationWarning
 
     # Check read deprecation
     class A(rfm.RegressionMixin):
@@ -544,3 +544,15 @@ def test_var_aliases():
 
     s.x = 3
     assert s.y == 3
+
+    # Test deprecated aliases
+    class S(T):
+        y = deprecate(variable(alias=x), f'y is deprecated')
+
+    with pytest.warns(ReframeDeprecationWarning):
+        class U(S):
+            y = 10
+
+    s = S()
+    with pytest.warns(ReframeDeprecationWarning):
+        s.y = 10

--- a/unittests/test_variables.py
+++ b/unittests/test_variables.py
@@ -508,13 +508,13 @@ def test_var_aliases():
             y = variable(alias=x, field=TypedField)
 
     class T(rfm.RegressionMixin):
-        x = variable(int, value=1)
+        x = variable(int, value=0)
         y = variable(alias=x)
         z = variable(alias=y)
 
     t = T()
-    assert t.y == 1
-    assert t.z == 1
+    assert t.y == 0
+    assert t.z == 0
 
     t.x = 4
     assert t.y == 4

--- a/unittests/test_variables.py
+++ b/unittests/test_variables.py
@@ -495,6 +495,18 @@ def test_var_aliases():
             x = variable(int, value=1)
             y = variable(alias=x, value=2)
 
+    with pytest.raises(TypeError, match=r"'alias' must refer to a variable"):
+        class T(rfm.RegressionMixin):
+            x = variable(int, value=1)
+            y = variable(alias=10)
+
+    with pytest.raises(ValueError, match=r"'field' cannot be set"):
+        from reframe.core.fields import TypedField
+
+        class T(rfm.RegressionMixin):
+            x = variable(int, value=1)
+            y = variable(alias=x, field=TypedField)
+
     class T(rfm.RegressionMixin):
         x = variable(int, value=1)
         y = variable(alias=x)


### PR DESCRIPTION
The use of `variables` is deprecated in both the configuration and the tests. Users should use `env_vars` instead.

This PR builds on top of #2647.

Closes #1774.