### PR TITLE
[feat] Relax the value syntax of `env_vars`

### DIFF
--- a/reframe/core/environments.py
+++ b/reframe/core/environments.py
@@ -45,7 +45,15 @@ class Environment(jsonext.JSONSerializable):
         self._name = name
         self._modules = normalize_module_list(modules)
         self._module_names = [m['name'] for m in self._modules]
-        self._env_vars = collections.OrderedDict(env_vars)
+
+        # Convert values of env_vars to strings before storing
+        if isinstance(env_vars, dict):
+            env_vars = env_vars.items()
+
+        self._env_vars = collections.OrderedDict()
+        for k, v in env_vars:
+            self._env_vars[k] = str(v)
+
         self._extras = extras or {}
         self._features = features or []
 

--- a/reframe/core/environments.py
+++ b/reframe/core/environments.py
@@ -131,9 +131,19 @@ class Environment(jsonext.JSONSerializable):
         if not isinstance(other, type(self)):
             return NotImplemented
 
-        return (self.name == other.name and
-                set(self.modules) == set(other.modules) and
-                self.env_vars == other.env_vars)
+        if (self.name != other.name or
+            set(self.modules) != set(other.modules)):
+            return False
+
+        # Env. variables are checked against their string representation
+        for kv0, kv1 in zip(self.env_vars.items(),
+                            other.env_vars.items()):
+            k0, v0 = kv0
+            k1, v1 = kv1
+            if k0 != k1 or str(v0) != str(v1):
+                return False
+
+        return True
 
     def __str__(self):
         return self.name

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -781,11 +781,11 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
 
     #: Environment variables to be set before running this test.
     #:
-    #: :type: :class:`Dict[str, str]`
+    #: :type: :class:`Dict[str, object]`
     #: :default: ``{}``
     #:
     #: .. versionadded:: 4.0.0
-    env_vars = variable(typ.Dict[str, str], value={}, loggable=True)
+    env_vars = variable(typ.Dict[str, object], value={}, loggable=True)
 
     #: Environment variables to be set before running this test.
     #:

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -781,6 +781,9 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
 
     #: Environment variables to be set before running this test.
     #:
+    #: The value of the environment variables can be of any type. ReFrame will
+    #: invoke :func:`str` on it whenever it needs to emit it in a script.
+    #:
     #: :type: :class:`Dict[str, object]`
     #: :default: ``{}``
     #:

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -788,7 +788,11 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #: :default: ``{}``
     #:
     #: .. versionadded:: 4.0.0
-    env_vars = variable(typ.Dict[str, object], value={}, loggable=True)
+    env_vars = variable(typ.Dict[str, str],
+                        typ.Dict[str, object], value={}, loggable=True)
+    # NOTE: We still keep the original type, just to allow setting this
+    # variable from the command line, because otherwise, ReFrame will not know
+    # how to convert a value to an arbitrary object.
 
     #: Environment variables to be set before running this test.
     #:

--- a/reframe/core/runtime.py
+++ b/reframe/core/runtime.py
@@ -382,7 +382,8 @@ class temp_environment:
         self._variables = variables
 
     def __enter__(self):
-        new_env = Environment('_rfm_temp_env', self._modules, self._variables)
+        new_env = Environment('_rfm_temp_env', self._modules,
+                              self._variables.items())
         self._environ_save, _ = loadenv(new_env)
         return new_env
 

--- a/tutorials/advanced/parameterized/stream.py
+++ b/tutorials/advanced/parameterized/stream.py
@@ -68,7 +68,7 @@ class StreamMultiSysTest(rfm.RegressionTest):
         num_threads = self.cores.get(self.current_partition.fullname, 1)
         self.num_cpus_per_task = num_threads
         self.env_vars = {
-            'OMP_NUM_THREADS': str(num_threads),
+            'OMP_NUM_THREADS': num_threads,
             'OMP_PLACES': 'cores'
         }
 

--- a/tutorials/basics/stream/stream4.py
+++ b/tutorials/basics/stream/stream4.py
@@ -18,7 +18,7 @@ class StreamMultiSysTest(rfm.RegressionTest):
     build_system = 'SingleSource'
     sourcepath = 'stream.c'
     env_vars = {
-        'OMP_NUM_THREADS': '4',
+        'OMP_NUM_THREADS': 4,
         'OMP_PLACES': 'cores'
     }
     reference = {

--- a/tutorials/basics/stream/stream4.py
+++ b/tutorials/basics/stream/stream4.py
@@ -57,7 +57,7 @@ class StreamMultiSysTest(rfm.RegressionTest):
         num_threads = self.cores.get(self.current_partition.fullname, 1)
         self.num_cpus_per_task = num_threads
         self.env_vars = {
-            'OMP_NUM_THREADS': str(num_threads),
+            'OMP_NUM_THREADS': num_threads,
             'OMP_PLACES': 'cores'
         }
 

--- a/tutorials/cscs-webinar-2022/tests/stream4.py
+++ b/tutorials/cscs-webinar-2022/tests/stream4.py
@@ -30,7 +30,7 @@ class stream_test(rfm.RegressionTest):
         procinfo = self.current_partition.processor
         self.num_cpus_per_task = procinfo.num_cores
         self.env_vars = {
-            'OMP_NUM_THREADS': str(self.num_cpus_per_task),
+            'OMP_NUM_THREADS': self.num_cpus_per_task,
             'OMP_PLACES': 'cores'
         }
 

--- a/tutorials/cscs-webinar-2022/tests/stream5.py
+++ b/tutorials/cscs-webinar-2022/tests/stream5.py
@@ -33,7 +33,7 @@ class stream_test(rfm.RegressionTest):
         procinfo = self.current_partition.processor
         self.num_cpus_per_task = procinfo.num_cores
         self.env_vars = {
-            'OMP_NUM_THREADS': str(self.num_cpus_per_task),
+            'OMP_NUM_THREADS': self.num_cpus_per_task,
             'OMP_PLACES': 'cores'
         }
 

--- a/tutorials/cscs-webinar-2022/tests/stream6.py
+++ b/tutorials/cscs-webinar-2022/tests/stream6.py
@@ -35,7 +35,7 @@ class stream_test(rfm.RegressionTest):
         procinfo = self.current_partition.processor
         self.num_cpus_per_task = procinfo.num_cores
         self.env_vars = {
-            'OMP_NUM_THREADS': str(self.num_cpus_per_task),
+            'OMP_NUM_THREADS': self.num_cpus_per_task,
             'OMP_PLACES': 'cores'
         }
 

--- a/tutorials/cscs-webinar-2022/tests/stream7.py
+++ b/tutorials/cscs-webinar-2022/tests/stream7.py
@@ -46,7 +46,7 @@ class stream_test(rfm.RunOnlyRegressionTest):
         procinfo = self.current_partition.processor
         self.num_cpus_per_task = procinfo.num_cores
         self.env_vars = {
-            'OMP_NUM_THREADS': str(self.num_cpus_per_task),
+            'OMP_NUM_THREADS': self.num_cpus_per_task,
             'OMP_PLACES': 'cores'
         }
 

--- a/tutorials/cscs-webinar-2022/tests/stream8.py
+++ b/tutorials/cscs-webinar-2022/tests/stream8.py
@@ -46,7 +46,7 @@ class stream_test(rfm.RunOnlyRegressionTest):
         procinfo = self.current_partition.processor
         self.num_cpus_per_task = procinfo.num_cores
         self.env_vars = {
-            'OMP_NUM_THREADS': str(self.num_cpus_per_task),
+            'OMP_NUM_THREADS': self.num_cpus_per_task,
             'OMP_PLACES': 'cores'
         }
 
@@ -67,7 +67,7 @@ class stream_scale_test(stream_test):
     @run_before('run')
     def set_cpus_per_task(self):
         self.num_cpus_per_task = self.num_threads
-        self.env_vars['OMP_NUM_THREADS'] = str(self.num_cpus_per_task)
+        self.env_vars['OMP_NUM_THREADS'] = self.num_cpus_per_task
 
     @run_after('setup')
     def skip_if_too_large(self):

--- a/tutorials/cscs-webinar-2022/tests/stream9.py
+++ b/tutorials/cscs-webinar-2022/tests/stream9.py
@@ -47,7 +47,7 @@ class stream_test(rfm.RunOnlyRegressionTest):
         procinfo = self.current_partition.processor
         self.num_cpus_per_task = procinfo.num_cores
         self.env_vars = {
-            'OMP_NUM_THREADS': str(self.num_cpus_per_task),
+            'OMP_NUM_THREADS': self.num_cpus_per_task,
             'OMP_PLACES': 'cores'
         }
 
@@ -83,4 +83,5 @@ class stream_scale_test(stream_test):
     @run_before('run')
     def set_cpus_per_task(self):
         self.num_cpus_per_task = self.num_threads
-        self.env_vars['OMP_NUM_THREADS'] = str(self.num_cpus_per_task)
+
+        self.env_vars['OMP_NUM_THREADS'] = self.num_cpus_per_task

--- a/unittests/test_environments.py
+++ b/unittests/test_environments.py
@@ -154,8 +154,13 @@ def test_load_overlapping(base_environ):
 
 
 def test_env_equal(base_environ):
-    env1 = env.Environment('env1', modules=['foo', 'bar'])
-    env2 = env.Environment('env1', modules=['bar', 'foo'])
+    env1 = env.Environment('env1', modules=['foo', 'bar'],
+                           env_vars=[('a', '1')])
+    env2 = env.Environment('env1', modules=['bar', 'foo'],
+                           env_vars=[('a', 1)])
+
+    # Environments variables must be checked against their string
+    # representation
     assert env1 == env2
     assert env2 == env1
 

--- a/unittests/test_pipeline.py
+++ b/unittests/test_pipeline.py
@@ -160,7 +160,7 @@ def test_eq():
 
 def test_environ_setup(hellotest, local_exec_ctx):
     # Use test environment for the regression check
-    hellotest.env_vars = {'_FOO_': '1', '_BAR_': '2'}
+    hellotest.env_vars = {'_FOO_': 1, '_BAR_': 2}
     hellotest.setup(*local_exec_ctx)
     for k in hellotest.env_vars.keys():
         assert k not in os.environ
@@ -1895,13 +1895,13 @@ def test_set_var_default():
 def _test_variables_deprecation():
     with pytest.warns(ReframeDeprecationWarning):
         class _X(rfm.RunOnlyRegressionTest):
-            variables = {'FOO': '1'}
+            variables = {'FOO': 1}
 
     test = _X()
     print('===')
-    assert test.env_vars['FOO'] == '1'
+    assert test.env_vars['FOO'] == 1
 
     with pytest.warns(ReframeDeprecationWarning):
-        test.variables['BAR'] == '2'
+        test.variables['BAR'] == 2
 
-    assert test.env_vars['BAR'] == '2'
+    assert test.env_vars['BAR'] == 2


### PR DESCRIPTION
Now the value of environment variables can accept any Python type. ReFrame will invoke `str(value)` automatically to emit it in a script.

This PR depends on #2648.

Fixes #56.