### PR TITLE
[bugfix] Pass explicitly the `--cpus-per-task` option to `srun` for Slurm >= 22.05

### DIFF
--- a/reframe/core/launchers/mpi.py
+++ b/reframe/core/launchers/mpi.py
@@ -17,7 +17,7 @@ from reframe.utility import seconds_to_hms
 class SrunLauncher(JobLauncher):
     def __init__(self):
         self.options = []
-        self.explicit_cpus_per_task = True
+        self.use_cpus_per_task = True
         try:
             out = osext.run_command('srun --version')
             match = re.search('slurm (\d+).(\d+).(\d+)', out.stdout)
@@ -31,14 +31,12 @@ class SrunLauncher(JobLauncher):
                     )
                 )
                 if slurm_version < semver.VersionInfo(22, 5, 0):
-                    self.explicit_cpus_per_task = False
-
+                    self.use_cpus_per_task = False
             else:
                 getlogger().warning(
                     'could not get version of Slurm, --cpus-per-task will be '
                     'set according to the num_cpus_per_task attribute'
                 )
-
         except Exception:
             getlogger().warning(
                 'could not get version of Slurm, --cpus-per-task will be set '
@@ -47,7 +45,7 @@ class SrunLauncher(JobLauncher):
 
     def command(self, job):
         ret = ['srun']
-        if self.explicit_cpus_per_task and job.num_cpus_per_task:
+        if self.use_cpus_per_task and job.num_cpus_per_task:
             ret.append(f'--cpus-per-task={job.num_cpus_per_task}')
 
         return ret

--- a/reframe/core/launchers/mpi.py
+++ b/reframe/core/launchers/mpi.py
@@ -20,7 +20,7 @@ class SrunLauncher(JobLauncher):
         self.explicit_cpus_per_task = True
         try:
             out = osext.run_command('srun --version')
-            match = re.search('slurm (\d+).0*(\d+).0*(\d+)', out.stdout)
+            match = re.search('slurm (\d+).(\d+).(\d+)', out.stdout)
             if match:
                 # We cannot pass to semver strings like 22.05.1 directly
                 # because it is not a valid version string for semver. We
@@ -48,7 +48,7 @@ class SrunLauncher(JobLauncher):
     def command(self, job):
         ret = ['srun']
         if self.explicit_cpus_per_task and job.num_cpus_per_task:
-            ret += [f'--cpus-per-task={job.num_cpus_per_task}']
+            ret.append(f'--cpus-per-task={job.num_cpus_per_task}')
 
         return ret
 

--- a/reframe/core/launchers/mpi.py
+++ b/reframe/core/launchers/mpi.py
@@ -12,8 +12,15 @@ from reframe.utility import seconds_to_hms
 class SrunLauncher(JobLauncher):
     def command(self, job):
         # For Slurm versions >= 22.05 the cpus per task need to be specified
-        # in the srun command
-        return ['srun', '--cpus-per-task=$SLURM_CPUS_PER_TASK']
+        # in the srun command. If SLURM_CPUS_PER_TASK is set to the empty
+        # string the command will fail so we have to put more logic in the
+        # command
+        return [
+            'if [ -v SLURM_CPUS_PER_TASK ];',
+            'then export SRUN_CPUS_PER_TASK=${SLURM_CPUS_PER_TASK};',
+            'fi;',
+            'srun'
+        ]
 
 
 @register_launcher('ibrun')

--- a/reframe/core/launchers/mpi.py
+++ b/reframe/core/launchers/mpi.py
@@ -20,7 +20,7 @@ class SrunLauncher(JobLauncher):
         self.use_cpus_per_task = True
         try:
             out = osext.run_command('srun --version')
-            match = re.search('slurm (\d+).(\d+).(\d+)', out.stdout)
+            match = re.search('slurm (\d+)\.(\d+)\.(\d+)', out.stdout)
             if match:
                 # We cannot pass to semver strings like 22.05.1 directly
                 # because it is not a valid version string for semver. We

--- a/reframe/core/launchers/mpi.py
+++ b/reframe/core/launchers/mpi.py
@@ -26,10 +26,13 @@ class SrunLauncher(JobLauncher):
                 # because it is not a valid version string for semver. We
                 # need to remove all the leading zeros.
                 slurm_version = (
-                    f'{match.group(1)}.{match.group(2)}.{match.group(3)}'
+                    semver.VersionInfo(
+                        match.group(1), match.group(2), match.group(3)
+                    )
                 )
-                if semver.compare(slurm_version, '22.5.0') < 0:
+                if slurm_version < semver.VersionInfo(22, 5, 0):
                     self.explicit_cpus_per_task = False
+
             else:
                 getlogger().warning(
                     'could not get version of Slurm, --cpus-per-task will be '

--- a/reframe/core/launchers/mpi.py
+++ b/reframe/core/launchers/mpi.py
@@ -11,7 +11,9 @@ from reframe.utility import seconds_to_hms
 @register_launcher('srun')
 class SrunLauncher(JobLauncher):
     def command(self, job):
-        return ['srun']
+        # For Slurm versions >= 22.05 the cpus per task need to be specified
+        # in the srun command
+        return ['srun', '--cpus-per-task=$SLURM_CPUS_PER_TASK']
 
 
 @register_launcher('ibrun')

--- a/unittests/test_launchers.py
+++ b/unittests/test_launchers.py
@@ -116,7 +116,7 @@ def test_run_command(job):
     elif launcher_name == 'mpirun':
         assert command == 'mpirun -np 4 --foo'
     elif launcher_name == 'srun':
-        assert command == 'srun --foo'
+        assert command == 'srun --cpus-per-task=$SLURM_CPUS_PER_TASK --foo'
     elif launcher_name == 'srunalloc':
         assert command == ('srun '
                            '--job-name=fake_job '
@@ -159,7 +159,7 @@ def test_run_command_minimal(minimal_job):
     elif launcher_name == 'mpirun':
         assert command == 'mpirun -np 1 --foo'
     elif launcher_name == 'srun':
-        assert command == 'srun --foo'
+        assert command == 'srun --cpus-per-task=$SLURM_CPUS_PER_TASK --foo'
     elif launcher_name == 'srunalloc':
         assert command == ('srun '
                            '--job-name=fake_job '

--- a/unittests/test_launchers.py
+++ b/unittests/test_launchers.py
@@ -116,11 +116,7 @@ def test_run_command(job):
     elif launcher_name == 'mpirun':
         assert command == 'mpirun -np 4 --foo'
     elif launcher_name == 'srun':
-        assert command == (
-            'if [ -v SLURM_CPUS_PER_TASK ]; '
-            'then export SRUN_CPUS_PER_TASK=${SLURM_CPUS_PER_TASK}; '
-            'fi; srun --foo'
-        )
+        assert command == 'srun --cpus-per-task=2 --foo'
     elif launcher_name == 'srunalloc':
         assert command == ('srun '
                            '--job-name=fake_job '
@@ -163,11 +159,7 @@ def test_run_command_minimal(minimal_job):
     elif launcher_name == 'mpirun':
         assert command == 'mpirun -np 1 --foo'
     elif launcher_name == 'srun':
-        assert command == (
-            'if [ -v SLURM_CPUS_PER_TASK ]; '
-            'then export SRUN_CPUS_PER_TASK=${SLURM_CPUS_PER_TASK}; '
-            'fi; srun --foo'
-        )
+        assert command == 'srun --foo'
     elif launcher_name == 'srunalloc':
         assert command == ('srun '
                            '--job-name=fake_job '

--- a/unittests/test_launchers.py
+++ b/unittests/test_launchers.py
@@ -104,6 +104,9 @@ def minimal_job(make_job, launcher):
 
 def test_run_command(job):
     launcher_name = type(job.launcher).registered_name
+    # This is relevant only for the srun launcher, because it may
+    # run in different platforms with older versions of Slurm
+    job.launcher.explicit_cpus_per_task = True
     command = job.launcher.run_command(job)
     if launcher_name == 'alps':
         assert command == 'aprun -n 4 -N 2 -d 2 -j 0 --foo'
@@ -147,6 +150,9 @@ def test_run_command(job):
 
 def test_run_command_minimal(minimal_job):
     launcher_name = type(minimal_job.launcher).registered_name
+    # This is relevant only for the srun launcher, because it may
+    # run in different platforms with older versions of Slurm
+    minimal_job.launcher.explicit_cpus_per_task = True
     command = minimal_job.launcher.run_command(minimal_job)
     if launcher_name == 'alps':
         assert command == 'aprun -n 1 --foo'

--- a/unittests/test_launchers.py
+++ b/unittests/test_launchers.py
@@ -106,7 +106,7 @@ def test_run_command(job):
     launcher_name = type(job.launcher).registered_name
     # This is relevant only for the srun launcher, because it may
     # run in different platforms with older versions of Slurm
-    job.launcher.explicit_cpus_per_task = True
+    job.launcher.use_cpus_per_task = True
     command = job.launcher.run_command(job)
     if launcher_name == 'alps':
         assert command == 'aprun -n 4 -N 2 -d 2 -j 0 --foo'
@@ -152,7 +152,7 @@ def test_run_command_minimal(minimal_job):
     launcher_name = type(minimal_job.launcher).registered_name
     # This is relevant only for the srun launcher, because it may
     # run in different platforms with older versions of Slurm
-    minimal_job.launcher.explicit_cpus_per_task = True
+    minimal_job.launcher.use_cpus_per_task = True
     command = minimal_job.launcher.run_command(minimal_job)
     if launcher_name == 'alps':
         assert command == 'aprun -n 1 --foo'

--- a/unittests/test_launchers.py
+++ b/unittests/test_launchers.py
@@ -116,7 +116,11 @@ def test_run_command(job):
     elif launcher_name == 'mpirun':
         assert command == 'mpirun -np 4 --foo'
     elif launcher_name == 'srun':
-        assert command == 'srun --cpus-per-task=$SLURM_CPUS_PER_TASK --foo'
+        assert command == (
+            'if [ -v SLURM_CPUS_PER_TASK ]; '
+            'then export SRUN_CPUS_PER_TASK=${SLURM_CPUS_PER_TASK}; '
+            'fi; srun --foo'
+        )
     elif launcher_name == 'srunalloc':
         assert command == ('srun '
                            '--job-name=fake_job '
@@ -159,7 +163,11 @@ def test_run_command_minimal(minimal_job):
     elif launcher_name == 'mpirun':
         assert command == 'mpirun -np 1 --foo'
     elif launcher_name == 'srun':
-        assert command == 'srun --cpus-per-task=$SLURM_CPUS_PER_TASK --foo'
+        assert command == (
+            'if [ -v SLURM_CPUS_PER_TASK ]; '
+            'then export SRUN_CPUS_PER_TASK=${SLURM_CPUS_PER_TASK}; '
+            'fi; srun --foo'
+        )
     elif launcher_name == 'srunalloc':
         assert command == ('srun '
                            '--job-name=fake_job '


### PR DESCRIPTION
For Slurm version >= 22.05 we pass explicitly `--cpus-per-task` to `srun` if `num_cpus_per_task` is set. For older versions we simply emit the `srun` command. If we cannot get the version of Slurm we also pass the option since it shouldn't hurt in theory for older versions.

Fixes #2655 .