### PR TITLE
[bugfix] Expand nodelist with the scontrol utility

### DIFF
--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -81,7 +81,10 @@ class _SlurmJob(sched.Job):
     def nodelist(self):
         # Redefine nodelist so as to generate it from the nodespec
         if self._nodelist is None and self._nodespec is not None:
-            self._nodelist = nodelist_expand(self._nodespec)
+            completed = osext.run_command(
+                f'scontrol show hostname {self._nodespec}', log=False
+            )
+            self._nodelist = completed.stdout.splitlines()
 
         return self._nodelist
 


### PR DESCRIPTION
To be honest I like a bit more the original solution of @rsarm , using the utility of scontrol instead of maintaining our own `nodelist_expand`. I did the minimum changes and haven't updated the unittests to discuss first what you think.

Fixes #2677