### PR TITLE
[bugfix] Fix injection of env variables for non default craype

### DIFF
--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -1036,7 +1036,7 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
         if rt.runtime().get_option('general/0/non_default_craype'):
             self._cdt_environ = Environment(
                 name='__rfm_cdt_environ',
-                variables={
+                env_vars={
                     'LD_LIBRARY_PATH': '$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH'
                 }
             )


### PR DESCRIPTION
This is a small bugfix, because currently all tests are skipped because of errors like this with `--non-default-craype`:
```bash
WARNING: skipping test 'MKLResolveTest': type error: __init__() got an unexpected keyword argument 'variables' (rerun with '-v' for more information)
Traceback (most recent call last):
  File "/users/eirinik/repos/reframe/reframe/core/decorators.py", line 74, in instantiate_all
    leaf_tests.append(test(*args, **kwargs))
  File "/users/eirinik/repos/reframe/reframe/core/meta.py", line 439, in __call__
    obj.__init__(*args, **kwargs)
  File "/users/eirinik/repos/reframe/reframe/core/hooks.py", line 97, in _fn
    getattr(obj, h.__name__)()
  File "/users/eirinik/repos/reframe/reframe/core/pipeline.py", line 972, in __pre_init__
    self.__deferred_rfm_init.evaluate()
  File "/users/eirinik/repos/reframe/reframe/core/deferrable.py", line 73, in evaluate
    ret = self._fn(*fn_args, **fn_kwargs)
  File "/users/eirinik/repos/reframe/reframe/core/pipeline.py", line 1040, in __rfm_init__
    'LD_LIBRARY_PATH': '$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH'
TypeError: __init__() got an unexpected keyword argument 'variables'
```