### PR TITLE
[bugfix] Do not require `handlers$` in the logging config

### DIFF
--- a/reframe/core/config.py
+++ b/reframe/core/config.py
@@ -571,7 +571,12 @@ class _SiteConfig:
                         f"for system '{system_fullname}'"
                     )
 
-        # Verify that all environments defined by the system are defined for
+        # Check that handlers$ are defined for the current system
+        if 'handlers$' not in local_config['logging'][0]:
+            raise ConfigError(f"'logging/handlers$' are not defined "
+                              f"for system {system_fullname!r}")
+
+        # Check that all environments defined by the system are defined for
         # the current system
         if not ignore_resolve_errors:
             sys_environs = {

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -451,7 +451,6 @@
                     },
                     "target_systems": {"$ref": "#/defs/system_ref"}
                 },
-                "required": ["handlers$"],
                 "additionalProperties": false
             }
         },

--- a/unittests/test_config.py
+++ b/unittests/test_config.py
@@ -207,6 +207,14 @@ def test_select_subconfig_ignore_no_section_errors():
     site_config.select_subconfig(ignore_resolve_errors=True)
 
 
+def test_select_subconfig_empty_logging():
+    site_config = config.load_config('reframe/core/settings.py')
+    site_config['logging'][0] = {}
+    with pytest.raises(ConfigError,
+                       match=rf"'logging/handlers\$' are not defined"):
+        site_config.select_subconfig()
+
+
 def test_select_subconfig(site_config):
     site_config.select_subconfig('testsys')
     assert len(site_config['systems']) == 1


### PR DESCRIPTION
This allows config files to define logging partially for specific systems and inherit its value from the builtin config.