### PR TITLE
[feat] Add ability to specify number of nodes for slurm scheduler

### DIFF
--- a/docs/regression_test_api.rst
+++ b/docs/regression_test_api.rst
@@ -335,6 +335,7 @@ Mapping of Test Attributes to Job Scheduler Backends
    Test attribute               Slurm option                  Torque option                                                                              PBS option
    ============================ ============================= ========================================================================================== ==================
    :attr:`num_tasks`            :obj:`--ntasks`:sup:`1`       :obj:`-l nodes={num_tasks//num_tasks_per_node}:ppn={num_tasks_per_node*num_cpus_per_task}` :obj:`-l select={num_tasks//num_tasks_per_node}:mpiprocs={num_tasks_per_node}:ncpus={num_tasks_per_node*num_cpus_per_task}`
+   :attr:`num_nodes`            :obj:`--nodes`                n/a                                                                                        n/a
    :attr:`num_tasks_per_node`   :obj:`--ntasks-per-node`      see :attr:`num_tasks`                                                                      see :attr:`num_tasks`
    :attr:`num_tasks_per_core`   :obj:`--ntasks-per-core`      n/a                                                                                        n/a
    :attr:`num_tasks_per_socket` :obj:`--ntasks-per-socket`    n/a                                                                                        n/a

--- a/reframe/core/launchers/mpi.py
+++ b/reframe/core/launchers/mpi.py
@@ -134,6 +134,9 @@ class SrunAllocationLauncher(JobLauncher):
 
         if job.num_tasks:
             ret += ['--ntasks=%s' % str(job.num_tasks)]
+        
+        if job.num_nodes:
+            ret += ['--nodes=%s' % str(job.num_nodes)]
 
         if job.num_tasks_per_node:
             ret += ['--ntasks-per-node=%s' % str(job.num_tasks_per_node)]

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -541,7 +541,20 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #:
     #: .. |--flex-alloc-nodes| replace:: :attr:`--flex-alloc-nodes`
     #: .. _--flex-alloc-nodes: manpage.html#cmdoption-flex-alloc-nodes
-    num_tasks = variable(int, value=1, loggable=True)
+    num_tasks = variable(int,type(None), value=1, loggable=True)
+
+
+    #: Number of nodes for this job.
+    #:
+    #: :type: integral
+    #: :default: ``None``
+    #:
+    #: .. note::
+    #:    This attribute is set by the framework just before submitting the job
+    #:    based on the test information.
+    #:
+    #: .. versionadded:: 3.11.0
+    num_nodes = variable(int, type(None), value=None)
 
     #: Number of tasks per node required by this test.
     #:
@@ -1872,6 +1885,7 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
                 )
 
         self.job.num_tasks = self.num_tasks
+        self.job.num_nodes=self.num_nodes
         self.job.num_tasks_per_node = self.num_tasks_per_node
         self.job.num_tasks_per_core = self.num_tasks_per_core
         self.job.num_tasks_per_socket = self.num_tasks_per_socket

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -554,7 +554,7 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #:    based on the test information.
     #:
     #: .. versionadded:: 3.11.0
-    num_nodes = variable(int, type(None), value=None)
+    num_nodes = variable(int, type(None), value=None,loggable=True)
 
     #: Number of tasks per node required by this test.
     #:

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -527,8 +527,9 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #: :attr:`num_tasks` to ``0`` is equivalent to setting it to
     #: :attr:`-num_tasks_per_node
     #: <reframe.core.pipeline.RegressionTest.num_tasks_per_node>`.
+    #: If set to :attr:`None` it will be omitted from any job scripts created and when combined with :attr:`num_nodes` this will allow a more flexible number of tasks to be run.
     #:
-    #: :type: integral
+    #: :type: integral or :class:`None`
     #: :default: ``1``
     #:
     #: .. note::
@@ -546,14 +547,10 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
 
     #: Number of nodes for this job.
     #:
-    #: :type: integral
+    #: :type: integral or :class:`None`
     #: :default: ``None``
     #:
-    #: .. note::
-    #:    This attribute is set by the framework just before submitting the job
-    #:    based on the test information.
     #:
-    #: .. versionadded:: 3.11.0
     num_nodes = variable(int, type(None), value=None,loggable=True)
 
     #: Number of tasks per node required by this test.

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -1882,7 +1882,7 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
                 )
 
         self.job.num_tasks = self.num_tasks
-        self.job.num_nodes=self.num_nodes
+        self.job.num_nodes = self.num_nodes
         self.job.num_tasks_per_node = self.num_tasks_per_node
         self.job.num_tasks_per_core = self.num_tasks_per_core
         self.job.num_tasks_per_socket = self.num_tasks_per_socket

--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -152,7 +152,7 @@ class Job(jsonext.JSONSerializable, metaclass=JobMeta):
     #:    based on the test information.
     #:
     #: .. versionadded:: 3.11.0
-    num_nodes = variable(int, type(None), value=1)
+    num_nodes = variable(int, type(None), value=None)
 
     #: Number of tasks per node for this job.
     #:

--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -138,7 +138,21 @@ class Job(jsonext.JSONSerializable, metaclass=JobMeta):
     #:    based on the test information.
     #:
     #: .. versionadded:: 3.11.0
-    num_tasks = variable(int, value=1)
+    num_tasks = variable(int, type(None), value=1)
+
+
+
+    #: Number of nodes for this job.
+    #:
+    #: :type: integral
+    #: :default: ``None``
+    #:
+    #: .. note::
+    #:    This attribute is set by the framework just before submitting the job
+    #:    based on the test information.
+    #:
+    #: .. versionadded:: 3.11.0
+    num_nodes = variable(int, type(None), value=1)
 
     #: Number of tasks per node for this job.
     #:
@@ -461,7 +475,7 @@ class Job(jsonext.JSONSerializable, metaclass=JobMeta):
 
     def prepare(self, commands, environs=None, prepare_cmds=None, **gen_opts):
         environs = environs or []
-        if self.num_tasks <= 0:
+        if self.num_tasks!=None and self.num_tasks <= 0:
             getlogger().debug(f'[F] Flexible node allocation requested')
             num_tasks_per_node = self.num_tasks_per_node or 1
             min_num_tasks = (-self.num_tasks if self.num_tasks else

--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -144,14 +144,10 @@ class Job(jsonext.JSONSerializable, metaclass=JobMeta):
 
     #: Number of nodes for this job.
     #:
-    #: :type: integral
+    #: :type: integral or :class:`None`
     #: :default: ``None``
     #:
-    #: .. note::
-    #:    This attribute is set by the framework just before submitting the job
-    #:    based on the test information.
     #:
-    #: .. versionadded:: 3.11.0
     num_nodes = variable(int, type(None), value=None)
 
     #: Number of tasks per node for this job.

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -174,7 +174,6 @@ class SlurmJobScheduler(sched.JobScheduler):
 
         # WIP: If ntasks is found to be none and a number of nodes are requested, then assume the desire is to fill the whole node
         # if this is not true then omit the explicit request of any nodes and allow reframe / slurm to calculate that the default way
-        print(job.num_tasks,job.num_nodes)
         if job.num_tasks==None and job.num_nodes!=None:
             preamble.append(self._format_option(job.num_nodes, '--nodes={0}'))
         else:

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -200,7 +200,7 @@ class SlurmJobScheduler(sched.JobScheduler):
                 self._format_option(job.exclusive_access, '--exclusive')
             )
 
-        if self._use_nodes_opt:
+        if self._use_nodes_opt and job.num_nodes==None:
             num_nodes = job.num_tasks // job.num_tasks_per_node
             preamble.append(self._format_option(num_nodes, '--nodes={0}'))
 

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -174,10 +174,9 @@ class SlurmJobScheduler(sched.JobScheduler):
 
         # WIP: If ntasks is found to be none and a number of nodes are requested, then assume the desire is to fill the whole node
         # if this is not true then omit the explicit request of any nodes and allow reframe / slurm to calculate that the default way
-        if job.num_tasks==None and job.num_nodes!=None:
-            preamble.append(self._format_option(job.num_nodes, '--nodes={0}'))
-        else:
-            preamble.append(self._format_option(job.num_tasks, '--ntasks={0}'))
+
+        preamble.append(self._format_option(job.num_nodes, '--nodes={0}'))
+        preamble.append(self._format_option(job.num_tasks, '--ntasks={0}'))
             
 
 

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -159,9 +159,9 @@ class SlurmJobScheduler(sched.JobScheduler):
             return ''
 
     def emit_preamble(self, job):
-
         preamble = [
             self._format_option(job.name, '--job-name="{0}"'),
+            self._format_option(job.num_tasks, '--ntasks={0}'),
             self._format_option(job.num_tasks_per_node,
                                 '--ntasks-per-node={0}'),
             self._format_option(job.num_tasks_per_core,
@@ -169,16 +169,8 @@ class SlurmJobScheduler(sched.JobScheduler):
             self._format_option(job.num_tasks_per_socket,
                                 '--ntasks-per-socket={0}'),
             self._format_option(job.num_cpus_per_task, '--cpus-per-task={0}'),
-            
+            self._format_option(job.num_nodes, '--nodes={0}')
         ]
-
-        # WIP: If ntasks is found to be none and a number of nodes are requested, then assume the desire is to fill the whole node
-        # if this is not true then omit the explicit request of any nodes and allow reframe / slurm to calculate that the default way
-
-        preamble.append(self._format_option(job.num_nodes, '--nodes={0}'))
-        preamble.append(self._format_option(job.num_tasks, '--ntasks={0}'))
-            
-
 
         # Determine if job refers to a Slurm job array, by looking into the
         # job.options and job.cli_options

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -162,7 +162,6 @@ class SlurmJobScheduler(sched.JobScheduler):
 
         preamble = [
             self._format_option(job.name, '--job-name="{0}"'),
-            self._format_option(job.num_tasks, '--ntasks={0}'),
             self._format_option(job.num_tasks_per_node,
                                 '--ntasks-per-node={0}'),
             self._format_option(job.num_tasks_per_core,

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -159,6 +159,7 @@ class SlurmJobScheduler(sched.JobScheduler):
             return ''
 
     def emit_preamble(self, job):
+
         preamble = [
             self._format_option(job.name, '--job-name="{0}"'),
             self._format_option(job.num_tasks, '--ntasks={0}'),
@@ -169,7 +170,18 @@ class SlurmJobScheduler(sched.JobScheduler):
             self._format_option(job.num_tasks_per_socket,
                                 '--ntasks-per-socket={0}'),
             self._format_option(job.num_cpus_per_task, '--cpus-per-task={0}'),
+            
         ]
+
+        # WIP: If ntasks is found to be none and a number of nodes are requested, then assume the desire is to fill the whole node
+        # if this is not true then omit the explicit request of any nodes and allow reframe / slurm to calculate that the default way
+        print(job.num_tasks,job.num_nodes)
+        if job.num_tasks==None and job.num_nodes!=None:
+            preamble.append(self._format_option(job.num_nodes, '--nodes={0}'))
+        else:
+            preamble.append(self._format_option(job.num_tasks, '--ntasks={0}'))
+            
+
 
         # Determine if job refers to a Slurm job array, by looking into the
         # job.options and job.cli_options


### PR DESCRIPTION
I believe that being able to explicitly ask for a number of nodes would be a useful feature, especially where the same set of tests are reused between clusters and partitions. This should give the ability to request full nodes from the Slurm scheduler without having to be explicit about how many tasks to run with, or how many cores the node has.

Helps solve some of the issues mentioned in #2093 