### PR TITLE
[ci] Add support for Python 3.11 and update CI workflow for Python 3.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,17 +34,22 @@ jobs:
         fail_ci_if_error: true
 
   unittest-py36:
-    runs-on: ubuntu-latest
-    permissions:
-      packages: read
-    container:
-      image: "reframehpc/rfm-ci-ubuntu-py36:latest"
-      options: "--platform=linux/amd64 --user root -it --init"
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        python-version: ['3.6']
     steps:
-      - name: Run Python 3.6 unit tests
-        run: |
-          cd /reframe
-          ./test_reframe.py -v
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        ./bootstrap.sh
+    - name: Generic Unittests
+      run: |
+        ./test_reframe.py
 
   unittest-macos:
     runs-on: macos-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -32,6 +32,19 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         fail_ci_if_error: true
+
+  unittest-py36:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: read
+    container:
+      image: "reframehpc/rfm-ci-ubuntu-py36:latest"
+      options: "--platform=linux/amd64 --user root -it --init"
+    steps:
+      - name: Run Python 3.6 unit tests
+        run: |
+          cd /reframe
+          ./test_reframe.py -v
 
   unittest-macos:
     runs-on: macos-latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     License :: OSI Approved :: BSD License
     Operating System :: MacOS
     Operating System :: POSIX :: Linux


### PR DESCRIPTION
We need to use an older container to test python 3.6 now, as the Github action with `ubuntu-latest` does not include it.