### PR TITLE
[bugfix] Properly set display name of tests with join fixtures

### DIFF
--- a/reframe/core/meta.py
+++ b/reframe/core/meta.py
@@ -433,7 +433,8 @@ class RegressionTestMeta(type):
         # the init phase
         varinfo = cls.get_variant_info(variant_num, recurse=True)
         for fname, finfo in varinfo['fixtures'].items():
-            if not isinstance(finfo, tuple):
+            fixt = cls.fixture_space[fname]
+            if fixt.action != 'join':
                 setattr(obj, fname, fixtures.FixtureProxy(finfo))
 
         obj.__init__(*args, **kwargs)

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -1149,11 +1149,10 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
                 name += f'{prefix}{p}={format_fn(v)}'
 
             for f, v in info['fixtures'].items():
-                if isinstance(v, tuple):
-                    # This is join fixture
+                fixt = cls.fixture_space[f]
+                if fixt.action == 'join':
                     continue
 
-                fixt = cls.fixture_space[f]
                 name += _format_params(fixt.cls, v, f'{prefix}{f}.')
 
                 # Append any variables set for the fixtures

--- a/unittests/test_fixtures.py
+++ b/unittests/test_fixtures.py
@@ -202,7 +202,6 @@ def test_fixture_early_access():
 
     class Bar(rfm.RegressionTest):
         f = fixture(FooB, variables={'z': 5})
-        w = fixture(FooB, action='join')
 
         valid_systems = ['*']
         valid_prog_environs = ['*']
@@ -211,7 +210,6 @@ def test_fixture_early_access():
         def early_access(self):
             assert self.f.foo.x == 1
             assert self.f.y == 2
-            assert self.w.y == 2
 
     Bar(variant_num=0)
 


### PR DESCRIPTION
If a test had a join fixture over a parameterised test, whose parameterisation space is a single point only, ReFrame will erroneously include the fixture's parameter name in the display name of the test that is using it. This is not correct as tests with join fixtures do not inherit the fixture parameters. This bug was due to how `display_name` was checking if a fixture was a join or not; it was relying on the `get_variant_info()` information, which encodes the fixture space as a tuple only if it has more than two points. We instead use a much more robust check by checking directly the `action` of the fixture instance. The same bug was present also when constructing the `FixtureProxy` to allow early access to fixtures. Early access to join fixtures is not allowed, but the current implementation was giving access to join fixtures with a single point fixture space.

This is an example to demonstrate the display name before and after. Given the following test:

```python
class X(rfm.RunOnlyRegressionTest):
    p = parameter([1])


@rfm.simple_test
class mytest(rfm.RunOnlyRegressionTest):
    valid_systems = ['*']
    valid_prog_environs = ['*']
    f = fixture(X, scope='session', action='join')
```

This lists `mytest` as follows if `p` has a single value:

```
- mytest %f.p=1 /f68d27da
    ^X %p=1 ~generic /2a18b33e
```

But if `p` has more than two values, then this is how it is displayed:

```
- mytest /f68d27da
    ^X %p=2 ~generic /d1dd186c
    ^X %p=1 ~generic /2a18b33e
```

This PR fixes the first case and now the display name is as expected:

```
- mytest /f68d27da
    ^X %p=1 ~generic /2a18b33e
```
