### PR TITLE
[feat] Update `temp_environment` to use `env_vars`  as an argument

### DIFF
--- a/reframe/core/runtime.py
+++ b/reframe/core/runtime.py
@@ -377,13 +377,13 @@ def valid_sysenv_comb(valid_systems, valid_prog_environs,
 class temp_environment:
     '''Context manager to temporarily change the environment.'''
 
-    def __init__(self, modules=[], variables=[]):
-        self._modules = modules
-        self._variables = variables
+    def __init__(self, modules=None, env_vars=None):
+        self._modules = modules or []
+        self._env_vars = env_vars or {}
 
     def __enter__(self):
         new_env = Environment('_rfm_temp_env', self._modules,
-                              self._variables.items())
+                              self._env_vars.items())
         self._environ_save, _ = loadenv(new_env)
         return new_env
 

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -418,7 +418,7 @@ class SlurmJobScheduler(sched.JobScheduler):
         if not jobs:
             return
 
-        with rt.temp_environment(variables={'SLURM_TIME_FORMAT': '%s'}):
+        with rt.temp_environment(env_vars={'SLURM_TIME_FORMAT': '%s'}):
             t_start = time.strftime(
                 '%F', time.localtime(min(job.submit_time for job in jobs))
             )

--- a/reframe/frontend/autodetect.py
+++ b/reframe/frontend/autodetect.py
@@ -237,12 +237,12 @@ def detect_topology():
                 vars.update(part.local_env.env_vars)
 
                 # Unconditionally detect the system for fully local partitions
-                with runtime.temp_environment(modules=modules, variables=vars):
+                with runtime.temp_environment(modules=modules, env_vars=vars):
                     part._processor = ProcessorInfo(cpuinfo())
 
                 _save_info(topo_file, part.processor.info)
             elif detect_remote_systems:
-                with runtime.temp_environment(modules=modules, variables=vars):
+                with runtime.temp_environment(modules=modules, env_vars=vars):
                     part._processor = ProcessorInfo(_remote_detect(part))
 
                 if part.processor.info:

--- a/unittests/test_argparser.py
+++ b/unittests/test_argparser.py
@@ -140,7 +140,7 @@ def extended_parser():
 
 
 def test_option_precedence(default_exec_ctx, extended_parser):
-    with rt.temp_environment(variables={
+    with rt.temp_environment(env_vars={
             'RFM_TIMESTAMP': '%F',
             'RFM_NON_DEFAULT_CRAYPE': 'yes',
             'RFM_MODULES_PRELOAD': 'a,b,c',
@@ -162,7 +162,7 @@ def test_option_precedence(default_exec_ctx, extended_parser):
 
 
 def test_option_with_config(default_exec_ctx, extended_parser, tmp_path):
-    with rt.temp_environment(variables={
+    with rt.temp_environment(env_vars={
             'RFM_TIMESTAMP': '%F',
             'RFM_NON_DEFAULT_CRAYPE': 'yes',
             'RFM_MODULES_PRELOAD': 'a,b,c',
@@ -187,7 +187,7 @@ def test_option_with_config(default_exec_ctx, extended_parser, tmp_path):
 
 
 def test_option_envvar_conversion_error(default_exec_ctx, extended_parser):
-    with rt.temp_environment(variables={
+    with rt.temp_environment(env_vars={
             'RFM_NON_DEFAULT_CRAYPE': 'foo',
             'RFM_GIT_TIMEOUT': 'non-float'
     }):
@@ -198,7 +198,7 @@ def test_option_envvar_conversion_error(default_exec_ctx, extended_parser):
 
 
 def test_envvar_option(default_exec_ctx, extended_parser):
-    with rt.temp_environment(variables={'RFM_ENV_OPT': 'BAR'}):
+    with rt.temp_environment(env_vars={'RFM_ENV_OPT': 'BAR'}):
         options = extended_parser.parse_args([])
         assert options.env_option == 'BAR'
 


### PR DESCRIPTION
This is a leftover from the change of `variables` to `env_vars`.