### PR TITLE
[bugfix] Fix hash clashes for parameterised tests

### DIFF
--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -1194,7 +1194,7 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
             return self._rfm_hashcode
 
         m = hashlib.sha256()
-        if self.is_fixture:
+        if self.is_fixture():
             m.update(self.unique_name.encode('utf-8'))
         else:
             basename, *params = self.display_name.split(' %')

--- a/unittests/test_filters.py
+++ b/unittests/test_filters.py
@@ -83,7 +83,9 @@ def test_have_any_name_param_test(sample_param_cases):
                              sample_param_cases)
     assert 0 == count_checks(filters.have_any_name(['_X@12']),
                              sample_param_cases)
-    assert 2 == count_checks(filters.have_any_name(['/023313dc', '/efddbc6c']),
+
+    # The /0951c7ff selects two tests as they both have x=1
+    assert 3 == count_checks(filters.have_any_name(['/0951c7ff', '/37e9e1c6']),
                              sample_param_cases)
     assert 2 == count_checks(filters.have_any_name(['_X@0', '_X@1']),
                              sample_param_cases)

--- a/unittests/test_pipeline.py
+++ b/unittests/test_pipeline.py
@@ -1902,6 +1902,33 @@ def test_set_var_default():
     assert x.bar == 100
 
 
+def test_hashcode():
+    # We always redefine _X0 here so that the test gets always the same base
+    # name (class name) and only the parameter values should change. We then
+    # use aliases to access the various definitions for our assertions.
+
+    class _X0(rfm.RunOnlyRegressionTest):
+        p = parameter([1])
+
+    class _X0(rfm.RunOnlyRegressionTest):
+        p = parameter([2])
+
+    _X1 = _X0
+
+    class _X0(rfm.RunOnlyRegressionTest):
+        p = parameter([1, 2])
+
+    _X2 = _X0
+
+    t0 = _X0(variant_num=0)
+    t1 = _X1(variant_num=0)
+    t2, t3 = (_X2(variant_num=i) for i in range(_X2.num_variants))
+
+    assert t0.hashcode != t1.hashcode
+    assert t2.hashcode == t0.hashcode
+    assert t3.hashcode == t1.hashcode
+
+
 def test_variables_deprecation():
     with pytest.warns(ReframeDeprecationWarning):
         class _X(rfm.RunOnlyRegressionTest):


### PR DESCRIPTION
While I was working with parameterised tests, I noticed some hash clashes, where a test with a single parameter value was being assigned the same hash even if the parameter value changed. It turned out the bug was a missing `()` ! The `hashcode`  property was treating `is_fixture` as a property instead of a function, so the test was always returning true, thus the has was actually being computed based on the test's unique name and not based on its display name... I've added a unit test to avoid that from happening again.