### PR TITLE
[bugfix] Fix cleanup crash for non-performance tests when the `perflog_compat` option is on

### DIFF
--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -735,15 +735,16 @@ class LoggerAdapter(logging.LoggerAdapter):
         if multiline:
             # Log one record for each performance variable
             check = self.extra['__rfm_check__']
-            for var, info in check.perfvalues.items():
-                val, ref, lower, upper, unit = info
-                self.extra['check_perf_var'] = var.split(':')[-1]
-                self.extra['check_perf_value'] = val
-                self.extra['check_perf_ref'] = ref
-                self.extra['check_perf_lower_thres'] = lower
-                self.extra['check_perf_upper_thres'] = upper
-                self.extra['check_perf_unit'] = unit
-                self.log(level, msg)
+            if check:
+                for var, info in check.perfvalues.items():
+                    val, ref, lower, upper, unit = info
+                    self.extra['check_perf_var'] = var.split(':')[-1]
+                    self.extra['check_perf_value'] = val
+                    self.extra['check_perf_ref'] = ref
+                    self.extra['check_perf_lower_thres'] = lower
+                    self.extra['check_perf_upper_thres'] = upper
+                    self.extra['check_perf_unit'] = unit
+                    self.log(level, msg)
         else:
             self.log(level, msg)
 

--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -735,16 +735,15 @@ class LoggerAdapter(logging.LoggerAdapter):
         if multiline:
             # Log one record for each performance variable
             check = self.extra['__rfm_check__']
-            if check:
-                for var, info in check.perfvalues.items():
-                    val, ref, lower, upper, unit = info
-                    self.extra['check_perf_var'] = var.split(':')[-1]
-                    self.extra['check_perf_value'] = val
-                    self.extra['check_perf_ref'] = ref
-                    self.extra['check_perf_lower_thres'] = lower
-                    self.extra['check_perf_upper_thres'] = upper
-                    self.extra['check_perf_unit'] = unit
-                    self.log(level, msg)
+            for var, info in check.perfvalues.items():
+                val, ref, lower, upper, unit = info
+                self.extra['check_perf_var'] = var.split(':')[-1]
+                self.extra['check_perf_value'] = val
+                self.extra['check_perf_ref'] = ref
+                self.extra['check_perf_lower_thres'] = lower
+                self.extra['check_perf_upper_thres'] = upper
+                self.extra['check_perf_unit'] = unit
+                self.log(level, msg)
         else:
             self.log(level, msg)
 

--- a/reframe/frontend/executors/__init__.py
+++ b/reframe/frontend/executors/__init__.py
@@ -386,8 +386,9 @@ class RegressionTask:
 
         self._current_stage = 'finalize'
         self._notify_listeners('on_task_success')
-        self._perflogger.log_performance(logging.INFO, self,
-                                         multiline=self._perflog_compat)
+        if self.check.is_performance_check():
+            self._perflogger.log_performance(logging.INFO, self,
+                                             multiline=self._perflog_compat)
 
     @logging.time_function
     def cleanup(self, *args, **kwargs):
@@ -397,8 +398,9 @@ class RegressionTask:
         self._failed_stage = self._current_stage
         self._exc_info = exc_info or sys.exc_info()
         self._notify_listeners('on_task_failure')
-        self._perflogger.log_performance(logging.INFO, self,
-                                         multiline=self._perflog_compat)
+        if self.check.is_performance_check():
+            self._perflogger.log_performance(logging.INFO, self,
+                                             multiline=self._perflog_compat)
 
     def skip(self, exc_info=None):
         self._skipped = True

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -990,6 +990,20 @@ def perf_test():
 
 
 @pytest.fixture
+def simple_test():
+    class _MySimpleTest(rfm.RunOnlyRegressionTest):
+        valid_systems = ['*']
+        valid_prog_environs = ['*']
+        executable = 'echo hello'
+
+        @sanity_function
+        def validate(self):
+            return sn.assert_found(r'hello', self.stdout)
+
+    return _MySimpleTest()
+
+
+@pytest.fixture
 def config_perflog(make_config_file):
     def _config_perflog(fmt, perffmt=None, logging_opts=None):
         logging_config = {
@@ -1178,7 +1192,7 @@ def test_perf_logging_no_perfvars(make_runner, make_exec_ctx, perf_test,
 
 
 def test_perf_logging_multiline(make_runner, make_exec_ctx, perf_test,
-                                config_perflog, tmp_path):
+                                simple_test, config_perflog, tmp_path):
     make_exec_ctx(
         config_perflog(
             fmt=(
@@ -1193,7 +1207,7 @@ def test_perf_logging_multiline(make_runner, make_exec_ctx, perf_test,
     )
     logging.configure_logging(rt.runtime().site_config)
     runner = make_runner()
-    testcases = executors.generate_testcases([perf_test])
+    testcases = executors.generate_testcases([perf_test, simple_test])
     runner.runall(testcases)
 
     logfile = tmp_path / 'perflogs' / 'generic' / 'default' / '_MyTest.log'


### PR DESCRIPTION
This is first attempt to fix the bug, but maybe we should investigate more:
1. how to handle errors in `log_performance`. It's not a good idea to completely suppress them, because the error that ReFrame gives in this case can be very confusing
2. if it's correct to have `check == None` for non-performance tests

Fixes #2715 .