### PR TITLE
[bugfix] Add MANIFEST.in to include the README_minimal.md

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README_minimal.md


### PR DESCRIPTION
Signed-off-by: Theofilos Manitaras <manitaras@cscs.ch>

A file not following the README.* pattern is not included in the build dists and therefore the `long_description` remains empty.

Fixes #2730 