### PR TITLE
[feat] Relax the regex matching for test names and tags

### DIFF
--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -96,6 +96,11 @@ This happens recursively so that if test ``T1`` depends on ``T2`` and ``T2`` dep
 
    .. versionadded:: 3.9.1
 
+   .. versionchanged:: 4.1.0
+
+      The ``MAINTAINER`` pattern is matched anywhere in the maintainer's name and not at its beginning.
+      If you want to match at the beginning of the name, you should prepend ``^``.
+
 .. option:: -n, --name=NAME
 
    Filter tests by name.
@@ -125,6 +130,11 @@ This happens recursively so that if test ``T1`` depends on ``T2`` and ``T2`` dep
    .. versionchanged:: 4.0.0
 
       Support selecting tests by their hash code.
+
+   .. versionchanged:: 4.1.0
+
+      The ``NAME`` pattern is matched anywhere in the test name and not at its beginning.
+      If you want to match at the beginning of a test name, you should prepend ``^``.
 
 
 .. option:: -p, --prgenv=NAME
@@ -158,6 +168,11 @@ This happens recursively so that if test ``T1`` depends on ``T2`` and ``T2`` dep
    This option may be specified multiple times, in which case tests with *any* of the specified tags will be excluded:
    ``-T TAG1 -T TAG2`` is therefore equivalent to ``-T 'TAG1|TAG2'``.
 
+   .. versionchanged:: 4.1.0
+
+      The ``TAG`` pattern is matched anywhere in the tag name and not at its beginning.
+      If you want to match at the beginning of a tag, you should prepend ``^``.
+
 .. option:: -t, --tag=TAG
 
    Filter tests by tag.
@@ -167,6 +182,11 @@ This happens recursively so that if test ``T1`` depends on ``T2`` and ``T2`` dep
    To restrict the selection to tests defining only ``'foo'``, you should use ``-t 'foo$'``.
 
    This option may be specified multiple times, in which case only tests defining or matching *all* tags will be selected.
+
+   .. versionchanged:: 4.1.0
+
+      The ``TAG`` pattern is matched anywhere in the tag name and not at its beginning.
+      If you want to match at the beginning of a tag, you should prepend ``^``.
 
 .. option:: -x, --exclude=NAME
 
@@ -178,6 +198,10 @@ This happens recursively so that if test ``T1`` depends on ``T2`` and ``T2`` dep
    This option may be specified multiple times, in which case tests with *any* of the specified names will be excluded:
    ``-x NAME1 -x NAME2`` is therefore equivalent to ``-x 'NAME1|NAME2'``.
 
+   .. versionchanged:: 4.1.0
+
+      The ``NAME`` pattern is matched anywhere in the test name and not at its beginning.
+      If you want to match at the beginning of a test name, you should prepend ``^``.
 
 ------------
 Test actions

--- a/reframe/frontend/filters.py
+++ b/reframe/frontend/filters.py
@@ -30,7 +30,7 @@ def _have_name(patt):
             # Do an exact match on the hashcode
             return patt[1:] == case.check.hashcode
         else:
-            return regex.match(display_name)
+            return regex.search(display_name)
 
     return _fn
 
@@ -76,7 +76,7 @@ def have_any_name(names):
 
         display_name = case.check.display_name.replace(' ', '')
         if regex:
-            return regex.match(display_name)
+            return regex.search(display_name)
 
         return False
 
@@ -87,7 +87,7 @@ def have_tag(patt):
     regex = re_compile(patt)
 
     def _fn(case):
-        return any(regex.match(p) for p in case.check.tags)
+        return any(regex.search(p) for p in case.check.tags)
 
     return _fn
 
@@ -103,7 +103,7 @@ def have_maintainer(patt):
     regex = re_compile(patt)
 
     def _fn(case):
-        return any(regex.match(p) for p in case.check.maintainers)
+        return any(regex.search(p) for p in case.check.maintainers)
 
     return _fn
 

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -834,7 +834,7 @@ def test_maxfail_negative(run_reframe):
 
 def test_repeat_option(run_reframe):
     returncode, stdout, stderr = run_reframe(
-        more_options=['--repeat', '2', '-n', 'HelloTest'],
+        more_options=['--repeat', '2', '-n', '^HelloTest'],
         checkpath=['unittests/resources/checks/hellocheck.py']
     )
     assert 'Traceback' not in stdout
@@ -877,7 +877,7 @@ def test_exec_order(run_reframe, exec_order):
     import reframe.utility.sanity as sn
 
     returncode, stdout, stderr = run_reframe(
-        more_options=['--repeat', '11', '-n', 'HelloTest',
+        more_options=['--repeat', '11', '-n', '^HelloTest',
                       f'--exec-order={exec_order}'],
         checkpath=['unittests/resources/checks/hellocheck.py'],
         action='list_detailed',
@@ -973,7 +973,7 @@ def test_fixture_registry_env_sys(run_reframe):
         system='sys1:p0',
         environs=['e3'],
         checkpath=['unittests/resources/checks_unlisted/fixtures_simple.py'],
-        more_options=['-n', 'HelloFixture'],
+        more_options=['-n', '^HelloFixture'],
         action='list_detailed'
     )
     assert returncode == 0
@@ -983,7 +983,7 @@ def test_fixture_registry_env_sys(run_reframe):
         system='sys1:p0',
         environs=['e1'],
         checkpath=['unittests/resources/checks_unlisted/fixtures_simple.py'],
-        more_options=['-n', 'HelloFixture'],
+        more_options=['-n', '^HelloFixture'],
         action='list_detailed'
     )
     assert returncode == 0
@@ -993,7 +993,7 @@ def test_fixture_registry_env_sys(run_reframe):
         system='sys1:p1',
         environs=['e1'],
         checkpath=['unittests/resources/checks_unlisted/fixtures_simple.py'],
-        more_options=['-n', 'HelloFixture'],
+        more_options=['-n', '^HelloFixture'],
         action='list_detailed'
     )
     assert returncode == 0
@@ -1003,7 +1003,7 @@ def test_fixture_registry_env_sys(run_reframe):
         system='sys1:p1',
         environs=['e2'],
         checkpath=['unittests/resources/checks_unlisted/fixtures_simple.py'],
-        more_options=['-n', 'HelloFixture'],
+        more_options=['-n', '^HelloFixture'],
         action='list_detailed'
     )
     assert returncode == 0
@@ -1027,7 +1027,7 @@ def test_dynamic_tests(run_reframe, tmp_path):
         environs=[],
         checkpath=['unittests/resources/checks_unlisted/distribute.py'],
         action='run',
-        more_options=['-n', 'Complex', '--distribute=idle']
+        more_options=['-n', '^Complex', '--distribute=idle']
     )
     assert returncode == 0
     assert 'Ran 10/10 test case(s)' in stdout

--- a/unittests/test_testgenerators.py
+++ b/unittests/test_testgenerators.py
@@ -22,7 +22,7 @@ def test_distribute_testcases(sys0_exec_ctx):
     ])
     testcases = executors.generate_testcases(loader.load_all())
     testcases = filter(
-        filters.have_any_name('Simple'), testcases
+        filters.have_any_name(['Simple']), testcases
     )
 
     testcases = list(testcases)


### PR DESCRIPTION
We now use `re.search()` instead of `re.match()` for matching the name or tag patterns in the related cli options. So there is no need any more to prepend  `.*` to a name pattern so as to match something in the middle of the test name.

Closes #2658 