### PR TITLE
[bugfix] Fix performance logging when `perf_variables` are set in a performance stage hook

### DIFF
--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -726,7 +726,7 @@ class LoggerAdapter(logging.LoggerAdapter):
         )
 
     def log_performance(self, level, task, msg=None, multiline=False):
-        if self.extra['__rfm_check__'] is None:
+        if self.check is None or not self.check.is_performance_check():
             return
 
         self.extra['check_partition'] = task.testcase.partition.name
@@ -737,8 +737,7 @@ class LoggerAdapter(logging.LoggerAdapter):
 
         if multiline:
             # Log one record for each performance variable
-            check = self.extra['__rfm_check__']
-            for var, info in check.perfvalues.items():
+            for var, info in self.check.perfvalues.items():
                 val, ref, lower, upper, unit = info
                 self.extra['check_perf_var'] = var.split(':')[-1]
                 self.extra['check_perf_value'] = val

--- a/reframe/frontend/executors/__init__.py
+++ b/reframe/frontend/executors/__init__.py
@@ -368,9 +368,7 @@ class RegressionTask:
 
     @logging.time_function
     def performance(self):
-        if self.check.is_performance_check():
-            self._perflogger = logging.getperflogger(self.check)
-
+        self._perflogger = logging.getperflogger(self.check)
         self._safe_call(self.check.performance)
 
     @logging.time_function


### PR DESCRIPTION
Fixes #2728.