### PR TITLE
[feat] Allow custom JSON formatting for log records in the `httpjson` handler

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -1362,6 +1362,43 @@ An example configuration of this handler for performance logging is shown here:
 
 This handler transmits the whole log record, meaning that all the information will be available and indexable at the remote end.
 
+.. py:attribute:: logging.handlers..httpjson..debug
+
+.. py:attribute:: logging.handlers_perflog..httpjson..debug
+
+   :required: No
+   :default: ``false``
+
+   If set, the ``httpjson`` handler will not attempt to send the data to the server, but it will instead dump the JSON record in the current directory.
+   The filename has the following form: ``httpjson_record_<timestamp>.json``.
+
+   .. versionadded:: 4.1
+
+
+.. py:attribute:: logging.handlers..httpjson..json_formatter
+
+.. py:attribute:: logging.handlers_perflog..httpjson..json_formatter
+
+   A callable for converting the log record into JSON.
+
+   The formatter's signature is the following:
+
+   .. py:function:: json_formatter(record: object, extras: Dict[str, str], ignore_keys: Set[str]) -> str
+
+      :arg record: The prepared log record.
+         The log record is a simple Python object with all the attributes listed in :attr:`~config.logging.handlers.format`, as well as all the default Python `log record <https://docs.python.org/3.8/library/logging.html#logrecord-attributes>`__ attributes.
+         In addition to those, there is also the special :attr:`__rfm_check__` attribute that contains a reference to the actual test for which the performance is being logged.
+      :arg extras: Any extra attributes specified in :attr:`~config.logging.handlers..httpjson..extras`.
+      :arg ignore_keys: The set of keys specified in :attr:`~config.logging.handlers..httpjson..ignore_keys`.
+         ReFrame always adds the default Python log record attributes in this set.
+      :returns: A string representation of the JSON record to be sent to the server or :obj:`None` if the record should not be sent to the server.
+
+   .. note::
+      This configuration parameter can only be used in a Python configuration file.
+
+   .. versionadded:: 4.1
+
+
 
 Execution Mode Configuration
 ----------------------------

--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -962,3 +962,27 @@ def time_function_noexit(fn):
         return fn(*args, **kwargs)
 
     return _fn
+
+
+# The following is meant to be used only by the unit tests
+
+class logging_sandbox:
+    '''Define a region that you can safely change the logging config.
+
+    At entering the region, this context manager saves the logging
+    configuration and restores it at exit.
+
+    :meta private:
+    '''
+
+    def __enter__(self):
+        self._logger = _logger
+        self._perf_logger = _perf_logger
+        self._context_logger = _context_logger
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        global _logger, _perf_logger, _context_logger
+
+        _logger = self._logger
+        _perf_logger = self._perf_logger
+        _context_logger = self._context_logger

--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -594,7 +594,7 @@ class HTTPJSONHandler(logging.Handler):
 
         if self._debug:
             import time
-            ts = time.time_ns()
+            ts = int(time.time() * 1_000)
             dump_file = f'httpjson_record_{ts}.json'
             with open(dump_file, 'w') as fp:
                 fp.write(json_record)

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -163,7 +163,9 @@
                         "ignore_keys": {
                             "type": "array",
                             "items": {"type": "string"}
-                        }
+                        },
+                        "json_formatter": {},
+                        "debug": {"type": "boolean"}
                     },
                     "required": ["url"]
                 }
@@ -565,6 +567,8 @@
         "logging/handlers*/graylog_extras": {},
         "logging/handlers*/httpjson_extras": {},
         "logging/handlers*/httpjson_ignore_keys": [],
+        "logging/handlers*/httpjson_json_formatter": null,
+        "logging/handlers*/httpjson_debug": false,
         "logging/handlers*/stream_name": "stdout",
         "logging/handlers*/syslog_socktype": "udp",
         "logging/handlers*/syslog_facility": "user",

--- a/unittests/test_logging.py
+++ b/unittests/test_logging.py
@@ -251,12 +251,18 @@ def default_exec_ctx(make_exec_ctx_g, config_file):
     yield from make_exec_ctx_g(config_file())
 
 
-def test_valid_level(default_exec_ctx):
+@pytest.fixture
+def logging_sandbox():
+    with rlog.logging_sandbox():
+        yield
+
+
+def test_valid_level(default_exec_ctx, logging_sandbox):
     rlog.configure_logging(rt.runtime().site_config)
     assert rlog.INFO == rlog.getlogger().getEffectiveLevel()
 
 
-def test_handler_level(default_exec_ctx, logfile):
+def test_handler_level(default_exec_ctx, logfile, logging_sandbox):
     rlog.configure_logging(rt.runtime().site_config)
     rlog.getlogger().info('foo')
     rlog.getlogger().warning('bar')
@@ -264,7 +270,7 @@ def test_handler_level(default_exec_ctx, logfile):
     assert _found_in_logfile('bar', logfile)
 
 
-def test_handler_append(default_exec_ctx, logfile):
+def test_handler_append(default_exec_ctx, logfile, logging_sandbox):
     rlog.configure_logging(rt.runtime().site_config)
     rlog.getlogger().warning('foo')
     _close_handlers()
@@ -277,7 +283,8 @@ def test_handler_append(default_exec_ctx, logfile):
     assert _found_in_logfile('bar', logfile)
 
 
-def test_handler_noappend(make_exec_ctx, config_file, logfile):
+def test_handler_noappend(make_exec_ctx, config_file,
+                          logfile, logging_sandbox):
     make_exec_ctx(
         config_file({
             'level': 'info',
@@ -307,7 +314,8 @@ def test_handler_noappend(make_exec_ctx, config_file, logfile):
     assert _found_in_logfile('bar', logfile)
 
 
-def test_handler_bad_format(make_exec_ctx, config_file, logfile):
+def test_handler_bad_format(make_exec_ctx, config_file,
+                            logfile, logging_sandbox):
     make_exec_ctx(
         config_file({
             'level': 'info',
@@ -330,7 +338,7 @@ def test_handler_bad_format(make_exec_ctx, config_file, logfile):
     assert _found_in_logfile('<error formatting the log message:', logfile)
 
 
-def test_warn_once(default_exec_ctx, logfile):
+def test_warn_once(default_exec_ctx, logfile, logging_sandbox):
     rlog.configure_logging(rt.runtime().site_config)
     rlog.getlogger().warning('foo', cache=True)
     rlog.getlogger().warning('foo', cache=True)
@@ -342,7 +350,7 @@ def test_warn_once(default_exec_ctx, logfile):
         assert len(re.findall('foo', fp.read())) == 1
 
 
-def test_date_format(default_exec_ctx, logfile):
+def test_date_format(default_exec_ctx, logfile, logging_sandbox):
     rlog.configure_logging(rt.runtime().site_config)
     rlog.getlogger().warning('foo')
     assert _found_in_logfile(datetime.now().strftime('%F'), logfile)
@@ -353,7 +361,7 @@ def stream(request):
     return request.param
 
 
-def test_stream_handler(make_exec_ctx, config_file, stream):
+def test_stream_handler(make_exec_ctx, config_file, stream, logging_sandbox):
     make_exec_ctx(
         config_file({
             'level': 'info',
@@ -372,7 +380,8 @@ def test_stream_handler(make_exec_ctx, config_file, stream):
     assert handler.stream == stream
 
 
-def test_multiple_handlers(make_exec_ctx, config_file, logfile):
+def test_multiple_handlers(make_exec_ctx, config_file,
+                           logfile, logging_sandbox):
     make_exec_ctx(
         config_file({
             'level': 'info',
@@ -388,7 +397,8 @@ def test_multiple_handlers(make_exec_ctx, config_file, logfile):
     assert len(rlog.getlogger().logger.handlers) == 3
 
 
-def test_file_handler_timestamp(make_exec_ctx, config_file, logfile):
+def test_file_handler_timestamp(make_exec_ctx, config_file,
+                                logfile, logging_sandbox):
     make_exec_ctx(
         config_file({
             'level': 'info',
@@ -414,7 +424,7 @@ def test_file_handler_timestamp(make_exec_ctx, config_file, logfile):
     assert os.path.exists(filename)
 
 
-def test_syslog_handler(make_exec_ctx, config_file):
+def test_syslog_handler(make_exec_ctx, config_file, logging_sandbox):
     import platform
 
     if platform.system() == 'Linux':
@@ -435,7 +445,7 @@ def test_syslog_handler(make_exec_ctx, config_file):
     rlog.getlogger().info('foo')
 
 
-def test_syslog_handler_tcp_port_noint(make_exec_ctx, config_file):
+def test_syslog_handler_tcp_port_noint(make_exec_ctx, config_file, logging_sandbox):
     make_exec_ctx(
         config_file({
             'level': 'info',
@@ -450,7 +460,7 @@ def test_syslog_handler_tcp_port_noint(make_exec_ctx, config_file):
         rlog.configure_logging(rt.runtime().site_config)
 
 
-def test_global_noconfig():
+def test_global_noconfig(logging_sandbox):
     # This is to test the case when no configuration is set, but since the
     # order the unit tests are invoked is arbitrary, we emulate the
     # 'no-config' state by passing `None` to `configure_logging()`
@@ -459,12 +469,12 @@ def test_global_noconfig():
     assert rlog.getlogger() is rlog.null_logger
 
 
-def test_global_config(default_exec_ctx):
+def test_global_config(default_exec_ctx, logging_sandbox):
     rlog.configure_logging(rt.runtime().site_config)
     assert rlog.getlogger() is not rlog.null_logger
 
 
-def test_logging_context(default_exec_ctx, logfile):
+def test_logging_context(default_exec_ctx, logfile, logging_sandbox):
     rlog.configure_logging(rt.runtime().site_config)
     with rlog.logging_context() as logger:
         assert logger is rlog.getlogger()
@@ -475,7 +485,8 @@ def test_logging_context(default_exec_ctx, logfile):
     assert _found_in_logfile('error from context', logfile)
 
 
-def test_logging_context_check(default_exec_ctx, logfile, fake_check):
+def test_logging_context_check(default_exec_ctx, fake_check,
+                               logfile, logging_sandbox):
     rlog.configure_logging(rt.runtime().site_config)
     with rlog.logging_context(check=fake_check):
         rlog.getlogger().error('error from context')
@@ -489,7 +500,7 @@ def test_logging_context_check(default_exec_ctx, logfile, fake_check):
     )
 
 
-def test_logging_context_error(default_exec_ctx, logfile):
+def test_logging_context_error(default_exec_ctx, logfile, logging_sandbox):
     rlog.configure_logging(rt.runtime().site_config)
     try:
         with rlog.logging_context(level=rlog.ERROR):
@@ -512,7 +523,8 @@ def malformed_url(request):
     return request.param
 
 
-def test_httpjson_handler_bad_url(make_exec_ctx, config_file, malformed_url):
+def test_httpjson_handler_bad_url(make_exec_ctx, config_file,
+                                  malformed_url, logging_sandbox):
     url, error = malformed_url
     make_exec_ctx(
         config_file({
@@ -533,13 +545,14 @@ def url_scheme(request):
     return request.param
 
 
-def test_httpjson_handler_no_port(make_exec_ctx, config_file, url_scheme):
-    make_exec_ctx(
+def test_httpjson_handler_no_port(make_exec_ctx, config_file,
+                                  url_scheme, logging_sandbox):
+    ctx = make_exec_ctx(
         config_file({
             'level': 'info',
             'handlers_perflog': [{
                 'type': 'httpjson',
-                'url': f'{url_scheme}://foo.com/rfm',
+                'url': f'{url_scheme}://xyz/rfm',
             }],
         })
     )


### PR DESCRIPTION
This PR introduces two new configuration parameters for the `httpjson` handler:

1. `json_formatter`: this is a callable that will be passed the log record and it should return a valid JSON-encoded string. This configuration parameter is only valid for the Python config.
2. `debug`: if specified, then the server will not be contacted, but instead the encoded record will be dumped in a file in the current working directory.

This PR also changes how `check_perfvalues` are logged by the `httpjson` handler. Similarly to the `filelog` handler these are flattened and a separate batch of properties is created for each performance variable. For example, the various performance variables of the STREAM benchmark (Copy, Scale, etc.) are logged as follows:

```json
{
  "check_perf_Copy_value": 16940.8,
  "check_perf_Copy_ref": 0,
  "check_perf_Copy_lower_thres": null,
  "check_perf_Copy_upper_thres": null,
  "check_perf_Copy_unit": "MB/s",
  "check_perf_Scale_value": 13619.6,
  "check_perf_Scale_ref": 0,
  "check_perf_Scale_lower_thres": null,
  "check_perf_Scale_upper_thres": null,
  "check_perf_Scale_unit": "MB/s",
  "check_perf_Add_value": 14997.2,
  "check_perf_Add_ref": 0,
  "check_perf_Add_lower_thres": null,
  "check_perf_Add_upper_thres": null,
  "check_perf_Add_unit": "MB/s",
  "check_perf_Triad_value": 15254.9,
  "check_perf_Triad_ref": 0,
  "check_perf_Triad_lower_thres": null,
  "check_perf_Triad_upper_thres": null,
  "check_perf_Triad_unit": "MB/s",
}
```

I have also added some unit test that basically check the initialisation of the handler but not its functionality. For functionality tests, we would need something more advanced as described in #2760.

### Todos

- [x] Do not require the port in the URL for the `httpjson` handler
- [x] Update the documentation