### PR TITLE
[feat] Print the first lines of stderr and stdout in case of sanity failures

### DIFF
--- a/reframe/frontend/statistics.py
+++ b/reframe/frontend/statistics.py
@@ -231,18 +231,25 @@ class TestStats:
         return self._run_data
 
     def print_failure_report(self, printer, rerun_info=True):
-        def first_n_lines_of_file(filename, prefix, num_lines=10):
-            lines = [
-                f'--- {filename} (first {num_lines} lines) ---'
-            ]
-            with contextlib.suppress(OSError):
+        def _head_n(filename, prefix, num_lines=10):
+            # filename and prefix are `None` before setup
+            if filename is None or prefix is None:
+                return []
+
+            try:
                 with open(os.path.join(prefix, filename)) as fp:
+                    lines = [
+                        f'--- {filename} (first {num_lines} lines) ---'
+                    ]
                     for i, line in enumerate(fp):
                         if i < num_lines:
                             # Remove trailing '\n'
-                            lines.append(line[:-1])
+                            lines.append(line.rstrip())
 
-            lines += [f'--- {filename} ---']
+                lines += [f'--- {filename} ---']
+            except OSError as e:
+                lines = [f'--- {filename} ({e}) ---']
+
             return lines
 
         line_width = shutil.get_terminal_size()[0]
@@ -280,14 +287,14 @@ class TestStats:
                              f" -p {r['environment']} --system "
                              f"{r['system']} -r'")
 
-            mssg = r['fail_reason']
-            if mssg.startswith('sanity error'):
-                lines = [mssg]
-                lines += first_n_lines_of_file(r['job_stdout'], prefix = r['stagedir'])
-                lines += first_n_lines_of_file(r['job_stderr'], prefix = r['stagedir'])
-                mssg = '\n'.join(lines)
+            msg = r['fail_reason']
+            if isinstance(r['fail_info']['exc_value'], errors.SanityError):
+                lines = [msg]
+                lines += _head_n(r['job_stdout'], prefix = r['stagedir'])
+                lines += _head_n(r['job_stderr'], prefix = r['stagedir'])
+                msg = '\n'.join(lines)
 
-            printer.info(f"  * Reason: {mssg}")
+            printer.info(f"  * Reason: {msg}")
 
             tb = ''.join(traceback.format_exception(*r['fail_info'].values()))
             if r['fail_severe']:

--- a/reframe/frontend/statistics.py
+++ b/reframe/frontend/statistics.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-import contextlib
 import inspect
 import os
 import shutil


### PR DESCRIPTION
We do something similar in case of `BuildError`, where we add the `stderr` in the message of the exception: https://github.com/reframe-hpc/reframe/blob/develop/reframe/core/exceptions.py#L164
I print stderr and stdout in statistics because we have checks at CSCS that raise their own `SanityError` ([like this example](https://github.com/eth-cscs/cscs-reframe-tests/blob/main/checks/prgenv/affinity_check.py#L335)) and I thought other people may be using it like this.
What do you think? Should I change the PR and go with the approach of `BuildError`?

Closes #2668 .