### PR TITLE
[bugfix] Pass long job options with `=`

### DIFF
--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -935,7 +935,7 @@ def main():
             elif len(optstr) == 1:
                 parsed_job_options.append(f'-{optstr} {valstr}')
             else:
-                parsed_job_options.append(f'--{optstr} {valstr}')
+                parsed_job_options.append(f'--{optstr}={valstr}')
 
         # Locate and load checks; `force=True` is not needed for normal
         # invocations from the command line and has practically no effect, but


### PR DESCRIPTION
Fixes #2745.

@flx42 Could you test this, as I don't have access to a Slurm cluster as a [privileged](https://slurm.schedmd.com/srun.html#OPT_nice) user?