### PR TITLE
[testlib] Change execution stage in OSU test library

### DIFF
--- a/hpctestlib/microbenchmarks/mpi/osu.py
+++ b/hpctestlib/microbenchmarks/mpi/osu.py
@@ -130,7 +130,7 @@ class osu_benchmark(rfm.RunOnlyRegressionTest):
         ('mpi.pt2pt.osu_latency', 'latency')
     ], fmt=lambda x: x[0], loggable=True)
 
-    @run_after('init')
+    @run_before('setup')
     def setup_per_benchmark(self):
         bench, bench_metric = self.benchmark_info
         if bench_metric == 'latency':


### PR DESCRIPTION
This change should allow applying more fine-grained test customizations (see, e.g., https://github.com/eth-cscs/cscs-reframe-tests/pull/52) in the OSU micro-benchmarks. 
Thanks to @rsarm for suggesting this solution!