### PR TITLE
[bugfix] Fix confusing stack trace dump when a logging error occurs

### DIFF
--- a/reframe/frontend/executors/policies.py
+++ b/reframe/frontend/executors/policies.py
@@ -513,7 +513,6 @@ class AsynchronousExecutionPolicy(ExecutionPolicy, TaskEventListener):
                 return 1
             else:
                 return 0
-
         except TaskExit:
             self._partition_tasks[partname].remove(task)
             self._current_tasks.remove(task)
@@ -530,9 +529,9 @@ class AsynchronousExecutionPolicy(ExecutionPolicy, TaskEventListener):
             task.finalize()
             self._retired_tasks.append(task)
             self._current_tasks.remove(task)
+            return 1
         except TaskExit:
             self._current_tasks.remove(task)
-        finally:
             return 1
 
     def deps_failed(self, task):


### PR DESCRIPTION
This is more general than a logging error, but this is the case that exposes the bug to the users. The problem was that we were unwittingly suppressing all exceptions (except `TaskExit`, which effectively denotes test errors) inside the `_advance_completing()` function. This was also posing a problem during development as it was masquerading programming errors that caused exceptions to be thrown from within this function. So much intricate was the bug to spot as so much trivial is the fix!

Fixes #2747.

