### PR TITLE
[bugfix] Warn for unset variables only for the tests that are selected

### DIFF
--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -999,6 +999,15 @@ def main():
             f'{len(testcases)} remaining'
         )
 
+        # Warn on any unset test variables for the final set of selected tests
+        for clsname in {type(tc.check).__name__ for tc in testcases}:
+            varlist = ', '.join(f'{v!r}' for v in loader.unset_vars(clsname))
+            if varlist:
+                printer.warning(
+                    f'test {clsname!r}: '
+                    f'the following variables were not set: {varlist}'
+                )
+
         # Filter in failed cases
         if options.failed:
             if options.restore_session is None:


### PR DESCRIPTION
The fix turned out to be easy, since we were already storing the unset variables. This is now moved at the loader level and we warn only after all test filtering has happened in the cli (but before the treatment of the special options `--failed`, `--distribute` and `--repeat`).

Fixes #2672.