### PR TITLE
[enhancement] Properly combine `append`-type command-line options defined in execution modes

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -1400,6 +1400,8 @@ This handler transmits the whole log record, meaning that all the information wi
 
 
 
+.. _exec-mode-config:
+
 Execution Mode Configuration
 ----------------------------
 

--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -489,8 +489,15 @@ Options controlling ReFrame execution
 
    ReFrame execution mode to use.
 
-   An execution mode is simply a predefined invocation of ReFrame that is set with the :data:`modes` configuration parameter.
-   If an option is specified both in an execution mode and in the command-line, then command-line takes precedence.
+   An execution mode is simply a predefined set of options that is set in the :attr:`~modes` :ref:`configuration parameter <exec-mode-config>`.
+   Additional options can be passed to the command line, in which case they will be combined with the options defined in the selected execution mode.
+   More specifically, any additional ReFrame options will be *appended* to the command line options of the selected mode.
+   As a result, if a normal option is specified both inside the execution mode and the in the command line, the command line option will take precedence.
+   On the other hand, if an option that is allowed to be specified multiple times, e.g., the :option:`-S` option, is passed both inside the execution mode and in the command line, their values will be combined.
+   For example, if the execution mode ``foo`` defines ``-S modules=foo``, the invocation ``-S mode=foo -S num_tasks=10`` is the equivalent of ``-S modules=foo -S num_tasks=10``.
+
+   .. versionchanged:: 4.1
+      Options that can be specified multiple times are now combined between execution modes and the command line.
 
 .. option:: --repeat=N
 

--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -494,7 +494,7 @@ Options controlling ReFrame execution
    More specifically, any additional ReFrame options will be *appended* to the command line options of the selected mode.
    As a result, if a normal option is specified both inside the execution mode and the in the command line, the command line option will take precedence.
    On the other hand, if an option that is allowed to be specified multiple times, e.g., the :option:`-S` option, is passed both inside the execution mode and in the command line, their values will be combined.
-   For example, if the execution mode ``foo`` defines ``-S modules=foo``, the invocation ``-S mode=foo -S num_tasks=10`` is the equivalent of ``-S modules=foo -S num_tasks=10``.
+   For example, if the execution mode ``foo`` defines ``-S modules=foo``, the invocation ``--mode=foo -S num_tasks=10`` is the equivalent of ``-S modules=foo -S num_tasks=10``.
 
    .. versionchanged:: 4.1
       Options that can be specified multiple times are now combined between execution modes and the command line.

--- a/reframe/frontend/argparse.py
+++ b/reframe/frontend/argparse.py
@@ -9,6 +9,7 @@ import os
 
 import reframe.utility.typecheck as typ
 
+
 #
 # Notes on the ArgumentParser design
 #
@@ -278,10 +279,20 @@ class ArgumentParser(_ArgumentHolder):
 
         # Update parser's defaults with groups' defaults
         self._update_defaults()
+
+        # Update the parsed options of those from the given namespace and/or
+        # the defaults
         for attr, val in options.__dict__.items():
             if val is None:
-                options.__dict__[attr] = self._resolve_attr(
-                    attr, [namespace, self._defaults]
-                )
+                resolved = self._resolve_attr(attr,
+                                              [namespace, self._defaults])
+                options.__dict__[attr] = resolved
+            elif self._option_map[attr][2] == 'append':
+                # 'append' options are combined with those from the given
+                # namespace, but *not* with the defaults (important)
+                resolved = self._resolve_attr(attr, [namespace])
+                if resolved is not None:
+                    v = options.__dict__[attr]
+                    options.__dict__[attr] = resolved + v
 
         return _Namespace(options, self._option_map)

--- a/unittests/test_argparser.py
+++ b/unittests/test_argparser.py
@@ -74,7 +74,9 @@ def test_parsing(argparser, foo_options, bar_options):
         '--bar beer --foolist any'.split(), options
     )
     assert 'name' == options.foo
-    assert ['any'] == options.foolist
+
+    # 'append' options are extended
+    assert ['gag', 'any'] == options.foolist
     assert not options.foobar
     assert not options.unfoo
     assert 'beer' == options.bar


### PR DESCRIPTION
The documentation for this case is a bit grey area. In documentation of the `modes` configuration parameter it is stated:

> The options of an execution mode will be passed to ReFrame as if they were specified in the command line.

And the docs for the `--mode` read as:

> If an option is specified both in an execution mode and in the command-line, then command-line takes precedence.

These are consistent for the options that can be specified only once: every time such an option is re-passed, it overwrites the previous one. But it's unclear what happens with options that are of an `append` type. The first excerpt implies that the options will be simply unpacked and combined with the same options in the command line (desired behaviour that this PR provides), but the second excerpt allows the interpretation that if such an option is specified in the command line will still overwrite completely that in the execution mode (current behaviour and what was validated in the unit tests).

I believe that options that can be specified multiple options must be combined and not overwritten, because this would allow users to set test variables in an execution mode and then set additional variables or reset existing ones from the command line without the need to repass all options.

Since the current behaviour was validated in the existing unit tests, I am not classifying this as a bug fix, but as an enhancement, so it targets the `develop` branch.

Fixes #2785.