### PR TITLE
[feat] Support arbitrary Spack environment configuration

### DIFF
--- a/docs/tutorial_build_automation.rst
+++ b/docs/tutorial_build_automation.rst
@@ -108,6 +108,8 @@ By default, ReFrame will create a new Spack environment in the test's stage dire
 .. note::
    Optional spec attributes, such as ``target`` and ``os``, should be specified in :attr:`~reframe.core.buildsystems.Spack.specs` and not as install options in :attr:`~reframe.core.buildsystems.Spack.install_opts`.
 
+You can set Spack configuration options for the new environment with the :attr:`~reframe.core.buildsystems.Spack.config_opts` attribute. These options take precedence over Spack's ``spack.yaml`` defaults.
+
 Users may also specify an existing Spack environment by setting the :attr:`~reframe.core.buildsystems.Spack.environment` attribute.
 In this case, ReFrame treats the environment as a *test resource* so it expects to find it under the test's :attr:`~reframe.core.pipeline.RegressionTest.sourcesdir`, which defaults to ``'src'``.
 

--- a/reframe/core/buildsystems.py
+++ b/reframe/core/buildsystems.py
@@ -873,6 +873,8 @@ class Spack(BuildSystem):
     #:
     #: :type: :class:`List[str]`
     #: :default: ``[]``
+    #:
+    #: .. versionadded:: 4.2
     config_opts = variable(typ.List[str], value=[])
 
     def __init__(self):
@@ -889,7 +891,7 @@ class Spack(BuildSystem):
 
         config_opts += self.config_opts
         for opt in config_opts:
-       		ret.append(f'spack -e {self.environment} config add "{opt}"')
+            ret.append(f'spack -e {self.environment} config add "{opt}"')
 
         if self.specs:
             specs_str = ' '.join(self.specs)

--- a/reframe/core/buildsystems.py
+++ b/reframe/core/buildsystems.py
@@ -869,6 +869,12 @@ class Spack(BuildSystem):
     #: :default: ``[]``
     install_opts = variable(typ.List[str], value=[])
 
+    #: A list of Spack configurations in flattened YAML.
+    #:
+    #: :type: :class:`List[str]`
+    #: :default: ``[]``
+    config_opts = variable(typ.List[str], value=[])
+
     def __init__(self):
         # Set to True if the environment was auto-generated
         self._auto_env = False
@@ -880,6 +886,10 @@ class Spack(BuildSystem):
             install_tree = self.install_tree or 'opt/spack'
             ret.append(f'spack -e {self.environment} config add '
                        f'"config:install_tree:root:{install_tree}"')
+
+        if self.config_opts:
+            for opt in self.config_opts:
+                ret.append(f'spack -e {self.environment} config add "{opt}"')
 
         if self.specs:
             specs_str = ' '.join(self.specs)

--- a/reframe/core/buildsystems.py
+++ b/reframe/core/buildsystems.py
@@ -882,14 +882,14 @@ class Spack(BuildSystem):
     def emit_build_commands(self, environ):
         ret = self._create_env_cmds()
 
+        config_opts = []
         if self._auto_env:
             install_tree = self.install_tree or 'opt/spack'
-            ret.append(f'spack -e {self.environment} config add '
-                       f'"config:install_tree:root:{install_tree}"')
+            config_opts.append(f'config:install_tree:root:{install_tree}')
 
-        if self.config_opts:
-            for opt in self.config_opts:
-                ret.append(f'spack -e {self.environment} config add "{opt}"')
+        config_opts += self.config_opts
+        for opt in config_opts:
+       		ret.append(f'spack -e {self.environment} config add "{opt}"')
 
         if self.specs:
             specs_str = ' '.join(self.specs)

--- a/unittests/test_buildsystems.py
+++ b/unittests/test_buildsystems.py
@@ -302,6 +302,19 @@ def test_spack_no_env(environ, tmp_path):
     assert build_system.environment == 'rfm_spack_env'
 
 
+def test_spack_env_config(environ, tmp_path):
+    build_system = bs.Spack()
+    build_system.config_opts = ['section1:header1:value1', 'section2:header2:value2']
+    with osext.change_dir(tmp_path):
+        assert build_system.emit_build_commands(environ) == [
+            'spack env create -d rfm_spack_env',
+            'spack -e rfm_spack_env config add "config:install_tree:root:opt/spack"',
+            'spack -e rfm_spack_env config add "section1:header1:value1"',
+            'spack -e rfm_spack_env config add "section2:header2:value2"',
+            'spack -e rfm_spack_env install',
+        ]
+
+
 def test_easybuild(environ, tmp_path):
     build_system = bs.EasyBuild()
     build_system.easyconfigs = ['ec1.eb', 'ec2.eb']

--- a/unittests/test_buildsystems.py
+++ b/unittests/test_buildsystems.py
@@ -304,11 +304,12 @@ def test_spack_no_env(environ, tmp_path):
 
 def test_spack_env_config(environ, tmp_path):
     build_system = bs.Spack()
-    build_system.config_opts = ['section1:header1:value1', 'section2:header2:value2']
+    build_system.config_opts = ['section1:header1:value1',
+                                'section2:header2:value2']
     with osext.change_dir(tmp_path):
         assert build_system.emit_build_commands(environ) == [
             'spack env create -d rfm_spack_env',
-            'spack -e rfm_spack_env config add "config:install_tree:root:opt/spack"',
+            'spack -e rfm_spack_env config add "config:install_tree:root:opt/spack"',  # noqa: E501
             'spack -e rfm_spack_env config add "section1:header1:value1"',
             'spack -e rfm_spack_env config add "section2:header2:value2"',
             'spack -e rfm_spack_env install',


### PR DESCRIPTION
`reframe.core.buildsystems.Spack` supports setting `install_tree`, but there are many other ways to configure a Spack environment. This proposal introduces support for setting arbitrary Spack environment configuration options. The implementation is nearly identical to how `install_tree` works.

As an example with the changes proposed here, one could set the following:
`self.build_system.config_opts = ['concretizer:unify:false']`

If the configuration option is not already present in the default `spack.yaml`, it is added. If the configuration option is present in the default `spack.yaml`, Spack overwrites them with the values given via `spack config add`.