### PR TITLE
[testlib] support overriding executable_opts on the cmd line for gromacs test

### DIFF
--- a/hpctestlib/sciapps/gromacs/benchmarks.py
+++ b/hpctestlib/sciapps/gromacs/benchmarks.py
@@ -65,8 +65,8 @@ class gromacs_check(rfm.RunOnlyRegressionTest):
         self.prerun_cmds = [
             f'curl -LJO https://github.com/victorusu/GROMACS_Benchmark_Suite/raw/{self.benchmark_version}/{self.__bench}/benchmark.tpr'  # noqa: E501
         ]
-        if not self.executable_opts:
-            self.executable_opts = ['-nb', self.nb_impl]
+        if '-nb' not in ' '.join(self.executable_opts).split()
+            self.executable_opts += ['-nb', self.nb_impl]
         self.executable_opts += ['-s benchmark.tpr']
 
     @loggable

--- a/hpctestlib/sciapps/gromacs/benchmarks.py
+++ b/hpctestlib/sciapps/gromacs/benchmarks.py
@@ -65,7 +65,9 @@ class gromacs_check(rfm.RunOnlyRegressionTest):
         self.prerun_cmds = [
             f'curl -LJO https://github.com/victorusu/GROMACS_Benchmark_Suite/raw/{self.benchmark_version}/{self.__bench}/benchmark.tpr'  # noqa: E501
         ]
-        self.executable_opts += ['-nb', self.nb_impl, '-s benchmark.tpr']
+        if not self.executable_opts:
+            self.executable_opts = ['-nb', self.nb_impl]
+        self.executable_opts += ['-s benchmark.tpr']
 
     @loggable
     @property


### PR DESCRIPTION
currently, the gromacs option `-nb` is always set in the hpctestlib, which is not always what you want.

this PR modifies the behavior if the user sets executable_opts on the cmd line via `--setvar executable_opts=...`.
in that case, assume that the user knows what they are doing and don't set any options (except for the input file).