### PR TITLE
[feat] Add support for user-defined `spack env create` options

### DIFF
--- a/reframe/core/buildsystems.py
+++ b/reframe/core/buildsystems.py
@@ -863,7 +863,7 @@ class Spack(BuildSystem):
     #: :default: :obj:`True`
     emit_load_cmds = variable(bool, value=True)
 
-    #: Options to pass to ``spack install``
+    #: Options to pass to ``spack install``.
     #:
     #: :type: :class:`List[str]`
     #: :default: ``[]``
@@ -874,6 +874,12 @@ class Spack(BuildSystem):
     #: :type: :class:`List[str]`
     #: :default: ``[]``
     config_opts = variable(typ.List[str], value=[])
+
+    #: Options to pass to ``spack env create``.
+    #:
+    #: :type: :class:`List[str]`
+    #: :default: ``[]``
+    env_create_opts = variable(typ.List[str], value=[])
 
     def __init__(self):
         # Set to True if the environment was auto-generated
@@ -908,7 +914,12 @@ class Spack(BuildSystem):
 
         self.environment = 'rfm_spack_env'
         self._auto_env = True
-        return [f'spack env create -d {self.environment}']
+        
+        if self.env_create_opts:
+            env_create_opts = ' ' + ' '.join(self.env_create_opts)
+        else:
+            env_create_opts = ''
+        return [f'spack env create -d {self.environment}{env_create_opts}']
 
     def prepare_cmds(self):
         cmds = self._create_env_cmds()


### PR DESCRIPTION
ReFrame, unless targeting a user-specified existing Spack environment, automatically passes the `-d rfm_spack_env` option to create an ephemeral environment. This is a small addition that allows users to define extra `spack env create` options ([link to Spack docs for list of options](https://spack.readthedocs.io/en/latest/command_index.html#spack-env-create)). 

With the changes proposed here, a user could define the following:
```python
self.build_system.env_create_opts = ["--without-view"]
```

which produces following in the build job script:
```sh
spack env create -d rfm_spack_env --without-view
```

While technically this allows for any `spack env create` options, my motivation for this feature is use of `--without-view`. ReFrame's use of temporary Spack environments leaves little use for a filesystem view, and disabling it can reduce the possibility of `spack load`-time spec collisions.