### PR TITLE
[bugfix] Allow proper assignment of `time_limit` from command line

### DIFF
--- a/reframe/core/fields.py
+++ b/reframe/core/fields.py
@@ -7,9 +7,6 @@
 # Useful descriptors for advanced operations on fields
 #
 
-import datetime
-import re
-
 import reframe.utility.typecheck as types
 from reframe.core.warnings import user_deprecation_warning
 from reframe.utility import ScopedDict

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -625,9 +625,8 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #:
     #: :type: :class:`str` or :class:`datetime.timedelta`
     #: :default: :class:`None`
-    max_pending_time = variable(
-        type(None), field=fields.TimerField, value=None, loggable=True
-    )
+    max_pending_time = variable(type(None), typ.Duration, value=None,
+                                loggable=True, allow_implicit=True)
 
     #: Specify whether this test needs exclusive access to nodes.
     #:
@@ -860,8 +859,8 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #:    .. versionchanged:: 3.5.1
     #:       The default value is now :class:`None` and it can be set globally
     #:       per partition via the configuration.
-    time_limit = variable(type(None), field=fields.TimerField,
-                          value=None, loggable=True)
+    time_limit = variable(type(None), typ.Duration, value=None,
+                          loggable=True, allow_implicit=True)
 
     #: .. versionadded:: 3.5.1
     #:
@@ -871,8 +870,8 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #:
     #: :type: :class:`str` or :class:`float` or :class:`int`
     #: :default: :class:`None`
-    build_time_limit = variable(type(None), field=fields.TimerField,
-                                value=None, loggable=True)
+    build_time_limit = variable(type(None), typ.Duration, value=None,
+                                loggable=True, allow_implicit=True)
 
     #: .. versionadded:: 2.8
     #:

--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -10,7 +10,6 @@
 import abc
 import time
 
-import reframe.core.fields as fields
 import reframe.core.runtime as runtime
 import reframe.core.shell as shell
 import reframe.utility.jsonext as jsonext

--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -261,7 +261,8 @@ class Job(jsonext.JSONSerializable, metaclass=JobMeta):
     #:    based on the test information.
     #:
     #: .. versionadded:: 3.11.0
-    time_limit = variable(type(None), field=fields.TimerField, value=None)
+    time_limit = variable(type(None), typ.Duration,
+                          value=None, allow_implicit=True)
 
     #: Maximum pending time for this job.
     #:
@@ -273,8 +274,8 @@ class Job(jsonext.JSONSerializable, metaclass=JobMeta):
     #:    based on the test information.
     #:
     #: .. versionadded:: 3.11.0
-    max_pending_time = variable(type(None),
-                                field=fields.TimerField, value=None)
+    max_pending_time = variable(type(None), typ.Duration,
+                                value=None, allow_implicit=True)
 
     #: Arbitrary options to be passed to the backend job scheduler.
     #:

--- a/unittests/test_fields.py
+++ b/unittests/test_fields.py
@@ -67,6 +67,7 @@ def test_typed_field():
     class FieldTester:
         field = fields.TypedField(ClassA)
         field_any = fields.TypedField(ClassA, str, type(None))
+        field_convertible = fields.TypedField(int, allow_implicit=True)
 
         def __init__(self, value):
             self.field = value
@@ -88,6 +89,9 @@ def test_typed_field():
     with pytest.raises(TypeError):
         tester.field_any = 3
 
+    tester.field_convertible = 1
+    tester.field_convertible = '1'
+
 
 def test_typed_field_convertible():
     class FieldTester:
@@ -103,53 +107,6 @@ def test_typed_field_convertible():
 
     with pytest.raises(TypeError):
         tester.fieldC = fields.make_convertible(None)
-
-
-def test_timer_field():
-    class FieldTester:
-        field = fields.TimerField()
-        field_maybe_none = fields.TimerField(type(None))
-
-    tester = FieldTester()
-    tester.field = '1d65h22m87s'
-    tester.field_maybe_none = None
-    assert isinstance(FieldTester.field, fields.TimerField)
-    secs = datetime.timedelta(days=1, hours=65,
-                              minutes=22, seconds=87).total_seconds()
-    assert tester.field == secs
-    tester.field = secs
-    assert tester.field == secs
-    tester.field = ''
-    assert tester.field == 0
-    with pytest.raises(ValueError):
-        tester.field = '1e'
-
-    with pytest.raises(ValueError):
-        tester.field = '-10m5s'
-
-    with pytest.raises(ValueError):
-        tester.field = '10m-5s'
-
-    with pytest.raises(ValueError):
-        tester.field = 'm10s'
-
-    with pytest.raises(ValueError):
-        tester.field = '10m10'
-
-    with pytest.raises(ValueError):
-        tester.field = '10m10m1s'
-
-    with pytest.raises(ValueError):
-        tester.field = '10m5s3m'
-
-    with pytest.raises(ValueError):
-        tester.field = '10ms'
-
-    with pytest.raises(ValueError):
-        tester.field = '10'
-
-    with pytest.raises(ValueError):
-        tester.field = -10
 
 
 def test_deprecated_field():

--- a/unittests/test_fields.py
+++ b/unittests/test_fields.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-import datetime
 import pytest
 import semver
 import warnings

--- a/unittests/test_typecheck.py
+++ b/unittests/test_typecheck.py
@@ -40,6 +40,46 @@ def test_bool_type():
     assert typ.Bool('no') is False
 
 
+def test_duration_type():
+    assert typ.Duration(10) == 10
+    assert typ.Duration(10.5) == 10.5
+    assert typ.Duration('10') == 10
+    assert typ.Duration('10.5') == 10.5
+    assert typ.Duration('10s') == 10
+    assert typ.Duration('10m') == 600
+    assert typ.Duration('10m30s') == 630
+    assert typ.Duration('10h') == 36000
+    assert typ.Duration('1d') == 86400
+    assert typ.Duration('1d65h22m87s') == 321807
+
+    with pytest.raises(ValueError):
+        typ.Duration('1e')
+
+    with pytest.raises(ValueError):
+        typ.Duration('-10m5s')
+
+    with pytest.raises(ValueError):
+        typ.Duration('10m-5s')
+
+    with pytest.raises(ValueError):
+        typ.Duration('m10s')
+
+    with pytest.raises(ValueError):
+        typ.Duration('10m10')
+
+    with pytest.raises(ValueError):
+        typ.Duration('10m10m1s')
+
+    with pytest.raises(ValueError):
+        typ.Duration('10m5s3m')
+
+    with pytest.raises(ValueError):
+        typ.Duration('10ms')
+
+    with pytest.raises(ValueError):
+        typ.Duration(-10)
+
+
 def test_list_type():
     l = [1, 2]
     ll = [[1, 2], [3, 4]]


### PR DESCRIPTION
This PR fixes the same problem for all other `TimerField` variables. 

To allow setting these fields properly from the command line, we get rid of the `TimerField` and replace it with the augmented type `Duration`, which is similar in concept with the `Bool` type. This type allows conversion from floats, int and strings and applies essentially the logic of the former `TimerField`. Since for this field we want to allow conversions also when it's set from inside the test, e.g., `time_limit = '10s'`, we add a new argument `allow_implicit` to the `TypedField` constructor (also exposed through the `variable` builtin), which make the field try implicit conversions before assigning the value to the test attribute. Therefore a variable declared as `x = variable(int, allow_implicit=True)` can be set with either `x = 1` or `x = '1'`.

Closes #2815.