### PR TITLE
[feat] Support custom system auto-detection methods

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -68,15 +68,15 @@ It consists of the following properties, which we also call conventionally *conf
 
    A list of system auto-detection methods for identifying the current system.
 
-   The list can contain two type of methods:
+   The list can contain two types of methods:
 
    1. Python methods: These are prefixed with ``py::`` and should point to a Python callable taking zero arguments and returning a string.
-      If the specified Python callable is not prefixed with a module, it will be looked up in the loaded configuration file chain starting from the last file in the chain.
+      If the specified Python callable is not prefixed with a module, it will be looked up in the loaded configuration files starting from the last file.
       If the requested symbol cannot be found, a warning will be issued and the method will be ignored.
    2. Shell commands: Any string not prefixed with ``py::`` will be treated as a shell command and will be executed *during auto-detection* to retrieve the hostname.
       The standard output of the command will be used.
 
-   If the :option:`--system` option is not passed, ReFrame will try to autodetect the current system trying the methods in this list one after the other, until one of them succeeds.
+   If the :option:`--system` option is not passed, ReFrame will try to autodetect the current system trying the methods in this list successively, until one of them succeeds.
    The resulting name will be matched against the :attr:`~config.systems.hostnames` patterns of each system and the system that matches first will be used as the current one.
 
    The auto-detection methods can also be controlled through the :envvar:`RFM_AUTODETECT_METHODS` environment variable.

--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -61,6 +61,29 @@ It consists of the following properties, which we also call conventionally *conf
    A list of `general configuration objects <#general-configuration>`__.
 
 
+.. py:data:: autodetect_methods
+
+   :required: No
+   :default: ``["py::socket.gethostname"]``
+
+   A list of system auto-detection methods for identifying the current system.
+
+   The list can contain two type of methods:
+
+   1. Python methods: These are prefixed with ``py::`` and should point to a Python callable taking zero arguments and returning a string.
+      If the specified Python callable is not prefixed with a module, it will be looked up in the loaded configuration file chain starting from the last file in the chain.
+      If the requested symbol cannot be found, a warning will be issued and the method will be ignored.
+   2. Shell commands: Any string not prefixed with ``py::`` will be treated as a shell command and will be executed *during auto-detection* to retrieve the hostname.
+      The standard output of the command will be used.
+
+   If the :option:`--system` option is not passed, ReFrame will try to autodetect the current system trying the methods in this list one after the other, until one of them succeeds.
+   The resulting name will be matched against the :attr:`~config.systems.hostnames` patterns of each system and the system that matches first will be used as the current one.
+
+   The auto-detection methods can also be controlled through the :envvar:`RFM_AUTODETECT_METHODS` environment variable.
+
+   .. versionadded:: 4.3
+
+
 .. warning::
    .. versionchanged:: 4.0.0
       The :data:`schedulers` section is removed.

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -311,12 +311,9 @@ As discussed previously, ReFrame's configuration file can store the configuratio
 When launched, ReFrame will pick the first matching configuration and load it.
 
 ReFrame uses an auto-detection mechanism to get information about the host it is running on and uses that information to pick the right system configuration.
-Currently, only one auto-detection method is supported that retrieves the hostname.
-Based on this, ReFrame goes through all the systems in its configuration and tries to match the hostname against any of the patterns defined in each system's ``hostnames`` property.
-The detection process stops at the first match found, and that system's configuration is selected.
-
-The auto-detection process can be controlled through the :envvar:`RFM_AUTODETECT_METHOD`, :envvar:`RFM_AUTODETECT_FQDN` and :envvar:`RFM_AUTODETECT_XTHOSTNAME` environment variables.
-
+The default auto-detection method is using the ``hostname`` command, but you can define more methods using either the :attr:`~config.autodetect_methods` configuration parameter or the :envvar:`RFM_AUTODETECT_METHODS` environment variable.
+After having retrieved the hostname, ReFrame goes through all the systems in its configuration and tries to match it against the :attr:`~config.systems.hostnames` patterns defined for every system.
+The first system whose :attr:`~config.systems.hostnames` match will become the current system and its configuration will be loaded.
 
 As soon as a system configuration is selected, all configuration objects that have a ``target_systems`` property are resolved against the selected system, and any configuration object that is not applicable is dropped.
 So, internally, ReFrame keeps an *instantiation* of the site configuration for the selected system only.

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -311,8 +311,8 @@ As discussed previously, ReFrame's configuration file can store the configuratio
 When launched, ReFrame will pick the first matching configuration and load it.
 
 ReFrame uses an auto-detection mechanism to get information about the host it is running on and uses that information to pick the right system configuration.
-The default auto-detection method is using the ``hostname`` command, but you can define more methods using either the :attr:`~config.autodetect_methods` configuration parameter or the :envvar:`RFM_AUTODETECT_METHODS` environment variable.
-After having retrieved the hostname, ReFrame goes through all the systems in its configuration and tries to match it against the :attr:`~config.systems.hostnames` patterns defined for every system.
+The default auto-detection method uses the ``hostname`` command, but you can define more methods by setting either the :attr:`autodetect_methods` configuration parameter or the :envvar:`RFM_AUTODETECT_METHODS` environment variable.
+After having retrieved the hostname, ReFrame goes through all the systems in its configuration and tries to match it against the :attr:`~config.systems.hostnames` patterns defined for each system.
 The first system whose :attr:`~config.systems.hostnames` match will become the current system and its configuration will be loaded.
 
 As soon as a system configuration is selected, all configuration objects that have a ``target_systems`` property are resolved against the selected system, and any configuration object that is not applicable is dropped.

--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -1136,6 +1136,9 @@ Whenever an environment variable is associated with a configuration option, its 
    .. versionchanged:: 4.0.0
       This variable now defaults to ``0``.
 
+   .. deprecated:: 4.3
+      Please use ``RFM_AUTODETECT_METHODS=py::fqdn`` in the future.
+
 
 .. envvar:: RFM_AUTODETECT_METHOD
 
@@ -1155,6 +1158,16 @@ Whenever an environment variable is associated with a configuration option, its 
 
 
    .. versionadded:: 3.11.0
+   .. deprecated:: 4.3
+      This has no effect.
+      For setting multiple auto-detection methods, please use the :envvar:`RFM_AUTODETECT_METHODS`.
+
+.. envvar:: RFM_AUTODETECT_METHODS
+
+   A comma-separated list of system auto-detection methods.
+   Please refer to the :attr:`autodetect_methods` configuration parameter for more information on how to set this variable.
+
+   .. versionadded:: 4.3
 
 
 .. envvar:: RFM_AUTODETECT_XTHOSTNAME
@@ -1178,6 +1191,10 @@ Whenever an environment variable is associated with a configuration option, its 
 
    .. versionchanged:: 4.0.0
       This variable now defaults to ``0``.
+
+   .. deprecated:: 4.3
+      Please use ``RFM_AUTODETECT_METHODS='cat /etc/xthostname,hostname'`` in the future.
+
 
 .. envvar:: RFM_CHECK_SEARCH_PATH
 

--- a/reframe/core/config.py
+++ b/reframe/core/config.py
@@ -20,9 +20,7 @@ import reframe.core.settings as settings
 import reframe.utility as util
 import reframe.utility.osext as osext
 from reframe.core.environments import normalize_module_list
-from reframe.core.exceptions import (ConfigError,
-                                     ReframeFatalError,
-                                     SpawnedProcessError)
+from reframe.core.exceptions import (ConfigError, ReframeFatalError)
 from reframe.core.logging import getlogger
 from reframe.utility import ScopedDict
 

--- a/reframe/core/config.py
+++ b/reframe/core/config.py
@@ -13,7 +13,6 @@ import json
 import jsonschema
 import os
 import re
-import socket
 
 import reframe
 import reframe.core.settings as settings

--- a/reframe/core/config.py
+++ b/reframe/core/config.py
@@ -544,7 +544,8 @@ class _SiteConfig:
         local_config['systems'] = systems
         for name, section in site_config.items():
             if name == 'systems' or name == 'autodetect':
-                # The systems autodetect sections has already been treated
+                # The systems and autodetect sections have already been
+                # treated
                 continue
 
             # Convert section to a scoped dict that will handle correctly and

--- a/reframe/core/settings.py
+++ b/reframe/core/settings.py
@@ -8,6 +8,11 @@
 #
 
 site_configuration = {
+    "autodetect": [
+        {
+            "method": "hostname"
+        },
+    ],
     'systems': [
         {
             'name': 'generic',

--- a/reframe/core/settings.py
+++ b/reframe/core/settings.py
@@ -8,11 +8,6 @@
 #
 
 site_configuration = {
-    "autodetect": [
-        {
-            "method": "hostname"
-        },
-    ],
     'systems': [
         {
             'name': 'generic',

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -574,14 +574,13 @@ def main():
         dest='autodetect_method',
         envvar='RFM_AUTODETECT_METHOD',
         action='store',
-        default='hostname',
         help='Method to detect the system'
     )
     argparser.add_argument(
-        dest='config_path',
-        envvar='RFM_CONFIG_PATH :',
-        action='append',
-        help='Directories where ReFrame will look for base configuration'
+        dest='autodetect_methods',
+        envvar='RFM_AUTODETECT_METHODS',
+        action='store',
+        help='List of methods for detecting the current system'
     )
     argparser.add_argument(
         dest='autodetect_xthostname',
@@ -590,6 +589,12 @@ def main():
         default=False,
         type=typ.Bool,
         help="Use Cray's xthostname file to retrieve the host name"
+    )
+    argparser.add_argument(
+        dest='config_path',
+        envvar='RFM_CONFIG_PATH :',
+        action='append',
+        help='Directories where ReFrame will look for base configuration'
     )
     argparser.add_argument(
         dest='git_timeout',
@@ -707,9 +712,7 @@ def main():
     # First configure logging with our generic configuration so as to be able
     # to print pretty messages; logging will be reconfigured by user's
     # configuration later
-    site_config = config.load_config(
-        os.path.join(reframe.INSTALL_PREFIX, 'reframe/core/settings.py')
-    )
+    site_config = config.load_config('<builtin>')
     site_config.select_subconfig('generic')
     options.update_config(site_config)
     logging.configure_logging(site_config)
@@ -739,11 +742,32 @@ def main():
         )
         site_config = config.load_config(*conf_files)
         site_config.validate()
-        site_config.set_autodetect_meth(
-            options.autodetect_method,
-            use_fqdn=options.autodetect_fqdn,
-            use_xthostname=options.autodetect_xthostname
-        )
+
+        if options.autodetect_method:
+            printer.warning('RFM_AUTODETECT_METHOD is deprecated; '
+                            'please use RFM_AUTODETECT_METHODS instead')
+
+        autodetect_methods = []
+        if options.autodetect_methods:
+            autodetect_methods = options.autodetect_methods.split(',')
+        else:
+            if options.autodetect_fqdn:
+                printer.warning(
+                    'RFM_AUTODETECT_FQDN is deprecated; '
+                    'please use RFM_AUTODETECT_METHODS=py::socket.getfqdn '
+                    'instead'
+                )
+                autodetect_methods = ['py::socket.getfqdn']
+            elif options.autodetect_xthostname:
+                printer.warning(
+                    "RFM_AUTODETECT_XTHOSTNAME is deprecated; "
+                    "please use RFM_AUTODETECT_METHODS='cat /etc/xthostname' "
+                    "instead"
+                )
+                autodetect_methods = ['cat /etc/xthostname']
+
+        if autodetect_methods:
+            site_config.set_autodetect_methods(autodetect_methods)
 
         # We ignore errors about unresolved sections or configuration
         # parameters here, because they might be defined at the individual

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -14,7 +14,6 @@ import sys
 import time
 import traceback
 
-import reframe
 import reframe.core.config as config
 import reframe.core.exceptions as errors
 import reframe.core.logging as logging
@@ -761,10 +760,11 @@ def main():
             elif options.autodetect_xthostname:
                 printer.warning(
                     "RFM_AUTODETECT_XTHOSTNAME is deprecated; "
-                    "please use RFM_AUTODETECT_METHODS='cat /etc/xthostname' "
+                    "please use RFM_AUTODETECT_METHODS='cat /etc/xthostname,hostname' "  # noqa: E501
                     "instead"
                 )
-                autodetect_methods = ['cat /etc/xthostname']
+                autodetect_methods = ['cat /etc/xthostname',
+                                      'py::socket.gethostname']
 
         if autodetect_methods:
             site_config.set_autodetect_methods(autodetect_methods)

--- a/reframe/frontend/loader.py
+++ b/reframe/frontend/loader.py
@@ -20,19 +20,6 @@ from reframe.core.exceptions import NameConflictError, is_severe, what
 from reframe.core.logging import getlogger, time_function
 
 
-class temp_sys_path:
-    def __init__(self, path):
-        self._path = path
-        self._pos = None
-
-    def __enter__(self):
-        self._pos = len(sys.path)
-        sys.path.append(self._path)
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        sys.path.pop(self._pos)
-
-
 class no_op:
     def __enter__(self):
         pass
@@ -206,7 +193,7 @@ class RegressionCheckLoader:
         try:
             dirname = os.path.dirname(filename)
             with osext.change_dir(dirname):
-                with temp_sys_path(dirname):
+                with util.temp_sys_path(dirname):
                     return self.load_from_module(
                         util.import_module_from_file(filename, force)
                     )

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -234,47 +234,9 @@
     },
     "type": "object",
     "properties": {
-        "autodetect": {
+        "autodetect_methods": {
             "type": "array",
-            "items": {
-                "anyOf": [
-                    {
-                        "type": "object",
-                        "properties": {
-                            "method": {
-                                "type": "string",
-                                "enum": ["hostname", "fqdn", "xthostname"]
-                            }
-                        },
-                        "required": ["method"],
-                        "additionalProperties": false
-                    },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "method": {
-                                "type": "string",
-                                "enum": ["custom_file"]
-                            },
-                            "file": {"type": "string"}
-                        },
-                        "required": ["method", "file"],
-                        "additionalProperties": false
-                    },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "method": {
-                                "type": "string",
-                                "enum": ["custom_cmd"]
-                            },
-                            "cmd": {"type": "string"}
-                        },
-                        "required": ["method", "cmd"],
-                        "additionalProperties": false
-                    }
-                ]
-            }
+            "items": {"type": "string"}
         },
         "systems": {
             "type": "array",
@@ -555,6 +517,7 @@
     "required": ["systems", "environments", "logging"],
     "additionalProperties": false,
     "defaults": {
+        "autodetect_methods": ["py::socket.gethostname"],
         "environments/modules": [],
         "environments/env_vars": [],
         "environments/variables": [],

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -233,6 +233,48 @@
     },
     "type": "object",
     "properties": {
+        "autodetect": {
+            "type": "array",
+            "items": {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "method": {
+                                "type": "string",
+                                "enum": ["hostname", "fqdn", "xthostname"]
+                            }
+                        },
+                        "required": ["method"],
+                        "additionalProperties": false
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "method": {
+                                "type": "string",
+                                "enum": ["custom_file"]
+                            },
+                            "file": {"type": "string"}
+                        },
+                        "required": ["method", "file"],
+                        "additionalProperties": false
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "method": {
+                                "type": "string",
+                                "enum": ["custom_cmd"]
+                            },
+                            "cmd": {"type": "string"}
+                        },
+                        "required": ["method", "cmd"],
+                        "additionalProperties": false
+                    }
+                ]
+            }
+        },
         "systems": {
             "type": "array",
             "items": {

--- a/reframe/utility/__init__.py
+++ b/reframe/utility/__init__.py
@@ -1062,6 +1062,21 @@ class temp_setattr:
         setattr(self._obj, self._attr, self._saved)
 
 
+class temp_sys_path:
+    '''Context manager to temporarily change the py:obj:`sys.path`.'''
+
+    def __init__(self, path):
+        self._path = path
+        self._pos = None
+
+    def __enter__(self):
+        self._pos = len(sys.path)
+        sys.path.append(self._path)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        sys.path.pop(self._pos)
+
+
 class ScopedDict(UserDict):
     '''This is a special dictionary that imposes scopes on its keys.
 

--- a/unittests/resources/config/settings.py
+++ b/unittests/resources/config/settings.py
@@ -7,6 +7,11 @@
 # Configuration file just for unit testing
 #
 
+def hostname():
+    '''Custom hostname function for testing auto-detection'''
+    return 'testsys'
+
+
 site_configuration = {
     'systems': [
         {

--- a/unittests/test_config.py
+++ b/unittests/test_config.py
@@ -495,7 +495,7 @@ def test_hostname_autodetection(site_config):
     # order to trigger the auto-detection
     for use_xthostname in (True, False):
         for use_fqdn in (True, False):
-            site_config.set_autodetect_meth('hostname',
-                                            use_fqdn=use_fqdn,
-                                            use_xthostname=use_xthostname)
+            site_config.set_autodetect_methods(['py::socket.gethostname',
+                                                'py::socket.getfqdn',
+                                                'cat /etc/xthostname'])
             site_config.select_subconfig()

--- a/unittests/test_config.py
+++ b/unittests/test_config.py
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
-import os
 import json
 import pytest
 import sys

--- a/unittests/test_config.py
+++ b/unittests/test_config.py
@@ -3,8 +3,10 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+import os
 import json
 import pytest
+import sys
 
 import reframe.core.config as config
 import reframe.utility as util
@@ -18,7 +20,8 @@ def generate_partial_configs(tmp_path):
     part2 = tmp_path / 'settings-part2.py'
     part3 = tmp_path / 'settings-part3.py'
     mod = util.import_module_from_file(
-        'unittests/resources/config/settings.py')
+        'unittests/resources/config/settings.py'
+    )
     full_config = mod.site_configuration
 
     config_1 = {
@@ -37,7 +40,11 @@ def generate_partial_configs(tmp_path):
         'logging': full_config['logging'],
         'general': full_config['general'][3:],
     }
-    part1.write_text(f'site_configuration = {config_1!r}')
+
+    # We need to make sure that the custom hostname function is in one of the
+    # files
+    part1.write_text(f'def hostname(): return "testsys"\n'
+                     f'site_configuration = {config_1!r}')
     part2.write_text(f'site_configuration = {config_2!r}')
     part3.write_text(f'site_configuration = {config_3!r}')
     return part1, part2, part3
@@ -486,6 +493,56 @@ def test_variables(tmp_path):
     system = System.create(site_config)
     assert system.preload_environ.env_vars == {'FOO_CMD': 'foobar'}
     assert system.partitions[0].local_env.env_vars == {'FOO_GPU': 'yes'}
+
+
+def test_autodetect_meth_python(site_config, tmp_path):
+    moduledir = tmp_path / 'mymod'
+    moduledir.mkdir()
+    with open(moduledir / '__init__.py', 'w') as fp:
+        fp.write('def foo():\n\treturn "sys12"\n')
+
+    site_config.set_autodetect_methods(['py::mymod.foo'])
+    with util.temp_sys_path(str(tmp_path)):
+        site_config.select_subconfig()
+
+    assert site_config.get('systems/0/name') == 'sys0'
+
+    # Uncache the module
+    del sys.modules['mymod']
+
+
+def test_autodetect_meth_python_inline(site_config):
+    site_config.set_autodetect_methods(['py::hostname'])
+    site_config.select_subconfig()
+    assert site_config.get('systems/0/name') == 'testsys'
+
+
+def test_autodetect_meth_python_errors(site_config):
+    site_config.set_autodetect_methods(['py::mymod.foo'])
+    with pytest.raises(ConfigError):
+        site_config.select_subconfig()
+
+    site_config.set_autodetect_methods(['py::foo'])
+    with pytest.raises(ConfigError):
+        site_config.select_subconfig()
+
+
+def test_autodetect_meth_shell(site_config):
+    site_config.set_autodetect_methods(['echo testsys'])
+    site_config.select_subconfig()
+    assert site_config.get('systems/0/name') == 'testsys'
+
+
+def test_autodetect_meth_shell_errors(site_config):
+    site_config.set_autodetect_methods(['xxxxxxxxx'])
+    with pytest.raises(ConfigError):
+        site_config.select_subconfig()
+
+
+def test_autodetect_meth_multiple(site_config):
+    site_config.set_autodetect_methods(['py::foo', 'echo testsys'])
+    site_config.select_subconfig()
+    assert site_config.get('systems/0/name') == 'testsys'
 
 
 def test_hostname_autodetection(site_config):


### PR DESCRIPTION
~~There is a new section in the configuration that defines how to detect the system:~~
```python
# NOT VALID anymore
site_configuration = {
    'autodetect': [
        # The old methods can be defined like this
        {
            "method": "hostname",
        },
        {
            "method": "fqdn",
        },
        {
            "method": "xthostname",
        },
        # These are new methods
        {
            "method": "custom_cmd",
            "cmd": "echo sys",
            # we could also add a field to choose stdout or stderr
        },
        {
            "method": "custom_file",
            "file": "myhostnameo.txt"
        },
    ],
    'systems': [
...
```
~~Reframe will check the list and pick the system based on the first successful method. The default configuration has the standard `hostname` method. Reframe picks the first method that will be successful so as a result additional autodetect sections will be put on top of the list, like we do for systems.~~

EDIT from @vkarak 

I updated this PR so that the syntax of autodection methods is simplified but also generalised. More specifically, we introduce a new top-level section in the configuration, `autodetect_methods`. This is a list of strings which describe a method of autodetection. A normal string is a command to execute in order to retrieve a hostname. If this string is prefixed with `py::`, then the remaining string is interpreted as a Python method, which will be called to retrieve the hostname, e.g. `py::socket.gethostname`, will invoke `socket.gethostname()`. If the python callable name is not prefixed by a module name, then it will be searched in the configuration file.

Example config:

```python
site_configuration = {
    'autodetect_methods': ['cat /etc/xthostname', 'py::detect_azure_vm', 'py::socket.gethostname'],
    'systems': [...],
    'environments': [...]
}
```

A new `RFM_AUTODETECT_METHODS` environment variable is introduced, which is a comma-separated list of methods as described above. The former `RFM_AUTODETECT_METHOD`, `RFM_AUTODETECT_FQDN` and `RFM_AUTODETECT_XTHOSTNAME` are all deprecated as they can be replaced by the newly introduced env. variable.

We are still missing:
- [x] Documentation
- [x] Unit tests

Closes #2797.
Closes #2744.

@brandongc You should now be able to set `autodetect_methods` in your config to `['cat /etc/clustername', 'hostname']` and it should work.

@ireed This PR addresses also #2744 in the sense that you can now have reframe calling a custom Python method or a custom external script to retrieve a "hostname" that would match against the system's hostname patterns. Let me know if that would work in your scenario.