### PR TITLE
[feat] Add new `ci_extras` test variable that allows passing test-specific options to the pipeline generated by `--ci-generate`

### DIFF
--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -963,7 +963,7 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #: :default: :class:`True`
     build_locally = variable(typ.Bool, value=True, loggable=True)
 
-    #: .. versionadded:: ??
+    #: .. versionadded:: 4.2
     #:
     #: Options for CI pipeline passed in JSON format
     #:
@@ -974,8 +974,8 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #:
     #: :type: `dict`
     #: :default: ``{}``
-    ci_options = variable(typ.Dict[str, object],
-                          value={}, loggable=True)
+    ci_extras = variable(typ.Dict[typ.Str['gitlab'], object],
+                          value={}, loggable=False)
 
     # Special variables
 

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -963,6 +963,20 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #: :default: :class:`True`
     build_locally = variable(typ.Bool, value=True, loggable=True)
 
+    #: .. versionadded:: ??
+    #:
+    #: Options for CI pipeline passed in JSON format
+    #:
+    #: Example: If we want a pipeline to run only when files in
+    #: backend or src/main.c have changed, we add:
+    #:
+    #: ci_options = {"only": {"changes": ["backend/*", "src/main.c"]}
+    #:
+    #: :type: `dict`
+    #: :default: ``{}``
+    ci_options = variable(typ.Dict[str, object],
+                          value={}, loggable=True)
+
     # Special variables
 
     #: Dry-run mode

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -965,16 +965,27 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
 
     #: .. versionadded:: 4.2
     #:
-    #: Options for CI pipeline passed in JSON format
+    #: Extra options to be passed to the child CI pipeline generated for this
+    #: test using the :option:`--ci-generate` option.
     #:
-    #: Example: If we want a pipeline to run only when files in
-    #: backend or src/main.c have changed, we add:
+    #: This variable is a dictionary whose keys refer the CI generate backend
+    #: and the values can be in any CI backend-specific format.
     #:
-    #: ci_options = {"only": {"changes": ["backend/*", "src/main.c"]}
+    #: Currently, the only key supported is ``'gitlab'`` and the values is a
+    #: Gitlab configuration in JSON format. For example, if we want a pipeline
+    #: to run only when files in ``backend`` or ``src/main.c`` have changed,
+    #: this variable should be set as follows:
     #:
-    #: :type: `dict`
-    #: :default: ``{}``
-    ci_extras = variable(typ.Dict[typ.Str['gitlab'], object], value={})
+    #: .. code-block:: python
+    #:
+    #:    ci_extras = {
+    #:        'only': {'changes': ['backend/*', 'src/main.c']}
+    #:    }
+    #:
+    #: :type: :class:`dict` or :class:`NoneType`
+    #: :default: :obj:`None`
+    ci_extras = variable(typ.Dict[typ.Str['gitlab'], object], type(None),
+                         value=None)
 
     # Special variables
 

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -981,10 +981,9 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #:        'only': {'changes': ['backend/*', 'src/main.c']}
     #:    }
     #:
-    #: :type: :class:`dict` or :class:`NoneType`
-    #: :default: :obj:`None`
-    ci_extras = variable(typ.Dict[typ.Str['gitlab'], object], type(None),
-                         value=None)
+    #: :type: :class:`dict`
+    #: :default: ``{}``
+    ci_extras = variable(typ.Dict[typ.Str['gitlab'], object], value={})
 
     # Special variables
 

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -974,8 +974,7 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #:
     #: :type: `dict`
     #: :default: ``{}``
-    ci_extras = variable(typ.Dict[typ.Str['gitlab'], object],
-                          value={}, loggable=False)
+    ci_extras = variable(typ.Dict[typ.Str['gitlab'], object], value={})
 
     # Special variables
 

--- a/reframe/frontend/ci.py
+++ b/reframe/frontend/ci.py
@@ -68,7 +68,8 @@ def _emit_gitlab_pipeline(testcases, child_pipeline_opts):
             'artifacts': {
                 'paths': [f'{tc.check.unique_name}-report.json']
             },
-            'needs': [t.check.unique_name for t in tc.deps]
+            'needs': [t.check.unique_name for t in tc.deps],
+            **tc.check.ci_options
         }
         max_level = max(max_level, tc.level)
 

--- a/reframe/frontend/ci.py
+++ b/reframe/frontend/ci.py
@@ -75,8 +75,7 @@ def _emit_gitlab_pipeline(testcases, child_pipeline_opts):
         json['image'] = image_name
 
     for tc in testcases:
-        test_ci_extras = tc.check.ci_extras or {}
-        ci_extras = _valid_ci_extras(test_ci_extras.get('gitlab', {}))
+        ci_extras = _valid_ci_extras(tc.check.ci_extras.get('gitlab', {}))
         extra_artifacts = ci_extras.pop('artifacts', {})
         extra_artifact_paths = extra_artifacts.pop('paths', [])
         json[f'{tc.check.unique_name}'] = {

--- a/reframe/frontend/ci.py
+++ b/reframe/frontend/ci.py
@@ -69,7 +69,7 @@ def _emit_gitlab_pipeline(testcases, child_pipeline_opts):
                 'paths': [f'{tc.check.unique_name}-report.json']
             },
             'needs': [t.check.unique_name for t in tc.deps],
-            **tc.check.ci_options
+            **tc.check.ci_extras['gitlab']
         }
         max_level = max(max_level, tc.level)
 

--- a/reframe/frontend/ci.py
+++ b/reframe/frontend/ci.py
@@ -75,7 +75,8 @@ def _emit_gitlab_pipeline(testcases, child_pipeline_opts):
         json['image'] = image_name
 
     for tc in testcases:
-        ci_extras = _valid_ci_extras(tc.check.ci_extras.get('gitlab', {}))
+        test_ci_extras = tc.check.ci_extras or {}
+        ci_extras = _valid_ci_extras(test_ci_extras.get('gitlab', {}))
         extra_artifacts = ci_extras.pop('artifacts', {})
         extra_artifact_paths = extra_artifacts.pop('paths', [])
         json[f'{tc.check.unique_name}'] = {

--- a/reframe/frontend/ci.py
+++ b/reframe/frontend/ci.py
@@ -69,7 +69,7 @@ def _emit_gitlab_pipeline(testcases, child_pipeline_opts):
                 'paths': [f'{tc.check.unique_name}-report.json']
             },
             'needs': [t.check.unique_name for t in tc.deps],
-            **tc.check.ci_extras['gitlab']
+            **tc.check.ci_extras.get('gitlab', {})
         }
         max_level = max(max_level, tc.level)
 

--- a/unittests/test_ci.py
+++ b/unittests/test_ci.py
@@ -13,18 +13,27 @@ import yaml
 import reframe.frontend.ci as ci
 import reframe.frontend.dependencies as dependencies
 import reframe.frontend.executors as executors
+from reframe.core.exceptions import ReframeError
 from reframe.frontend.loader import RegressionCheckLoader
+
+
+def _generate_test_cases(checks):
+    return dependencies.toposort(
+        dependencies.build_deps(executors.generate_testcases(checks))[0]
+    )
+
+
+@pytest.fixture
+def hello_test():
+    from unittests.resources.checks.hellocheck import HelloTest
+    return HelloTest()
 
 
 def test_ci_gitlab_pipeline():
     loader = RegressionCheckLoader([
         'unittests/resources/checks_unlisted/deps_complex.py'
     ])
-    cases = dependencies.toposort(
-        dependencies.build_deps(
-            executors.generate_testcases(loader.load_all())
-        )[0]
-    )
+    cases = _generate_test_cases(loader.load_all())
     with io.StringIO() as fp:
         ci.emit_pipeline(fp, cases)
         pipeline = fp.getvalue()
@@ -41,3 +50,55 @@ def test_ci_gitlab_pipeline():
 
     schema = response.json()
     jsonschema.validate(yaml.safe_load(pipeline), schema)
+
+
+def test_ci_gitlab_ci_extras(hello_test):
+    hello_test.ci_extras = {
+        'gitlab': {
+            'before_script': ['touch foo.txt'],
+            'after_script': ['echo done'],
+            'artifacts': {
+                'paths': ['foo.txt']
+            },
+            'only': {
+                'changes': ['src/foo.c']
+            }
+        }
+    }
+    cases = _generate_test_cases([hello_test])
+    with io.StringIO() as fp:
+        ci.emit_pipeline(fp, cases)
+        pipeline = fp.getvalue()
+
+    pipeline_json = yaml.safe_load(pipeline)['HelloTest']
+    assert pipeline_json['before_script'] == ['touch foo.txt']
+    assert pipeline_json['after_script'] == ['echo done']
+    assert pipeline_json['artifacts'] == {
+        'paths': ['HelloTest-report.json', 'foo.txt']
+    }
+    assert pipeline_json['only'] == {'changes': ['src/foo.c']}
+
+
+def test_ci_gitlab_ci_extras_invalid(hello_test):
+    with pytest.raises(TypeError):
+        hello_test.ci_extras = {
+            'before_script': ['touch foo.txt']
+        }
+
+    with pytest.raises(TypeError):
+        hello_test.ci_extras = {
+            'foolab': {
+                'before_script': ['touch foo.txt']
+            }
+        }
+
+    # Check invalid keywords
+    for kwd in ('stage', 'script', 'needs'):
+        hello_test.ci_extras = {
+            'gitlab': {kwd: 'something'}
+        }
+        cases = _generate_test_cases([hello_test])
+        with io.StringIO() as fp:
+            with pytest.raises(ReframeError,
+                               match=rf'invalid keyword found: {kwd!r}'):
+                ci.emit_pipeline(fp, cases)


### PR DESCRIPTION
This PR allows to use Gitlab CI options to filter tests, e.g. based on [downstream pipelines](https://docs.gitlab.com/ee/ci/pipelines/downstream_pipelines.html) or [changes of the file](https://docs.gitlab.com/ee/ci/jobs/job_control.html). A minimal working example is provided in the repository https://gitlab.com/latticeqcd/reframe-debug, see [hello1.py](https://gitlab.com/latticeqcd/reframe-debug/-/blob/master/hello1.py)
- [Pipeline 810057836](https://gitlab.com/latticeqcd/reframe-debug/-/pipelines/810057836) runs for a branch that is in merge request, but has unmodified source file. Hence the test `HelloMergeRequest` is run.
- [Pipeline 810072116](https://gitlab.com/latticeqcd/reframe-debug/-/pipelines/810072116) now has modified source file and thus runs additionally `HelloModified`.