### PR TITLE
[feat] Add a symlink to the latest run report

### DIFF
--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+import functools
 import inspect
 import itertools
 import json
@@ -1369,6 +1370,23 @@ def main():
                 printer.warning(
                     f'failed to generate report in {report_file!r}: {e}'
                 )
+            else:
+                # Add a symlink to the latest report
+                with osext.change_dir(basedir):
+                    link_name = 'latest.json'
+                    create_symlink = functools.partial(
+                        os.symlink, os.path.basename(report_file), link_name
+                    )
+                    if not os.path.exists(link_name):
+                        create_symlink()
+                    else:
+                        if os.path.islink(link_name):
+                            os.remove(link_name)
+                            create_symlink()
+                        else:
+                            printer.warning('could not create a symlink '
+                                            'to the latest report file; '
+                                            'path exists and is not a symlink')
 
             # Generate the junit xml report for this session
             junit_report_file = rt.get_option('general/0/report_junit')

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -225,6 +225,7 @@ def test_report_file_with_sessionid(run_reframe, tmp_path, run_action):
     )
     assert returncode == 0
     assert os.path.exists(tmp_path / 'rfm-report-0.json')
+    assert os.readlink(tmp_path / 'latest.json') == 'rfm-report-0.json'
 
 
 def test_report_ends_with_newline(run_reframe, tmp_path, run_action):
@@ -237,6 +238,8 @@ def test_report_ends_with_newline(run_reframe, tmp_path, run_action):
     assert returncode == 0
     with open(tmp_path / 'rfm-report.json') as fp:
         assert fp.read()[-1] == '\n'
+
+    assert os.readlink(tmp_path / 'latest.json') == 'rfm-report.json'
 
 
 def test_check_submit_success(run_reframe, remote_exec_ctx, run_action):


### PR DESCRIPTION
This PR adds a `latest.json` symlink to the latest run report. This is useful when there are many reports and you would like to see all the details of the last run. Another extension that we could consider is to add an option to "tag" a report for quick future reference. This would create a symlink to the report using the tag name. What do you think?