### PR TITLE
[feat] Add support for repeated testing through two new options: `--reruns` and `--duration`

### DIFF
--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -459,6 +459,20 @@ Options controlling ReFrame execution
    .. versionadded:: 3.11.0
 
 
+.. option:: --duration=TIMEOUT
+
+   Run the test session repeatedly until the specified timeout expires.
+
+   ``TIMEOUT`` can be specified in one of the following forms:
+
+   - ``<int>`` or ``<float>``: number of seconds
+   - ``<days>d<hours>h<minutes>m<seconds>s``: a string denoting days, hours, minutes and/or seconds.
+
+   At the end, failures from every run will be reported and, similarly, the failure statistics printed by the :option:`--failure-stats` option will include all runs.
+
+   .. versionadded:: 4.2
+
+
 .. option:: --exec-order=ORDER
 
    Impose an execution order for the independent tests.
@@ -530,6 +544,24 @@ Options controlling ReFrame execution
       Repeating tests with dependencies is not supported, but you can repeat tests that use fixtures.
 
    .. versionadded:: 3.12.0
+
+
+.. option:: --reruns=N
+
+   Rerun the whole test session ``N`` times.
+
+   In total, the selected tests will run ``N+1`` times as the first time does not count as a rerun.
+
+   At the end, failures from every run will be reported and, similarly, the failure statistics printed by the :option:`--failure-stats` option will include all runs.
+
+   Although similar to :option:`--repeat`, this option behaves differently.
+   This option repeats the *whole* test session multiple times.
+   All the tests of the session will finish before a new run is started.
+   The :option:`--repeat` option on the other hand generates clones of the selected tests and schedules them for running in a single session.
+   As a result, all the test clones will run (by default) concurrently.
+
+   .. versionadded:: 4.2
+
 
 .. option:: --restore-session [REPORT1[,REPORT2,...]]
 

--- a/reframe/core/exceptions.py
+++ b/reframe/core/exceptions.py
@@ -101,6 +101,10 @@ class FailureLimitError(ReframeError):
     '''Raised when the limit of test failures has been reached.'''
 
 
+class RunSessionTimeout(ReframeError):
+    '''Raised when the maximum duration for a test session expires.'''
+
+
 class AbortTaskError(ReframeError):
     '''Raised by the runtime inside a regression task to denote that it has
     been aborted due to an external reason (e.g., keyboard interrupt, fatal
@@ -353,6 +357,12 @@ def is_severe(exc_type, exc_value, tb):
 
     # User errors are treated as soft
     return not is_user_error(exc_type, exc_value, tb)
+
+
+def is_warning(exc_type, exc_value, tb):
+    '''Check whether this exception can be treated as warning'''
+
+    return isinstance(exc_value, (RunSessionTimeout, KeyboardInterrupt))
 
 
 def what(exc_type, exc_value, tb):

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -30,7 +30,6 @@ import reframe.utility.jsonext as jsonext
 import reframe.utility.osext as osext
 import reframe.utility.typecheck as typ
 
-
 from reframe.frontend.testgenerators import (distribute_tests,
                                              getallnodes, repeat_tests)
 from reframe.frontend.executors.policies import (SerialExecutionPolicy,
@@ -403,6 +402,10 @@ def main():
               'is in STATE (default: "idle"')
     )
     run_options.add_argument(
+        '--duration', action='store', metavar='TIME',
+        help='Run the test session repeatedly for the specified duration'
+    )
+    run_options.add_argument(
         '--exec-order', metavar='ORDER', action='store',
         choices=['name', 'random', 'rname', 'ruid', 'uid'],
         help='Impose an execution order for independent tests'
@@ -437,6 +440,10 @@ def main():
     run_options.add_argument(
         '--repeat', action='store', metavar='N',
         help='Repeat selected tests N times'
+    )
+    run_options.add_argument(
+        '--reruns', action='store', metavar='N', default=0,
+        help='Rerun the whole test session N times', type=int
     )
     run_options.add_argument(
         '--restore-session', action='store', nargs='?', const='',
@@ -1297,11 +1304,21 @@ def main():
         if options.maxfail < 0:
             raise errors.CommandLineError(
                 f'--maxfail should be a non-negative integer: '
-                f'{options.maxfail!r}'
+                f'{options.maxfail}'
+            )
+
+        if options.reruns and options.duration:
+            raise errors.CommandLineError(
+                f"'--reruns' option cannot be combined with '--duration'"
+            )
+
+        if options.reruns < 0:
+            raise errors.CommandLineError(
+                f"'--reruns' should be a non-negative integer: {options.reruns}"
             )
 
         runner = Runner(exec_policy, printer, options.max_retries,
-                        options.maxfail)
+                        options.maxfail, options.reruns, options.duration)
         try:
             time_start = time.time()
             session_info['time_start'] = time.strftime(
@@ -1316,7 +1333,7 @@ def main():
             session_info['time_elapsed'] = time_end - time_start
 
             # Print a retry report if we did any retries
-            if runner.stats.failed(run=0):
+            if options.max_retries and runner.stats.failed(run=0):
                 printer.info(runner.stats.retry_report())
 
             # Print a failure report if we had failures in the last run
@@ -1324,10 +1341,13 @@ def main():
             if runner.stats.failed():
                 success = False
                 runner.stats.print_failure_report(
-                    printer, not options.distribute
+                    printer, not options.distribute,
+                    options.duration or options.reruns
                 )
                 if options.failure_stats:
-                    runner.stats.print_failure_stats(printer)
+                    runner.stats.print_failure_stats(
+                        printer, options.duration or options.reruns
+                    )
 
             if options.performance_report:
                 printer.info(runner.stats.performance_report())
@@ -1392,7 +1412,12 @@ def main():
     except (Exception, KeyboardInterrupt, errors.ReframeFatalError):
         exc_info = sys.exc_info()
         tb = ''.join(traceback.format_exception(*exc_info))
-        printer.error(f'run session stopped: {errors.what(*exc_info)}')
+        message = f'run session stopped: {errors.what(*exc_info)}'
+        if errors.is_warning(*exc_info):
+            printer.warning(message)
+        else:
+            printer.error(message)
+
         if errors.is_exit_request(*exc_info):
             # Print stack traces for exit requests only when TOO verbose
             printer.debug2(tb)

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -402,7 +402,7 @@ def main():
               'is in STATE (default: "idle"')
     )
     run_options.add_argument(
-        '--duration', action='store', metavar='TIME',
+        '--duration', action='store', metavar='TIMEOUT',
         help='Run the test session repeatedly for the specified duration'
     )
     run_options.add_argument(

--- a/reframe/frontend/executors/__init__.py
+++ b/reframe/frontend/executors/__init__.py
@@ -471,7 +471,7 @@ class TaskEventListener(abc.ABC):
 
     @abc.abstractmethod
     def on_task_abort(self, task):
-        '''Called when a RegressionTask has failed.'''
+        '''Called when a RegressionTask has aborted.'''
 
     @abc.abstractmethod
     def on_task_success(self, task):

--- a/reframe/frontend/printer.py
+++ b/reframe/frontend/printer.py
@@ -48,7 +48,7 @@ class PrettyPrinter:
 
         status_stripped = status.strip()
         if self.colorize:
-            if status_stripped in ('DRY', 'SKIP'):
+            if status_stripped in ('ABORT', 'ABORTED', 'DRY', 'SKIP'):
                 status = color.colorize(status, color.YELLOW)
             elif status_stripped in ('FAIL', 'FAILED', 'ERROR'):
                 status = color.colorize(status, color.RED)
@@ -56,8 +56,10 @@ class PrettyPrinter:
                 status = color.colorize(status, color.GREEN)
 
         final_msg = f'[ {status} ] '
-        if status_stripped in ('OK', 'SKIP', 'FAIL'):
-            self._progress_count += 1
+        if status_stripped in ('ABORT', 'OK', 'SKIP', 'FAIL'):
+            if self._progress_count < self._progress_total:
+                self._progress_count += 1
+
             width = len(str(self._progress_total))
             padded_progress = str(self._progress_count).rjust(width)
             final_msg += f'({padded_progress}/{self._progress_total}) '

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -888,7 +888,7 @@ def test_maxfail_option(run_reframe):
     assert 'Traceback' not in stdout
     assert 'Traceback' not in stderr
     assert ('Ran 2/2 test case(s) from 2 check(s) '
-            '(0 failure(s), 0 skipped)') in stdout
+            '(0 failure(s), 0 skipped, 0 aborted)') in stdout
     assert returncode == 0
 
 
@@ -925,7 +925,7 @@ def test_repeat_option(run_reframe, run_action):
     assert 'Traceback' not in stdout
     assert 'Traceback' not in stderr
     assert ('Ran 2/2 test case(s) from 2 check(s) '
-            '(0 failure(s), 0 skipped)') in stdout
+            '(0 failure(s), 0 skipped, 0 aborted)') in stdout
     assert returncode == 0
 
 
@@ -947,6 +947,30 @@ def test_repeat_negative(run_reframe):
         checkpath=['unittests/resources/checks/hellocheck.py']
     )
     errmsg = "argument to '--repeat' option must be a non-negative integer"
+    assert 'Traceback' not in stdout
+    assert 'Traceback' not in stderr
+    assert errmsg in stdout
+    assert returncode == 1
+
+
+def test_reruns_negative(run_reframe):
+    returncode, stdout, stderr = run_reframe(
+        more_options=['--reruns', '-1'],
+        checkpath=['unittests/resources/checks/hellocheck.py']
+    )
+    errmsg = "'--reruns' should be a non-negative integer"
+    assert 'Traceback' not in stdout
+    assert 'Traceback' not in stderr
+    assert errmsg in stdout
+    assert returncode == 1
+
+
+def test_reruns_with_duration(run_reframe):
+    returncode, stdout, stderr = run_reframe(
+        more_options=['--reruns=-1', '--duration=5s'],
+        checkpath=['unittests/resources/checks/hellocheck.py']
+    )
+    errmsg = "'--reruns' option cannot be combined with '--duration'"
     assert 'Traceback' not in stdout
     assert 'Traceback' not in stderr
     assert errmsg in stdout

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -27,8 +27,9 @@ import unittests.utility as test_util
 from lxml import etree
 from reframe.core.exceptions import (AbortTaskError,
                                      FailureLimitError,
-                                     ReframeError,
                                      ForceExitError,
+                                     ReframeError,
+                                     RunSessionTimeout,
                                      TaskDependencyError)
 from reframe.frontend.loader import RegressionCheckLoader
 from unittests.resources.checks.hellocheck import HelloTest
@@ -496,6 +497,34 @@ def test_sigterm_handling(make_runner, make_cases, common_exec_ctx):
     assert len(runner.stats.failed()) == 1
 
 
+def test_reruns(make_runner, make_cases, common_exec_ctx):
+    runner = make_runner(reruns=2)
+    test = HelloTest()
+
+    runner.runall(make_cases([test]))
+    stats = runner.stats
+    assert stats.num_runs == 3
+    assert not stats.failed(run=None)
+
+
+def test_duration_limit(make_runner, make_cases, common_exec_ctx):
+    runner = make_runner(timeout=2)
+    test = HelloTest()
+
+    with pytest.raises(RunSessionTimeout):
+        runner.runall(make_cases([test]))
+        stats = runner.stats
+
+        assert not stats.failed(run=None)
+
+        # A task may or may not be aborted depending on when the timeout
+        # expires, but if it gets aborted, only a single test can be aborted
+        # in this case for both policies.
+        num_aborted = stats.aborted(run=None)
+        if num_aborted:
+            assert num_aborted == 1
+
+
 @pytest.fixture
 def dep_checks(make_loader):
     return make_loader(
@@ -582,6 +611,9 @@ class _TaskEventMonitor(executors.TaskEventListener):
         pass
 
     def on_task_failure(self, task):
+        pass
+
+    def on_task_abort(self, task):
         pass
 
     def on_task_skip(self, task):


### PR DESCRIPTION
This PR introduces the following two options that are meant to allow users to use reframe for stress testing a target system:

- The `--reruns=N` option will rerun the same test suite N times (N+1 total runs).
- The `--duration=TIMEOUT` option will run the same test suite repeatedly until `TIMEOUT` expires.

Compared to the similar `--max-retries` option that reruns the failed tests, these options will report statistics as well as failures from _all_ runs.

Closes #619.

@brandongc FYI

### Todos

- [x] Update the docs