### PR TITLE
[bugfix] Fix log record attribute names of performance thresholds

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -1065,7 +1065,7 @@ All logging handlers share the following set of common attributes:
       ``%(check_perf_lower_thres)s``, The lower threshold of the logged performance variable.
       ``%(check_perf_ref)s``, The reference value of the logged performance variable.
       ``%(check_perf_unit)s``, The measurement unit of the logged performance variable.
-      ``%(check_perf_upper)s``, The upper thresholds of the logged performance variable.
+      ``%(check_perf_upper_thres)s``, The upper threshold of the logged performance variable.
       ``%(check_perf_value)s``, The actual value of the logged performance variable.
       ``%(check_perf_var)s``, The name of the logged performance variable.
 

--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -280,8 +280,8 @@ class CheckFieldFormatter(logging.Formatter):
                 'check_perf_value': val,
                 'check_perf_unit': unit,
                 'check_perf_ref': ref,
-                'check_perf_lower': lower,
-                'check_perf_upper': upper
+                'check_perf_lower_thres': lower,
+                'check_perf_upper_thres': upper
             }
             try:
                 chunks.append(self.__fmtperf % record)

--- a/reframe/core/settings.py
+++ b/reframe/core/settings.py
@@ -62,8 +62,8 @@ site_configuration = {
                     ),
                     'format_perfvars': (
                         '%(check_perf_value)s,%(check_perf_unit)s,'
-                        '%(check_perf_ref)s,%(check_perf_lower)s,'
-                        '%(check_perf_upper)s,'
+                        '%(check_perf_ref)s,%(check_perf_lower_thres)s,'
+                        '%(check_perf_upper_thres)s,'
                     ),
                     'append': True
                 }

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -1099,8 +1099,8 @@ def test_perf_logging(make_runner, make_exec_ctx, perf_test,
             ),
             perffmt=(
                 '%(check_perf_value)s,%(check_perf_unit)s,'
-                '%(check_perf_ref)s,%(check_perf_lower)s,'
-                '%(check_perf_upper)s,'
+                '%(check_perf_ref)s,%(check_perf_lower_thres)s,'
+                '%(check_perf_upper_thres)s,'
             )
         )
     )
@@ -1277,8 +1277,8 @@ def test_perf_logging_lazy(make_runner, make_exec_ctx, lazy_perf_test,
             ),
             perffmt=(
                 '%(check_perf_value)s,%(check_perf_unit)s,'
-                '%(check_perf_ref)s,%(check_perf_lower)s,'
-                '%(check_perf_upper)s,'
+                '%(check_perf_ref)s,%(check_perf_lower_thres)s,'
+                '%(check_perf_upper_thres)s,'
             )
         )
     )


### PR DESCRIPTION
ReFrame 4.0 erroneously changed the `check_perf_lower/upper_thres` log record attributes to `check_perf_lower/upper`, but only for the single line output of perflog. The multiline output still recognised the original names. This PR fixes this inconsistency by using the original names everywhere.

Closes #2809.