### PR TITLE
[feat] Allow custom HTTP headers with the `httpjson` log handler

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -1326,6 +1326,19 @@ The additional properties for the ``httpjson`` handler are the following:
    The URL to be used in the HTTP(S) request server.
 
 
+.. py:attribute:: logging.handlers..httpjson..extra_headers
+
+.. py:attribute:: logging.handlers_perflog..httpjson..extra_headers
+
+   :required: No
+   :default: ``{}``
+
+   A set of optional key/value pairs to be sent as HTTP message headers (e.g. API keys).
+   These may depend on the server configuration.
+
+   .. versionadded:: 4.2
+
+
 .. py:attribute:: logging.handlers..httpjson..extras
 
 .. py:attribute:: logging.handlers_perflog..httpjson..extras
@@ -1345,15 +1358,6 @@ The additional properties for the ``httpjson`` handler are the following:
 
    These keys will be excluded from the log record that will be sent to the server.
 
-.. py:attribute:: logging.handlers..httpjson..extra_headers
-
-.. py:attribute:: logging.handlers_perflog..httpjson..extra_headers
-
-   :required: No
-   :default: ``{}``
-
-   A set of optional key/value pairs to be sent as HTTP message headers(e.g. API keys).
-   These may depend on the server configuration.
 
 The ``httpjson`` handler sends log messages in JSON format using an HTTP POST request to the specified URL.
 
@@ -1365,12 +1369,12 @@ An example configuration of this handler for performance logging is shown here:
        'type': 'httpjson',
        'url': 'http://httpjson-server:12345/rfm',
        'level': 'info',
+       'extra_headers': {'Authorization': 'Token YOUR_API_TOKEN'},
        'extras': {
            'facility': 'reframe',
            'data-version': '1.0'
        },
        'ignore_keys': ['check_perfvalues']
-       'extra_headers': {'Authorization': 'Token YOUR_API_TOKEN'}
    }
 
 

--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -1345,6 +1345,15 @@ The additional properties for the ``httpjson`` handler are the following:
 
    These keys will be excluded from the log record that will be sent to the server.
 
+.. py:attribute:: logging.handlers..httpjson..extra_headers
+
+.. py:attribute:: logging.handlers_perflog..httpjson..extra_headers
+
+   :required: No
+   :default: ``{}``
+
+   A set of optional key/value pairs to be sent as HTTP message headers(e.g. API keys).
+   These may depend on the server configuration.
 
 The ``httpjson`` handler sends log messages in JSON format using an HTTP POST request to the specified URL.
 
@@ -1361,6 +1370,7 @@ An example configuration of this handler for performance logging is shown here:
            'data-version': '1.0'
        },
        'ignore_keys': ['check_perfvalues']
+       'extra_headers': {'Authorization': 'Token YOUR_API_TOKEN'}
    }
 
 

--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -515,7 +515,8 @@ def _create_httpjson_handler(site_config, config_prefix):
         getlogger().warning('httpjson: running in debug mode; '
                             'no data will be sent to the server')
 
-    return HTTPJSONHandler(url, extras, ignore_keys, json_formatter, extra_headers, debug)
+    return HTTPJSONHandler(url, extras, ignore_keys, json_formatter,
+                           extra_headers, debug)
 
 
 def _record_to_json(record, extras, ignore_keys):
@@ -587,6 +588,7 @@ class HTTPJSONHandler(logging.Handler):
                          'Accept-Charset': 'UTF-8'}
         if extra_headers:
             self._headers.update(extra_headers)
+
         self._debug = debug
 
     def emit(self, record):

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -166,6 +166,7 @@
                             "items": {"type": "string"}
                         },
                         "json_formatter": {},
+                        "extra_headers": {"type": "object"},
                         "debug": {"type": "boolean"}
                     },
                     "required": ["url"]
@@ -571,6 +572,7 @@
         "logging/handlers*/httpjson_extras": {},
         "logging/handlers*/httpjson_ignore_keys": [],
         "logging/handlers*/httpjson_json_formatter": null,
+        "logging/handlers*/httpjson_extra_headers": {},
         "logging/handlers*/httpjson_debug": false,
         "logging/handlers*/stream_name": "stdout",
         "logging/handlers*/syslog_socktype": "udp",


### PR DESCRIPTION
I tested this with ncat and a small config file as 

```python
site_configuration = {
    'logging': [
        {
        'handlers_perflog': [

            {
            'type': 'httpjson',
            'url': 'http://localhost:12345',
            'level': 'info',
            'extras': {
                'facility': 'reframe',
                'data-version': '1.0'
            },
            'debug': False,
            'extra_headers': {
               'ApiKey': 'test'
            }
            }
            ]
        }
    ]
}
```
Closes #2850.


~~Should we implement a test ?~~

