### PR TITLE
[bugfix] Do not symlink against report files in non-default locations

### DIFF
--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -367,10 +367,14 @@ Options controlling ReFrame output
    The file where ReFrame will store its report.
 
    The ``FILE`` argument may contain the special placeholder ``{sessionid}``, in which case ReFrame will generate a new report each time it is run by appending a counter to the report file.
+   If the report is generated in the default location (see the :attr:`~config.general.report_file` configuration option), a symlink to the latest report named ``latest.json`` will also be created.
 
    This option can also be set using the :envvar:`RFM_REPORT_FILE` environment variable or the :attr:`~config.general.report_file` general configuration parameter.
 
    .. versionadded:: 3.1
+
+   .. versionadded:: 4.2
+      Symlink to the latest report is now created.
 
 .. option:: --report-junit=FILE
 

--- a/reframe/core/runtime.py
+++ b/reframe/core/runtime.py
@@ -170,9 +170,22 @@ class RuntimeContext:
         :returns: The value of the option.
 
         .. versionchanged:: 3.11.0
-          Add ``default`` named argument.
+           Add ``default`` named argument.
         '''
         return self._site_config.get(option, default=default)
+
+    def get_default(self, option):
+        '''Get the default value for the option as defined in the configuration
+        schema.
+
+        :arg option: The option whose default value is requested
+        :returns: The default value of the requested option
+        :raises KeyError: if option does not have a default value
+
+        .. versionadded:: 4.2
+        '''
+
+        return self._site_config.schema['defaults'][option]
 
 
 # Global resources for the current host

--- a/reframe/frontend/runreport.py
+++ b/reframe/frontend/runreport.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import decimal
+import functools
 import json
 import jsonschema
 import lxml.etree as etree
@@ -13,6 +14,8 @@ import re
 import reframe as rfm
 import reframe.core.exceptions as errors
 import reframe.utility.jsonext as jsonext
+import reframe.utility.osext as osext
+from reframe.core.logging import getlogger
 from reframe.core.warnings import suppress_deprecations
 
 # The schema data version
@@ -177,6 +180,36 @@ def load_report(*filenames):
         rpt.add_fallback(_load_report(f))
 
     return rpt
+
+
+def write_report(report, filename, compress=False, link_to_last=False):
+    with open(filename, 'w') as fp:
+        if compress:
+            jsonext.dump(report, fp)
+        else:
+            jsonext.dump(report, fp, indent=2)
+            fp.write('\n')
+
+        if not link_to_last:
+            return
+
+        # Add a symlink to the latest report
+        basedir = os.path.dirname(filename)
+        with osext.change_dir(basedir):
+            link_name = 'latest.json'
+            create_symlink = functools.partial(
+                os.symlink, os.path.basename(filename), link_name
+            )
+            if not os.path.exists(link_name):
+                create_symlink()
+            else:
+                if os.path.islink(link_name):
+                    os.remove(link_name)
+                    create_symlink()
+                else:
+                    getlogger().warning('could not create a symlink '
+                                        'to the latest report file: '
+                                        'path exists and is not a symlink')
 
 
 def junit_xml_report(json_report):

--- a/test_reframe.py
+++ b/test_reframe.py
@@ -39,7 +39,12 @@ if __name__ == '__main__':
         '--rfm-help', action='help', help='Print this help message and exit.'
     )
     options, rem_args = parser.parse_known_args()
-    test_util.USER_CONFIG_FILE = options.rfm_user_config
+
+    user_config = options.rfm_user_config
+    if user_config is not None:
+        user_config = os.path.abspath(user_config)
+
+    test_util.USER_CONFIG_FILE = user_config
     test_util.USER_SYSTEM = options.rfm_user_system
     test_util.init_runtime()
 

--- a/unittests/resources/config/settings.py
+++ b/unittests/resources/config/settings.py
@@ -241,7 +241,7 @@ site_configuration = {
         {
             'name': 'unittest',
             'options': [
-                '-c unittests/resources/checks/hellocheck.py',
+                '-n ^HelloTest$',
                 '-p builtin',
                 '-S local=1'
             ]


### PR DESCRIPTION
This is a follow up of #2834 and fixes #2849.

The implementation of this feature is refactored as well as some of the unit tests. The `run_reframe()` is now running from the temp path, so some of the of the unit tests had to be adapted.