### PR TITLE
[doc] Use official Slack permanent invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/reframe-hpc)
 [![Downloads](https://pepy.tech/badge/reframe-hpc)](https://pepy.tech/project/reframe-hpc)
 [![Downloads](https://pepy.tech/badge/reframe-hpc/month)](https://pepy.tech/project/reframe-hpc)<br/>
-[![Slack](https://reframe-slack.herokuapp.com/badge.svg)](https://reframe-slack.herokuapp.com/)<br/>
+[![Slack](https://badgen.net/badge/icon/slack?icon=slack&label)](https://join.slack.com/t/reframetalk/shared_invite/zt-1tar8s71w-At0tolJ~~zxT2oG_2Ly9sw)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![DOI](https://zenodo.org/badge/89384186.svg)](https://zenodo.org/badge/latestdoi/89384186)<br/>
 [![Twitter Follow](https://img.shields.io/twitter/follow/ReFrameHPC?style=social)](https://twitter.com/ReFrameHPC)
@@ -93,7 +93,7 @@ You can get in contact with the ReFrame community in the following ways:
 
 ### Slack
 
-Please join the community's [Slack channel](https://reframe-slack.herokuapp.com) for keeping up with the latest news about ReFrame, posting questions and, generally getting in touch with other users and the developers.
+Please join the community's [Slack channel](https://join.slack.com/t/reframetalk/shared_invite/zt-1tar8s71w-At0tolJ~~zxT2oG_2Ly9sw) for keeping up with the latest news about ReFrame, posting questions and, generally getting in touch with other users and the developers.
 
 ## Contributing back
 


### PR DESCRIPTION
We will discontinue the use of the Heroku app for two reasons: (a) it's not anymore free and (b) it's not working for a while. This PR uses an official permanent invite link for the workspace.