### PR TITLE
[feat] Allow setting nested mapping types using the `-S` option

### DIFF
--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -632,6 +632,9 @@ Options controlling ReFrame execution
    - Sequence types: ``-S seqvar=1,2,3,4``
    - Mapping types: ``-S mapvar=a:1,b:2,c:3``
 
+   Nested mapping types can also be converted using JSON syntax.
+   For example, the :attr:`~reframe.core.pipeline.RegressionTest.extra_resources` complex dictionary could be set with ``-S extra_resources='{"gpu": {"num_gpus_per_node":8}}'``.
+
    Conversions to arbitrary objects are also supported.
    See :class:`~reframe.utility.typecheck.ConvertibleType` for more details.
 

--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -690,6 +690,9 @@ Options controlling ReFrame execution
 
       Allow setting variables in fixtures.
 
+   .. versionchanged:: 4.4
+
+      Allow setting nested mapping types using JSON syntax.
 
 .. option:: --skip-performance-check
 

--- a/reframe/utility/typecheck.py
+++ b/reframe/utility/typecheck.py
@@ -95,6 +95,7 @@ of :class:`List[int]`.
 
 import abc
 import datetime
+import json
 import re
 
 
@@ -322,19 +323,25 @@ class _MappingType(_BuiltinType):
         mappping_type = cls._type
         key_type = cls._key_type
         value_type = cls._value_type
-        seq = []
-        for key_datum in s.split(','):
-            try:
-                k, v = key_datum.split(':')
-            except ValueError:
-                # Re-raise as TypeError
-                raise TypeError(
-                    f'cannot convert string {s!r} to {cls.__name__!r}'
-                ) from None
 
-            seq.append((key_type(k), value_type(v)))
+        try:
+            d = json.loads(s)
+        except json.JSONDecodeError:
+            seq = []
+            for key_datum in s.split(','):
+                try:
+                    k, v = key_datum.split(':')
+                except ValueError:
+                    # Re-raise as TypeError
+                    raise TypeError(
+                        f'cannot convert string {s!r} to {cls.__name__!r}'
+                    ) from None
 
-        return mappping_type(seq)
+                seq.append((key_type(k), value_type(v)))
+
+            return mappping_type(seq)
+        else:
+            return mappping_type(d)
 
 
 class _StrType(_SequenceType):

--- a/reframe/utility/typecheck.py
+++ b/reframe/utility/typecheck.py
@@ -325,9 +325,9 @@ class _MappingType(_BuiltinType):
         value_type = cls._value_type
 
         try:
-            d = json.loads(s)
+            items = json.loads(s)
         except json.JSONDecodeError:
-            seq = []
+            items = []
             for key_datum in s.split(','):
                 try:
                     k, v = key_datum.split(':')
@@ -337,11 +337,9 @@ class _MappingType(_BuiltinType):
                         f'cannot convert string {s!r} to {cls.__name__!r}'
                     ) from None
 
-                seq.append((key_type(k), value_type(v)))
+                items.append((key_type(k), value_type(v)))
 
-            return mappping_type(seq)
-        else:
-            return mappping_type(d)
+        return mappping_type(items)
 
 
 class _StrType(_SequenceType):

--- a/unittests/test_typecheck.py
+++ b/unittests/test_typecheck.py
@@ -209,12 +209,12 @@ def test_mapping_type():
     assert typ.Dict[str, int]('a:1,b:2') == {'a': 1, 'b': 2}
 
     # Conversion with JSON syntax, for nested dictionaries
-    s = '{"gpu":{"num_gpus_per_node":8}, "mpi": {"num_slots": 64}}'
-    assert (typ.Dict[str, typ.Dict[str, object]](s) ==
-            {
-                "gpu": {"num_gpus_per_node": 8},
-                "mpi": {"num_slots": 64},
-            })
+    s = '{"gpu":{"num_gpus_per_node": 8}, "mpi": {"num_slots": 64}}'
+    expected = {
+        'gpu': {'num_gpus_per_node': 8},
+        'mpi': {'num_slots': 64},
+    }
+    assert typ.Dict[str, typ.Dict[str, object]](s) == expected
 
     with pytest.raises(TypeError):
         typ.Dict[str, int]('a:1,b')

--- a/unittests/test_typecheck.py
+++ b/unittests/test_typecheck.py
@@ -208,6 +208,14 @@ def test_mapping_type():
     # Test conversions
     assert typ.Dict[str, int]('a:1,b:2') == {'a': 1, 'b': 2}
 
+    # Conversion with JSON syntax, for nested dictionaries
+    s = '{"gpu":{"num_gpus_per_node":8}, "mpi": {"num_slots": 64}}'
+    assert (typ.Dict[str, typ.Dict[str, object]](s) ==
+            {
+                "gpu": {"num_gpus_per_node": 8},
+                "mpi": {"num_slots": 64},
+            })
+
     with pytest.raises(TypeError):
         typ.Dict[str, int]('a:1,b')
 


### PR DESCRIPTION
The advantage is that we can automatically convert nested mappings, like for example the `extra_resources` attribute, which can thus be set from the command line.

This is the kind of change I'd like to propose to fix #2868.  If this is deemed acceptable, I'll add some tests.