### PR TITLE
[feat] Parameterise test from command line

### DIFF
--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -539,6 +539,18 @@ Options controlling ReFrame execution
    .. versionchanged:: 4.1
       Options that can be specified multiple times are now combined between execution modes and the command line.
 
+.. option:: -P, --parameterize=[TEST.]VAR=VAL0,VAL1,...
+
+   Parameterize a test on an existing variable.
+
+   This option will create a new test with a parameter named ``$VAR`` with the values given in the comma-separated list ``VAL0,VAL1,...``.
+   The values will be converted based on the type of the target variable ``VAR``.
+   The ``TEST.`` prefix will only parameterize the variable ``VAR`` of test ``TEST``.
+
+   The :option:`-P` can be specified multiple times in order to parameterize multiple variables.
+
+   .. versionadded:: 4.3
+
 .. option:: --repeat=N
 
    Repeat the selected tests ``N`` times.

--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -549,6 +549,12 @@ Options controlling ReFrame execution
 
    The :option:`-P` can be specified multiple times in order to parameterize multiple variables.
 
+   .. note::
+
+      Conversely to the :option:`-S` option that can set a variable in an arbitrarily nested fixture,
+      the :option:`-P` option can only parameterize the leaf test:
+      it cannot be used to parameterize a fixture of the test.
+
    .. versionadded:: 4.3
 
 .. option:: --repeat=N

--- a/reframe/core/meta.py
+++ b/reframe/core/meta.py
@@ -937,17 +937,15 @@ def make_test(name, bases, body, methods=None, module=None, **kwargs):
     methods = methods or []
 
     # Update the namespace with the body elements
-    namespace.update(body)
+    #
+    # NOTE: We do not use `update()` here so as to force the `__setitem__`
+    # logic
+    for k, v in body.items():
+        namespace[k] = v
 
     # Add methods to the namespace
     for m in methods:
         namespace[m.__name__] = m
-
-    # We explicitly call reset on each namespace key to trigger the
-    # functionality of `__setitem__()` as if the body elements were actually
-    # being typed in the class definition
-    for k in list(namespace.keys()):
-        namespace.reset(k)
 
     cls = RegressionTestMeta(name, bases, namespace, **kwargs)
     if not module:

--- a/reframe/core/meta.py
+++ b/reframe/core/meta.py
@@ -936,20 +936,20 @@ def make_test(name, bases, body, methods=None, module=None, **kwargs):
     namespace = RegressionTestMeta.__prepare__(name, bases, **kwargs)
     methods = methods or []
 
-    # Add methods to the body
-    for m in methods:
-        body[m.__name__] = m
-
-    # We update the namespace with the body of the class and we explicitly
-    # call reset on each namespace key to trigger the functionality of
-    # `__setitem__()` as if the body elements were actually being typed in the
-    # class definition
+    # Update the namespace with the body elements
     namespace.update(body)
+
+    # Add methods to the namespace
+    for m in methods:
+        namespace[m.__name__] = m
+
+    # We explicitly call reset on each namespace key to trigger the
+    # functionality of `__setitem__()` as if the body elements were actually
+    # being typed in the class definition
     for k in list(namespace.keys()):
         namespace.reset(k)
 
     cls = RegressionTestMeta(name, bases, namespace, **kwargs)
-
     if not module:
         # Set the test's module to be that of our callers
         caller = inspect.currentframe().f_back

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -1101,7 +1101,7 @@ def main():
                 f'{len(testcases)} remaining'
             )
 
-        if options.parameterize is not None:
+        if options.parameterize:
             # Prepare parameters
             params = {}
             for param_spec in options.parameterize:

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -30,7 +30,8 @@ import reframe.utility.osext as osext
 import reframe.utility.typecheck as typ
 
 from reframe.frontend.testgenerators import (distribute_tests,
-                                             getallnodes, repeat_tests)
+                                             getallnodes, repeat_tests,
+                                             parameterize_tests)
 from reframe.frontend.executors.policies import (SerialExecutionPolicy,
                                                  AsynchronousExecutionPolicy)
 from reframe.frontend.executors import Runner, generate_testcases
@@ -435,6 +436,10 @@ def main():
     )
     run_options.add_argument(
         '--mode', action='store', help='Execution mode to use'
+    )
+    run_options.add_argument(
+        '-P', '--parameterize', action='append', metavar='VAR:VAL0,VAL1,...',
+        default=[], help='Parameterize a test on a set of variables'
     )
     run_options.add_argument(
         '--repeat', action='store', metavar='N',
@@ -1095,6 +1100,22 @@ def main():
                 f'Filtering successful test case(s): '
                 f'{len(testcases)} remaining'
             )
+
+        if options.parameterize is not None:
+            # Prepare parameters
+            params = {}
+            for param_spec in options.parameterize:
+                try:
+                    var, values_spec = param_spec.split('=')
+                except ValueError:
+                    raise errors.CommandLineError(
+                        f'invalid parameter spec: {param_spec}'
+                    ) from None
+                else:
+                    params[var] = values_spec.split(',')
+
+            testcases_all = parameterize_tests(testcases, params)
+            testcases = testcases_all
 
         if options.repeat is not None:
             try:

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -105,6 +105,8 @@ def run_reframe(tmp_path, monkeypatch):
             argv += ['--list-tags']
         elif action == 'help':
             argv += ['-h']
+        elif action == 'describe':
+            argv += ['--describe']
 
         if perflogdir:
             argv += ['--perflogdir', perflogdir]
@@ -955,6 +957,32 @@ def test_repeat_negative(run_reframe):
     assert 'Traceback' not in stderr
     assert errmsg in stdout
     assert returncode == 1
+
+
+def test_parameterize_tests(run_reframe):
+    returncode, stdout, _ = run_reframe(
+        more_options=['-P', 'num_tasks=2,4,8', '-n', '^HelloTest'],
+        checkpath=['unittests/resources/checks/hellocheck.py'],
+        action='describe'
+    )
+    assert returncode == 0
+
+    test_descr = json.loads(stdout)
+    print(json.dumps(test_descr, indent=2))
+    num_tasks = {t['num_tasks'] for t in test_descr}
+    assert num_tasks == {2, 4, 8}
+
+
+def test_parameterize_tests_invalid_params(run_reframe):
+    returncode, stdout, stderr = run_reframe(
+        more_options=['-P', 'num_tasks', '-n', '^HelloTest'],
+        checkpath=['unittests/resources/checks/hellocheck.py'],
+        action='list'
+    )
+    assert returncode == 1
+    assert 'Traceback' not in stdout
+    assert 'Traceback' not in stderr
+    assert 'invalid parameter spec' in stdout
 
 
 def test_reruns_negative(run_reframe):


### PR DESCRIPTION
This PR introduces parameterisation from the command line on existing variables. Passing `-P num_tasks=1,2,4,8` will create a parameterised version of a test with different `num_tasks` values. This feature cannot parameterise fixtures.

Closes #2665.

### Todos

- [x] Update the docs