### PR TITLE
[doc] Fix broken formatting in `extractall_s()` docs

### DIFF
--- a/reframe/utility/sanity.py
+++ b/reframe/utility/sanity.py
@@ -790,7 +790,7 @@ def extractall_s(patt, string, tag=0, conv=None):
     ``patt`` in ``string``.
 
     :arg patt: as in :func:`extractall`.
-'   :arg string: The string to examine.
+    :arg string: The string to examine.
     :arg tag: as in :func:`extractall`.
     :arg conv: as in :func:`extractall`.
     :returns: same as :func:`extractall`.


### PR DESCRIPTION
Fix #2909, broken formatting in `extractall_s()` docs.

Before:
<img width="729" alt="image" src="https://github.com/reframe-hpc/reframe/assets/32687739/e671397e-ecf5-4b3a-8784-fe214683f6bb">

After: 
<img width="722" alt="image" src="https://github.com/reframe-hpc/reframe/assets/32687739/8ca19395-1a50-47eb-b4cc-15830c099e36">
