### PR TITLE
[feat] Additional Spack build system options

### DIFF
--- a/reframe/core/buildsystems.py
+++ b/reframe/core/buildsystems.py
@@ -863,7 +863,7 @@ class Spack(BuildSystem):
     #: :default: :obj:`True`
     emit_load_cmds = variable(bool, value=True)
 
-    #: Options to pass to ``spack install``
+    #: Options to pass to ``spack install``.
     #:
     #: :type: :class:`List[str]`
     #: :default: ``[]``
@@ -876,6 +876,21 @@ class Spack(BuildSystem):
     #:
     #: .. versionadded:: 4.2
     config_opts = variable(typ.List[str], value=[])
+
+    #: Options to pass to ``spack env create``.
+    #:
+    #: :type: :class:`List[str]`
+    #: :default: ``[]``
+    env_create_opts = variable(typ.List[str], value=[])
+
+    #: A list of commands to run after a Spack environment
+    #: is created, but before it is installed.
+    #:
+    #: :type: :class:`List[str]`
+    #: :default: ``[]``
+    #:
+    preinstall_cmds = variable(typ.List[str], value=[])
+
 
     def __init__(self):
         # Set to True if the environment was auto-generated
@@ -897,6 +912,10 @@ class Spack(BuildSystem):
             specs_str = ' '.join(self.specs)
             ret.append(f'spack -e {self.environment} add {specs_str}')
 
+        if self.preinstall_cmds:
+            for cmd in self.preinstall_cmds:
+                ret.append(cmd)
+
         install_cmd = f'spack -e {self.environment} install'
         if self.install_opts:
             install_cmd += ' ' + ' '.join(self.install_opts)
@@ -910,7 +929,12 @@ class Spack(BuildSystem):
 
         self.environment = 'rfm_spack_env'
         self._auto_env = True
-        return [f'spack env create -d {self.environment}']
+
+        if self.env_create_opts:
+            env_create_opts = ' '.join(self.env_create_opts)
+            return [f'spack env create -d {self.environment} {env_create_opts}']
+        else:
+            return [f'spack env create -d {self.environment}']
 
     def prepare_cmds(self):
         cmds = self._create_env_cmds()

--- a/unittests/test_buildsystems.py
+++ b/unittests/test_buildsystems.py
@@ -304,14 +304,18 @@ def test_spack_no_env(environ, tmp_path):
 
 def test_spack_env_config(environ, tmp_path):
     build_system = bs.Spack()
+    build_system.env_create_opts = ['--without-view']
     build_system.config_opts = ['section1:header1:value1',
                                 'section2:header2:value2']
+    build_system.preinstall_cmds = ['echo hello', 'echo world']
     with osext.change_dir(tmp_path):
         assert build_system.emit_build_commands(environ) == [
-            'spack env create -d rfm_spack_env',
+            'spack env create -d rfm_spack_env --without-view',
             'spack -e rfm_spack_env config add "config:install_tree:root:opt/spack"',  # noqa: E501
             'spack -e rfm_spack_env config add "section1:header1:value1"',
             'spack -e rfm_spack_env config add "section2:header2:value2"',
+            'echo hello',
+            'echo world',
             'spack -e rfm_spack_env install',
         ]
 


### PR DESCRIPTION
## 1. Add support for user-defined `spack env create` options

ReFrame, unless targeting a user-specified existing Spack environment, automatically passes the `-d rfm_spack_env` option to create an ephemeral environment. This is a small addition that allows users to define extra `spack env create` options ([link to Spack docs for list of options](https://spack.readthedocs.io/en/latest/command_index.html#spack-env-create)). 

With the changes proposed here, a user could define the following:
```python
self.build_system.env_create_opts = ["--without-view"]
```

which produces following in the build job script:
```sh
spack env create -d rfm_spack_env --without-view
```

While technically this allows for any `spack env create` options, my motivation for this feature is use of `--without-view`. ReFrame's use of temporary Spack environments leaves little use for a filesystem view, and disabling it can reduce the possibility of `spack load`-time spec collisions.

## 2. Add support for inserting commands between Spack environment creation and environment installation

Under certain circumstances it may be necessary to run complex custom commands to prepare a Spack environment. This needs to happen post-creation, but pre-installation. This capability is added to the Spack build system via `build_system.preinstall_cmds`.