### PR TITLE
[doc] Fixed a typo in documentation - `JobLaucher` to `JobLauncher`

### DIFF
--- a/docs/tutorial_advanced.rst
+++ b/docs/tutorial_advanced.rst
@@ -647,7 +647,7 @@ If you use a Python-based configuration file, you can define your custom launche
 .. code:: python
 
    from reframe.core.backends import register_launcher
-   from reframe.core.launchers import JobLaucher
+   from reframe.core.launchers import JobLauncher
 
 
    @register_launcher('slrun')


### PR DESCRIPTION
Re-applying #2892 to `master`.