### PR TITLE
[bugfix] Properly cleanup resources of dependencies when their dependents are filtered

### DIFF
--- a/reframe/frontend/dependencies.py
+++ b/reframe/frontend/dependencies.py
@@ -205,6 +205,14 @@ def prune_deps(graph, testcases, max_depth=None):
                 if adj not in pruned_graph:
                     unvisited.append(adj)
 
+    # Re-calculate the in-degree of the pruned graph nodes
+    for u in pruned_graph:
+        u.in_degree = 0
+
+    for u, adjacent in pruned_graph.items():
+        for v in adjacent:
+            v.in_degree += 1
+
     return pruned_graph
 
 

--- a/unittests/test_dependencies.py
+++ b/unittests/test_dependencies.py
@@ -697,6 +697,14 @@ def test_prune_deps(default_exec_ctx):
             assert len(pruned_deps[node('t5')]) == 0
             assert len(pruned_deps[node('t0')]) == 0
 
+            # Check the degree of the nodes of the pruned graph
+            assert in_degree(pruned_deps, node('t0')) == 1
+            assert in_degree(pruned_deps, node('t1')) == 2
+            assert in_degree(pruned_deps, node('t2')) == 1
+            assert in_degree(pruned_deps, node('t3')) == 0
+            assert in_degree(pruned_deps, node('t5')) == 1
+            assert in_degree(pruned_deps, node('t7')) == 0
+
 
 def test_toposort(default_exec_ctx):
     #


### PR DESCRIPTION
The fix was straightforward; we need to re-calculate the the in-degree of the nodes of the pruned graph, which is the testcase graph after filtering.

Closes #2916.