### PR TITLE
[feat] Update default `--timestamp` format

### DIFF
--- a/reframe/core/runtime.py
+++ b/reframe/core/runtime.py
@@ -9,7 +9,7 @@
 
 import os
 import functools
-from datetime import datetime
+import time
 
 import reframe.core.config as config
 import reframe.utility.osext as osext
@@ -31,7 +31,7 @@ class RuntimeContext:
         self._site_config = site_config
         self._system = System.create(site_config)
         self._current_run = 0
-        self._timestamp = datetime.now()
+        self._timestamp = time.localtime()
 
     def _makedir(self, *dirs, wipeout=False):
         ret = os.path.join(*dirs)
@@ -111,7 +111,7 @@ class RuntimeContext:
     @property
     def timestamp(self):
         timefmt = self.site_config.get('general/0/timestamp_dirs')
-        return self._timestamp.strftime(timefmt)
+        return time.strftime(timefmt, self._timestamp)
 
     @property
     def output_prefix(self):

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -285,7 +285,7 @@ def main():
         envvar='RFM_SAVE_LOG_FILES', configvar='general/save_log_files'
     )
     output_options.add_argument(
-        '--timestamp', action='store', nargs='?', const='%FT%T',
+        '--timestamp', action='store', nargs='?', const='%y%m%dT%H%M%S%z',
         metavar='TIMEFMT',
         help=('Append a timestamp to the output and stage directory prefixes '
               '(default: "%%FT%%T")'),

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -551,14 +551,17 @@ def test_timestamp_option(run_reframe):
 
 
 def test_timestamp_option_default(run_reframe):
-    timefmt_date_part = time.strftime('%FT')
     returncode, stdout, _ = run_reframe(
         checkpath=['unittests/resources/checks'],
         action='list',
         more_options=['-R', '--timestamp']
     )
     assert returncode == 0
-    assert timefmt_date_part in stdout
+
+    matches = re.findall(
+        r'(stage|output) directory: .*\/(\d{6}T\d{6}\+\d{4})', stdout
+    )
+    assert len(matches) == 2
 
 
 def test_list_empty_prgenvs_check_and_options(run_reframe):


### PR DESCRIPTION
The new format is `%y%m%dT%H%M%S%z` which translates to `230620T005733+0200`.

Closes #2867.