### PR TITLE
[bugfix] logging configuration only being applied to last system specified in 'target_systems' 

### DIFF
--- a/reframe/core/config.py
+++ b/reframe/core/config.py
@@ -161,7 +161,10 @@ class _SiteConfig:
             entry = functools.reduce(
                 lambda l, r: l.update(r) or l, optionset
             )
-            entry['target_systems'] = [system]
+            if 'target_systems' in entry.keys():
+                entry['target_systems'].append(system)
+            else:
+                entry['target_systems'] = [system]
             ret.append(entry)
 
         return ret


### PR DESCRIPTION
When specifying multiple systems in the [logging configuration](https://reframe-hpc.readthedocs.io/en/stable/config_reference.html#config.logging.target_systems) only the last system would receive the configuration settings.

Example:

```
    'logging': [
        {
            'level': 'debug',
            'handlers': [
                {
                    'type': 'file',
                    'name': 'test_results/reframe-debug.log',
                    'level': 'debug',
                    'format': '[%(asctime)s] %(levelname)s: %(check_info)s: %(message)s',  # noqa: E501
                    'append': True
                },
            ],
            'target_systems': [
                'system1',
                'system2',
            ]
        }
    ],
```
When running a basic test, only the last system specified would log to the specified file.

System 1:
```
[ReFrame Setup]
  version:           4.2.1
  command:           'reframe/bin/reframe --system system1 -c tests -C config/hpc.py -r'
  launched by:       me@system
  working directory: 'reframe'
  settings files:    '<builtin>', 'config/hpc.py'
  check search path: (R) 'tests'
  stage directory:   'reframe/stage'
  output directory:  'reframe/output'
  log files:         '/tmp/rfm-p3arozpf.log'
...
Log file(s) saved in '/tmp/rfm-p3arozpf.log'
```

System 2:
```
[ReFrame Setup]
  version:           4.2.1
  command:           'reframe/bin/reframe --system system2 -c tests -C config/hpc.py -r'
  launched by:       me@system
  working directory: 'reframe'
  settings files:    '<builtin>', 'config/hpc.py'
  check search path: (R) 'tests'
  stage directory:   'reframe/stage'
  output directory:  'reframe/output'
  log files:         'test_results/reframe-debug.log'
...
Log file(s) saved in 'test_results/reframe-debug.log'
```

With my suggested change, both systems would now get the proper configurations applied. 