### PR TITLE
[bugfix] Properly apply logging configuration to all systems listed in `target_systems`

### DIFF
--- a/reframe/core/config.py
+++ b/reframe/core/config.py
@@ -161,7 +161,8 @@ class _SiteConfig:
             entry = functools.reduce(
                 lambda l, r: l.update(r) or l, optionset
             )
-            entry['target_systems'] = [system]
+            entry.setdefault('target_systems', [])
+            entry['target_systems'].append(system)
             ret.append(entry)
 
         return ret


### PR DESCRIPTION
…would get the configuration options.

Resolves #2932 