### PR TITLE
[feat] Support for custom schedulers

### DIFF
--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -116,8 +116,7 @@
                     "items": {"type": "string"}
                 },
                 "use_nodes_option": {"type": "boolean"}
-            },
-            "additionalProperties": false
+            }
         },
         "stream_handler": {
             "allOf": [
@@ -275,11 +274,7 @@
                                 "name": {"$ref": "#/defs/alphanum_ext_string"},
                                 "descr": {"type": "string"},
                                 "scheduler": {
-                                    "type": "string",
-                                    "enum": [
-                                        "flux", "local", "lsf", "oar", "pbs",
-                                        "sge", "slurm", "squeue", "torque"
-                                    ]
+                                    "type": "string"
                                 },
                                 "sched_options": {"$ref": "#/defs/sched_options"},
                                 "launcher": {


### PR DESCRIPTION
Allow users to define and integrate custom schedulers without having to modify the framework. This simply boils down to relaxing the configuration schema. Then users can simply import their scheduler code in the configuration and use the name that it is registered with.

The docs are deferred for #2610.

Closes #2954.