### PR TITLE
[testlib] Add ssh_audit test to hpctestlist

### DIFF
--- a/hpctestlib/system/ssh/ssh_audit.py
+++ b/hpctestlib/system/ssh/ssh_audit.py
@@ -1,0 +1,33 @@
+# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# ReFrame Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import reframe as rfm
+import reframe.utility as util
+import reframe.utility.sanity as sn
+
+
+@rfm.simple_test
+class ssh_audit_check(rfm.RunOnlyRegressionTest):
+    '''ssh audit config test.
+
+    `ssh-audit is a tool for ssh server & client configuration auditing.
+
+    The check consist on performing the basic ssh server config auditing
+    using the master version of https://github.com/jtesta/ssh-audit.
+    '''
+
+    executable = './ssh-audit.py'
+    executable_opts = ['-n', '-l', 'fail', 'localhost']
+    sourcesdir = 'https://github.com/jtesta/ssh-audit'
+    tags = {'system', 'ssh'}
+
+    @sanity_function
+    def assert_no_fails_are_found(self):
+        '''Assert that no fails are reported by the tool.'''
+
+        return sn.assert_not_found(
+                   r'\S+\s+--\s+\[fail\]', self.stdout,
+                   msg=(f"found ssh config failures")
+               )

--- a/hpctestlib/system/ssh/ssh_audit.py
+++ b/hpctestlib/system/ssh/ssh_audit.py
@@ -11,7 +11,7 @@ import reframe.utility.sanity as sn
 class ssh_audit_check(rfm.RunOnlyRegressionTest):
     '''ssh audit config test.
 
-    `ssh-audit is a tool for ssh server & client configuration auditing.
+    ssh-audit is a tool for ssh server & client configuration auditing.
 
     The check consist on performing the basic ssh server config auditing
     using the master version of https://github.com/jtesta/ssh-audit.

--- a/hpctestlib/system/ssh/ssh_audit.py
+++ b/hpctestlib/system/ssh/ssh_audit.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import reframe as rfm
-import reframe.utility as util
 import reframe.utility.sanity as sn
 
 


### PR DESCRIPTION
The test downloads the ssh-audit tool from GitHub and checks if there is any configuration that is considered as a failure.

The test is compatible with all the job schedulers. Because it only checks the localhost, where the test script runs. So, it becomes the responsibility of ReFrame to spawn the test script in the desired systems.