### PR TITLE
[feat] Add an SSH-based scheduler backend

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -273,7 +273,7 @@ System Partition Configuration
      This backend does not rely on job accounting to retrieve job statuses, but ReFrame does its best to query the job state as reliably as possible.
    - ``ssh``: Jobs will be launched on a remote host using SSH.
 
-     The remote host will be selected from the list of hosts specified in :attr:`~systems.partitions.sched_options.hosts`.
+     The remote host will be selected from the list of hosts specified in :attr:`~systems.partitions.sched_options.ssh_hosts`.
      The scheduler keeps track of the hosts that it has submitted jobs to, and it will select the next available one in a round-robin fashion.
      For connecting to a remote host, the options specified in :attr:`~systems.partitions.access` will be used.
 
@@ -283,6 +283,11 @@ System Partition Configuration
      The same :attr:`~systems.partitions.access` options will be used in those operations as well.
      Please note, that the connection options of ``ssh`` and ``scp`` differ and ReFrame will not attempt to translate any options between the two utilities in case ``scp`` is selected for copying to the remote host.
      In this case, it is preferable to set up the host connection options in ``~/.ssh/config`` and leave :attr:`~systems.partition.access` blank.
+
+     Job-scheduler command line options can be used to interact with the ``ssh`` backend.
+     More specifically, if the :option:`--distribute` option is used, a test will be generated for each host listed in :attr:`~systems.partitions.sched_options.ssh_hosts`.
+     You can also pin a test to a specific host if you pass the ``#host`` directive to the :option:`-J` option, e.g., ``-J '#host=myhost'``.
+
    - ``torque``: Jobs will be launched using the `Torque <https://en.wikipedia.org/wiki/TORQUE>`__ scheduler.
 
    .. versionadded:: 3.7.2
@@ -352,7 +357,7 @@ System Partition Configuration
    .. warning::
       This option is broken in 4.0.
 
-.. py:attribute:: systems.partitions.sched_options.hosts
+.. py:attribute:: systems.partitions.sched_options.ssh_hosts
 
    :required: No
    :default: ``[]``

--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -260,8 +260,9 @@ System Partition Configuration
    The job scheduler that will be used to launch jobs on this partition.
    Supported schedulers are the following:
 
-   - ``local``: Jobs will be launched locally without using any job scheduler.
    - ``flux``: Jobs will be launched using the `Flux Framework <https://flux-framework.org/>`_ scheduler.
+   - ``local``: Jobs will be launched locally without using any job scheduler.
+   - ``lsf``: Jobs will be launched using the `LSF <https://www.ibm.com/docs/en/spectrum-lsf/10.1.0?topic=lsf-session-scheduler>`__ scheduler.
    - ``oar``: Jobs will be launched using the `OAR <https://oar.imag.fr/>`__ scheduler.
    - ``pbs``: Jobs will be launched using the `PBS Pro <https://en.wikipedia.org/wiki/Portable_Batch_System>`__ scheduler.
    - ``sge``: Jobs will be launched using the `Sun Grid Engine <https://arc.liv.ac.uk/SGE/htmlman/manuals.html>`__ scheduler.
@@ -270,8 +271,19 @@ System Partition Configuration
      If not, you should consider using the ``squeue`` backend below.
    - ``squeue``: Jobs will be launched using the `Slurm <https://www.schedmd.com/>`__ scheduler.
      This backend does not rely on job accounting to retrieve job statuses, but ReFrame does its best to query the job state as reliably as possible.
+   - ``ssh``: Jobs will be launched on a remote host using SSH.
+
+     The remote host will be selected from the list of hosts specified in :attr:`~systems.partitions.sched_options.hosts`.
+     The scheduler keeps track of the hosts that it has submitted jobs to, and it will select the next available one in a round-robin fashion.
+     For connecting to a remote host, the options specified in :attr:`~systems.partitions.access` will be used.
+
+     When a job is submitted with this scheduler, its stage directory will be copied over to a unique temporary directory on the remote host, then the job will be executed and, finally, any produced artifacts will be copied back.
+
+     The contents of the stage directory are copied to the remote host either using ``rsync``, if available, or ``scp`` as a second choice.
+     The same :attr:`~systems.partitions.access` options will be used in those operations as well.
+     Please note, that the connection options of ``ssh`` and ``scp`` differ and ReFrame will not attempt to translate any options between the two utilities in case ``scp`` is selected for copying to the remote host.
+     In this case, it is preferable to set up the host connection options in ``~/.ssh/config`` and leave :attr:`~systems.partition.access` blank.
    - ``torque``: Jobs will be launched using the `Torque <https://en.wikipedia.org/wiki/TORQUE>`__ scheduler.
-   - ``lsf``: Jobs will be launched using the `LSF <https://www.ibm.com/docs/en/spectrum-lsf/10.1.0?topic=lsf-session-scheduler>`__ scheduler.
 
    .. versionadded:: 3.7.2
       Support for the SGE scheduler is added.
@@ -281,6 +293,9 @@ System Partition Configuration
 
    .. versionadded:: 3.11.0
       Support for the LSF scheduler is added.
+
+   .. versionadded:: 4.4
+      The ``ssh`` scheduler is added.
 
    .. note::
 
@@ -336,6 +351,14 @@ System Partition Configuration
 
    .. warning::
       This option is broken in 4.0.
+
+.. py:attribute:: systems.partitions.sched_options.hosts
+
+   :required: No
+   :default: ``[]``
+
+   List of hosts in a partition that uses the ``ssh`` scheduler.
+
 
 .. py:attribute:: systems.partitions.sched_options.ignore_reqnodenotavail
 

--- a/reframe/core/backends.py
+++ b/reframe/core/backends.py
@@ -23,7 +23,8 @@ _scheduler_backend_modules = [
     'reframe.core.schedulers.pbs',
     'reframe.core.schedulers.oar',
     'reframe.core.schedulers.sge',
-    'reframe.core.schedulers.slurm'
+    'reframe.core.schedulers.slurm',
+    'reframe.core.schedulers.ssh'
 ]
 _schedulers = {}
 

--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -628,6 +628,7 @@ class Node(abc.ABC):
                      :class:`False` otherwise.
         '''
 
+
 class AlwaysIdleNode(Node):
     def __init__(self, name):
         self._name = name

--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -627,3 +627,14 @@ class Node(abc.ABC):
            :returns: :class:`True` if the nodes's state matches the given one,
                      :class:`False` otherwise.
         '''
+
+class AlwaysIdleNode(Node):
+    def __init__(self, name):
+        self._name = name
+
+    @property
+    def name(self):
+        return self._name
+
+    def in_state(self, state):
+        return state.casefold() == 'idle'

--- a/reframe/core/schedulers/local.py
+++ b/reframe/core/schedulers/local.py
@@ -12,11 +12,7 @@ import time
 import reframe.core.schedulers as sched
 import reframe.utility.osext as osext
 from reframe.core.backends import register_scheduler
-from reframe.core.exceptions import JobError, ReframeError
-
-
-class _TimeoutExpired(ReframeError):
-    pass
+from reframe.core.exceptions import JobError
 
 
 class _LocalJob(sched.Job):
@@ -27,6 +23,7 @@ class _LocalJob(sched.Job):
         self._f_stderr = None
         self._signal = None
         self._cancel_time = None
+        self.spawn_command = f'./{self._script_filename}'
 
     @property
     def proc(self):
@@ -66,7 +63,7 @@ class LocalJobScheduler(sched.JobScheduler):
         # we can later kill any other processes that this might spawn by just
         # killing this one.
         proc = osext.run_command_async(
-            os.path.abspath(job.script_filename),
+            job.spawn_command,
             stdout=f_stdout,
             stderr=f_stderr,
             start_new_session=True

--- a/reframe/core/schedulers/local.py
+++ b/reframe/core/schedulers/local.py
@@ -23,7 +23,6 @@ class _LocalJob(sched.Job):
         self._f_stderr = None
         self._signal = None
         self._cancel_time = None
-        self.spawn_command = f'./{self._script_filename}'
 
     @property
     def proc(self):
@@ -63,7 +62,7 @@ class LocalJobScheduler(sched.JobScheduler):
         # we can later kill any other processes that this might spawn by just
         # killing this one.
         proc = osext.run_command_async(
-            job.spawn_command,
+            os.path.abspath(job.script_filename),
             stdout=f_stdout,
             stderr=f_stderr,
             start_new_session=True

--- a/reframe/core/schedulers/ssh.py
+++ b/reframe/core/schedulers/ssh.py
@@ -42,8 +42,8 @@ class _SSHJob(Job):
 
 @register_scheduler('ssh')
 class SSHJobScheduler(JobScheduler):
-    def __init__(self):
-        self._free_hosts = set(self.get_option('ssh_hosts'))
+    def __init__(self, *, hosts=None):
+        self._free_hosts = set(hosts or self.get_option('ssh_hosts'))
         self._allocated_hosts = set()
         if not self._free_hosts:
             raise ConfigError(f'no hosts specified for the SSH scheduler: '

--- a/reframe/core/schedulers/ssh.py
+++ b/reframe/core/schedulers/ssh.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import os
-import functools
 import time
 
 import reframe.utility.osext as osext

--- a/reframe/core/schedulers/ssh.py
+++ b/reframe/core/schedulers/ssh.py
@@ -1,0 +1,219 @@
+# Copyright 2016-2023 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# ReFrame Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+import functools
+import time
+
+import reframe.utility.osext as osext
+from reframe.core.backends import register_scheduler
+from reframe.core.exceptions import ConfigError, SpawnedProcessError
+from reframe.core.schedulers import Job, JobScheduler, AlwaysIdleNode
+
+
+class _SSHJob(Job):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._localdir = None
+        self._remotedir = None
+        self._host = None
+        self._ssh_options = []
+
+        # Async processes spawned for this job
+        self.steps = {}
+
+    @property
+    def localdir(self):
+        return self._localdir
+
+    @property
+    def remotedir(self):
+        return self._remotedir
+
+    @property
+    def host(self):
+        return self._host
+
+    @property
+    def ssh_options(self):
+        return self._ssh_options
+
+@register_scheduler('ssh')
+class SSHJobScheduler(JobScheduler):
+    def __init__(self):
+        self._free_hosts = set(self.get_option('hosts'))
+        self._allocated_hosts = set()
+        if not self._free_hosts:
+            raise ConfigError(f'no hosts specified for the SSH scheduler: {self._config_prefix}')
+
+        # Determine if rsync is available
+        try:
+            osext.run_command('rsync --version', check=True)
+        except SpawnedProcessError:
+            self._has_rsync = False
+        else:
+            self._has_rsync = True
+
+    def _reserve_host(self, host=None):
+        pool = self._free_hosts if self._free_hosts else self._allocated_hosts
+        if host:
+            pool.discard(host)
+            self._allocated_hosts.add(host)
+            return host
+
+        host = pool.pop()
+        self._allocated_hosts.add(host)
+        return host
+
+    def make_job(self, *args, **kwargs):
+        return _SSHJob(*args, **kwargs)
+
+    def emit_preamble(self, job):
+        return []
+
+    def _push_artefacts(self, job):
+        assert isinstance(job, _SSHJob)
+        options = ' '.join(job.ssh_options)
+
+        # Create a temporary directory on the remote host and push the job artifacts
+        completed = osext.run_command(f'ssh -o BatchMode=yes {options} {job.host} mktemp -td rfm.XXXXXXXX', check=True)
+        remotedir = completed.stdout.strip()
+
+        # Store the local and remote dirs
+        job._localdir = os.getcwd()
+        job._remotedir = remotedir
+
+        if self._has_rsync:
+            job.steps['push'] = osext.run_command_async2(
+                f'rsync -az -e "ssh -o BatchMode=yes {options}" {job.localdir}/ {job.host}:{remotedir}/', check=True
+            )
+        else:
+            job.steps['push'] = osext.run_command_async2(
+                f'scp -r -o BatchMode=yes {options} {job.localdir}/* {job.host}:{remotedir}/', shell=True, check=True
+            )
+
+
+    def _pull_artefacts(self, job):
+        assert isinstance(job, _SSHJob)
+        options = ' '.join(job.ssh_options)
+        if self._has_rsync:
+            job.steps['pull'] = osext.run_command_async2(
+                f'rsync -az -e "ssh -o BatchMode=yes {options}" {job.host}:{job.remotedir}/ {job.localdir}/'
+            )
+        else:
+            job.steps['pull'] = osext.run_command_async2(
+                f"scp -r -o BatchMode=yes {options} '{job.host}:{job.remotedir}/*' {job.localdir}/", shell=True
+            )
+
+    def _do_submit(self, job):
+        # Modify the spawn command and submit
+        options = ' '.join(job.ssh_options)
+        job.steps['exec'] = osext.run_command_async2(
+            f'ssh -o BatchMode=yes {options} {job.host} "cd {job.remotedir} && bash -l {job.script_filename}"'
+        )
+
+    def submit(self, job):
+        assert isinstance(job, _SSHJob)
+
+        # Check if `#host` pseudo-option is specified and use this as a host,
+        # stripping it off the rest of the options
+        host = None
+        stripped_opts = []
+        options = job.sched_access + job.options + job.cli_options
+        for opt in options:
+            if opt.startswith('#host='):
+                _, host = opt.split('=', maxsplit=1)
+            else:
+                stripped_opts.append(opt)
+
+        # Host is pinned externally (`--distribute` option)
+        if job.pin_nodes:
+            host = job.pin_nodes[0]
+
+        job._submit_time = time.time()
+        job._ssh_options = stripped_opts
+        job._host = self._reserve_host(host)
+
+        self._push_artefacts(job)
+        self._do_submit(job)
+        self._pull_artefacts(job)
+
+        def success(proc):
+            return proc.exitcode == 0
+
+        job.steps['push'].then(
+            job.steps['exec'],
+            when=success
+        ).then(
+            job.steps['pull'],
+            when=success
+        )
+        job.steps['push'].start()
+        job._jobid = job.steps['push'].pid
+
+    def wait(self, job):
+        for step in job.steps.values():
+            if step.started():
+                step.wait()
+
+    def cancel(self, job):
+        for step in job.steps.values():
+            if step.started():
+                step.cancel()
+
+    def finished(self, job):
+        if job.exception:
+            raise job.exception
+
+        return job.state is not None
+
+    def poll(self, *jobs):
+        for job in jobs:
+            self._poll_job(job)
+
+    def _poll_job(self, job):
+        last_done = None
+        last_failed = None
+        for proc_kind, proc in job.steps.items():
+            if proc.started() and proc.done():
+                last_done = proc_kind
+                if proc.exitcode != 0:
+                    last_failed = proc_kind
+                    break
+
+        if last_failed is None and last_done != 'pull':
+            return False
+
+        # Either all processes were done or one failed
+        # Update the job info
+        last_proc = job.steps[last_done]
+        job._exitcode = last_proc.exitcode
+        job._exception = last_proc.exception()
+        job._signal = last_proc.signal
+        if job._exitcode == 0:
+            job._state = 'SUCCESS'
+        else:
+            job._state = 'FAILURE'
+
+        exec_proc = job.steps['exec']
+        if exec_proc.started():
+            with osext.change_dir(job.localdir):
+                with open(job.stdout, 'w+') as fout, open(job.stderr, 'w+') as ferr:
+                    fout.write(exec_proc.stdout.read())
+                    ferr.write(exec_proc.stderr.read())
+
+        return True
+
+    def allnodes(self):
+        return [AlwaysIdleNode(h) for h in self._free_hosts]
+
+    def filternodes(self, job, nodes):
+        options = job.sched_access + job.options + job.cli_options
+        for opt in options:
+            if opt.startswith('#host='):
+                _, host = opt.split('=', maxsplit=1)
+                return [AlwaysIdleNode(host)]
+        else:
+            return [AlwaysIdleNode(h) for h in self._free_hosts]

--- a/reframe/core/schedulers/ssh.py
+++ b/reframe/core/schedulers/ssh.py
@@ -212,8 +212,8 @@ class SSHJobScheduler(JobScheduler):
             with osext.change_dir(job.localdir):
                 with (open(job.stdout, 'w+') as fout,
                       open(job.stderr, 'w+') as ferr):
-                    fout.write(exec_proc.stdout.read())
-                    ferr.write(exec_proc.stderr.read())
+                    fout.write(exec_proc.stdout().read())
+                    ferr.write(exec_proc.stderr().read())
 
         return True
 

--- a/reframe/core/schedulers/ssh.py
+++ b/reframe/core/schedulers/ssh.py
@@ -43,7 +43,7 @@ class _SSHJob(Job):
 @register_scheduler('ssh')
 class SSHJobScheduler(JobScheduler):
     def __init__(self):
-        self._free_hosts = set(self.get_option('hosts'))
+        self._free_hosts = set(self.get_option('ssh_hosts'))
         self._allocated_hosts = set()
         if not self._free_hosts:
             raise ConfigError(f'no hosts specified for the SSH scheduler: '

--- a/reframe/core/schedulers/ssh.py
+++ b/reframe/core/schedulers/ssh.py
@@ -210,9 +210,10 @@ class SSHJobScheduler(JobScheduler):
         exec_proc = job.steps['exec']
         if exec_proc.started():
             with osext.change_dir(job.localdir):
-                with (open(job.stdout, 'w+') as fout,
-                      open(job.stderr, 'w+') as ferr):
+                with open(job.stdout, 'w+') as fout:
                     fout.write(exec_proc.stdout().read())
+
+                with open(job.stderr, 'w+') as ferr:
                     ferr.write(exec_proc.stderr().read())
 
         return True

--- a/reframe/core/schedulers/ssh.py
+++ b/reframe/core/schedulers/ssh.py
@@ -52,7 +52,7 @@ class SSHJobScheduler(JobScheduler):
         # Determine if rsync is available
         try:
             osext.run_command('rsync --version', check=True)
-        except SpawnedProcessError:
+        except (FileNotFoundError, SpawnedProcessError):
             self._has_rsync = False
         else:
             self._has_rsync = True

--- a/reframe/core/schedulers/ssh.py
+++ b/reframe/core/schedulers/ssh.py
@@ -78,7 +78,8 @@ class SSHJobScheduler(JobScheduler):
         assert isinstance(job, _SSHJob)
         options = ' '.join(job.ssh_options)
 
-        # Create a temporary directory on the remote host and push the job artifacts
+        # Create a temporary directory on the remote host and push the job
+        # artifacts
         completed = osext.run_command(
             f'ssh -o BatchMode=yes {options} {job.host} '
             f'mktemp -td rfm.XXXXXXXX', check=True

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -619,7 +619,7 @@
         "systems/partitions/time_limit": null,
         "systems/partitions/devices": [],
         "systems/partitions/extras": {},
-        "systems/*/sched_options/ssh_hosts": [],
+        "systems*/sched_options/ssh_hosts": [],
         "systems*/sched_options/ignore_reqnodenotavail": false,
         "systems*/sched_options/job_submit_timeout": 60,
         "systems*/sched_options/resubmit_on_errors": [],

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -109,6 +109,10 @@
         "sched_options": {
             "type": "object",
             "properties": {
+                "hosts": {
+                    "type": "array",
+                    "items": {"type": "string"}
+                },
                 "ignore_reqnodenotavail": {"type": "boolean"},
                 "job_submit_timeout": {"type": "number"},
                 "resubmit_on_errors": {
@@ -278,7 +282,7 @@
                                     "type": "string",
                                     "enum": [
                                         "flux", "local", "lsf", "oar", "pbs",
-                                        "sge", "slurm", "squeue", "torque"
+                                        "sge", "slurm", "squeue", "ssh", "torque"
                                     ]
                                 },
                                 "sched_options": {"$ref": "#/defs/sched_options"},
@@ -620,6 +624,7 @@
         "systems/partitions/time_limit": null,
         "systems/partitions/devices": [],
         "systems/partitions/extras": {},
+        "systems/*/sched_options/hosts": [],
         "systems*/sched_options/ignore_reqnodenotavail": false,
         "systems*/sched_options/job_submit_timeout": 60,
         "systems*/sched_options/resubmit_on_errors": [],

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -619,7 +619,7 @@
         "systems/partitions/time_limit": null,
         "systems/partitions/devices": [],
         "systems/partitions/extras": {},
-        "systems/*/sched_options/hosts": [],
+        "systems/*/sched_options/ssh_hosts": [],
         "systems*/sched_options/ignore_reqnodenotavail": false,
         "systems*/sched_options/job_submit_timeout": 60,
         "systems*/sched_options/resubmit_on_errors": [],

--- a/reframe/utility/osext.py
+++ b/reframe/utility/osext.py
@@ -150,7 +150,8 @@ class _ProcFuture:
         '''
 
         if when is None:
-            def when(fut): return True
+            def when(fut):
+                return True
 
         if not util.is_trivially_callable(when, non_def_args=1):
             raise ValueError("the 'when' function must "

--- a/reframe/utility/osext.py
+++ b/reframe/utility/osext.py
@@ -35,6 +35,17 @@ class UnstartedProcError(ReframeError):
 
 
 class _ProcFuture:
+    '''A future encapsulating a command to be executed asynchronously.
+
+    Users may not create a :class:`_ProcFuture` directly, but should use
+    :func:`run_command_async2` instead.
+
+    :meta public:
+
+    .. versionadded:: 4.4
+
+    '''
+
     def __init__(self, check=False, *args, **kwargs):
         self._proc = None
         self._exitcode = None
@@ -51,6 +62,8 @@ class _ProcFuture:
             raise UnstartedProcError
 
     def start(self):
+        '''Start the future, i.e. spawn the encapsulated command.'''
+
         args, kwargs = self._cmd_args
         self._proc = run_command_async(*args, **kwargs)
 
@@ -59,37 +72,50 @@ class _ProcFuture:
         else:
             self._session = False
 
+        return self
+
     @property
     def pid(self):
+        '''The PID of the spawned process.'''
         return self._proc.pid
 
     @property
     def exitcode(self):
+        '''The exit code of the spawned process.'''
         return self._exitcode
 
     @property
     def signal(self):
+        '''The signal number that caused the spawned process to exit.'''
         return self._signal
 
     def cancelled(self):
+        '''Returns :obj:`True` if the future was cancelled.'''
         return self._cancelled
 
-    def scheduled(self):
-        return self._scheduled
-
     def is_session(self):
+        '''Returns :obj:`True` is the spawned process is a group or session
+        leader.'''
         return self._session
 
     def kill(self, signum):
+        '''Send signal ``signum`` to the spawned process.
+
+        If the process is a group or session leader, the signal will be sent
+        to the whole group or session.
+        '''
+
         self._check_started()
         kill_fn = os.killpg if self.is_session() else os.kill
         kill_fn(self.pid, signum)
         self._signal = signum
 
     def terminate(self):
+        '''Terminate the spawned process by sending ``SIGTERM``.'''
         self.kill(signal.SIGTERM)
 
     def cancel(self):
+        '''Cancel the spawned process by sending ``SIGKILL``.'''
         self._check_started()
         if not self.cancelled():
             self.kill(signal.SIGKILL)
@@ -97,16 +123,45 @@ class _ProcFuture:
         self._cancelled = True
 
     def add_done_callback(self, func):
+        '''Add a callback that will be called when this future is done.
+
+        The callback function will be called with the future as its sole
+        argument.
+        '''
+        if not util.is_trivially_callable(func, non_def_args=1):
+            raise ValueError('the callback function must '
+                             'accept a single argument')
+
         self._done_callbacks.append(func)
 
     def then(self, future, when=None):
+        '''Schedule another future for execution after this one.
+
+        :arg future: a :class:`_ProcFuture` to be started after this one
+            finishes.
+        :arg when: A callable that will be used as conditional for starting or
+            not the next future. It will be called with this future as its
+            sole argument and must return a boolean. If the return value is
+            true, then ``future`` will start execution, otherwise not.
+
+            If ``when`` is :obj:`None`, then the next future will be executed
+            unconditionally.
+        :returns: the passed ``future``, so that multiple :func:`then` calls
+            can be chained.
+        '''
+
         if when is None:
             def when(fut): return True
+
+        if not util.is_trivially_callable(when, non_def_args=1):
+            raise ValueError("the 'when' function must "
+                             "accept a single argument")
 
         self._next.append((future, when))
         return future
 
     def started(self):
+        '''Check if this future has started.'''
         return self._proc is not None
 
     def _wait(self, *, nohang=False):
@@ -146,13 +201,27 @@ class _ProcFuture:
         return self._completed
 
     def done(self):
+        '''Check if the future has finished.
+
+        This is a non-blocking call.
+        '''
         self._check_started()
         return self._wait(nohang=True)
 
     def wait(self):
+        '''Wait for this future to finish.'''
         self._wait()
 
     def exception(self):
+        '''Retrieve the exception raised by this future.
+
+        This is a blocking call and will wait until this future finishes.
+
+        The only exception that a :func:`_ProcFuture` can return is a
+        :class:`SpawnedProcessError` if the ``check`` flag was set in
+        :func:`run_command_async2`.
+        '''
+
         self._wait()
         if not self._check:
             return
@@ -165,13 +234,19 @@ class _ProcFuture:
                                    self._proc.stderr.read(),
                                    self._proc.returncode)
 
-    @property
     def stdout(self):
+        '''Retrieve the standard output of the spawned process.
+
+        This is a blocking call and will wait until the future finishes.
+        '''
         self._wait()
         return self._proc.stdout
 
-    @property
     def stderr(self):
+        '''Retrieve the standard error of the spawned process.
+
+        This is a blocking call and will wait until the future finishes.
+        '''
         self._wait()
         return self._proc.stderr
 
@@ -264,6 +339,22 @@ def run_command_async(cmd,
 
 
 def run_command_async2(*args, check=False, **kwargs):
+    '''Return a :class:`_ProcFuture` that encapsulates a command to be
+    executed.
+
+    The command to be executed will not start until the returned future is
+    started.
+
+    :arg args: Any of the arguments that can be passed to
+        :func:`run_command_async`
+    :arg check: If true, flag the future with a :func:`SpawnedProcessError`
+        exception, upon failure.
+    :arg kwargs: Any of the keyword arguments that can be passed to
+        :func:`run_command_async`.
+
+    .. versionadded:: 4.4
+
+    '''
     return _ProcFuture(check, *args, **kwargs)
 
 

--- a/reframe/utility/osext.py
+++ b/reframe/utility/osext.py
@@ -30,7 +30,9 @@ from . import OrderedSet
 
 
 class UnstartedProcError(ReframeError):
-    '''Raised when a process operation is attempted on an unstarted process future'''
+    '''Raised when a process operation is attempted on a
+    not yet started process future'''
+
 
 class _ProcFuture:
     def __init__(self, check=False, *args, **kwargs):
@@ -99,7 +101,7 @@ class _ProcFuture:
 
     def then(self, future, when=None):
         if when is None:
-            when = lambda fut: True
+            def when(fut): return True
 
         self._next.append((future, when))
         return future
@@ -260,8 +262,10 @@ def run_command_async(cmd,
                             shell=shell,
                             **popen_args)
 
+
 def run_command_async2(*args, check=False, **kwargs):
     return _ProcFuture(check, *args, **kwargs)
+
 
 def osuser():
     '''Return the name of the current OS user.

--- a/reframe/utility/osext.py
+++ b/reframe/utility/osext.py
@@ -43,7 +43,6 @@ class _ProcFuture:
     :meta public:
 
     .. versionadded:: 4.4
-
     '''
 
     def __init__(self, check=False, *args, **kwargs):

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -26,8 +26,8 @@ def launcher():
     return getlauncher('local')
 
 
-@pytest.fixture(params=['flux', 'local', 'lsf', 'oar',
-                        'pbs', 'sge', 'slurm', 'squeue', 'torque'])
+@pytest.fixture(params=['flux', 'local', 'lsf', 'oar', 'pbs',
+                        'sge', 'slurm', 'ssh', 'squeue', 'torque'])
 def scheduler(request):
     try:
         return getscheduler(request.param)
@@ -73,7 +73,13 @@ def exec_ctx(make_exec_ctx, scheduler):
 @pytest.fixture
 def make_job(scheduler, launcher, tmp_path):
     def _make_job(sched_opts=None, **jobargs):
-        sched = scheduler(**sched_opts) if sched_opts else scheduler()
+        if sched_opts:
+            sched = scheduler(**sched_opts)
+        elif scheduler.registered_name == 'ssh':
+            sched = scheduler(hosts=['localhost'])
+        else:
+            sched = scheduler()
+
         return Job.create(
             sched, launcher(),
             name='testjob',
@@ -358,6 +364,18 @@ def _expected_local_directives_minimal(job):
 
 
 def _expected_local_directives_no_tasks(job):
+    return set()
+
+
+def _expected_ssh_directives(job):
+    return set()
+
+
+def _expected_ssh_directives_minimal(job):
+    return set()
+
+
+def _expected_ssh_directives_no_tasks(job):
     return set()
 
 
@@ -649,6 +667,10 @@ def test_guess_num_tasks(minimal_job, scheduler):
         # of the default partition through the use of `scontrol show`
         minimal_job.scheduler._get_default_partition = lambda: 'pdef'
         assert minimal_job.guess_num_tasks() == 0
+    elif scheduler.registered_name == 'ssh':
+        minimal_job.num_tasks = 0
+        minimal_job._sched_flex_alloc_nodes = 'all'
+        assert minimal_job.guess_num_tasks() == 1
     else:
         with pytest.raises(NotImplementedError):
             minimal_job.guess_num_tasks()


### PR DESCRIPTION
The new backend is called `ssh` and will spawn a test job on a remote host. More specifically, it will copy the test's stage directory to the remote host, execute the job and copy back the results.

Multiple hosts can be assigned to a partition with an `ssh` scheduler, in which case the scheduler will pick the next free host to spawn a test on.

This PR also introduced a new `run_command_async2` utility for executing asynchronous commands. Conversely to the `run_command_async`, this returns a "future" encapsulating the spawned process. Process futures can be chained with the `then()` method and the chained futures will be called upon termination of the predecessor in the chain.

The SSH scheduler backend uses the process futures and spawns a chain of push artefacts-execute job-pull artefacts commands in its `submit()` method, so that it does not block. The progress is ensured by the scheduler's `poll()` method which polls the spawned futures for completion.

This PR essentially solves the feature request in #64.

More details about the new scheduler can be found in its docs.