### PR TITLE
[bugfix] Accept `y` and `n` for boolean conversions

### DIFF
--- a/reframe/utility/typecheck.py
+++ b/reframe/utility/typecheck.py
@@ -374,8 +374,9 @@ class Bool(metaclass=_BuiltinType):
     This type represents a boolean value but allows implicit conversions from
     :class:`str`. More specifically, the following conversions are supported:
 
-    - The strings ``'yes'``, ``'true'`` and ``'1'`` are converted to ``True``.
-    - The strings ``'no'``, ``'false'`` and ``'0'`` are converted to
+    - The strings ``'yes'``, ``'y'``, 'true'`` and ``'1'`` are converted to
+      ``True``.
+    - The strings ``'no'``, ``'n'``, ``'false'`` and ``'0'`` are converted to
       ``False``.
 
     The built-in :class:`bool` type is registered as a subclass of this type.
@@ -383,15 +384,21 @@ class Bool(metaclass=_BuiltinType):
     Boolean test variables that are meant to be set properly from the command
     line must be declared of this type and not :class:`bool`.
 
+    .. versionchanged:: 4.3.3
+
+       The strings ``'y'`` and ``'n'`` are also recognized as valid boolean
+       values and string comparison is now case-insensitive.
+
     '''
 
     _type = bool
 
     @classmethod
     def __rfm_cast_str__(cls, s):
-        if s in ('true', 'yes', '1'):
+        s = s.lower()
+        if s in ('true', 'yes', 'y', '1'):
             return True
-        elif s in ('false', 'no', '0'):
+        elif s in ('false', 'no', 'n', '0'):
             return False
 
         raise TypeError(f'cannot convert {s!r} to bool')

--- a/unittests/test_typecheck.py
+++ b/unittests/test_typecheck.py
@@ -27,17 +27,17 @@ def test_bool_type():
     with pytest.raises(TypeError):
         typ.Bool('foo')
 
-    with pytest.raises(TypeError):
-        typ.Bool('True')
-
-    with pytest.raises(TypeError):
-        typ.Bool('False')
-
     # Test for boolean conversion
     assert typ.Bool('true') is True
+    assert typ.Bool('True') is True
     assert typ.Bool('yes') is True
+    assert typ.Bool('y') is True
+    assert typ.Bool('YeS') is True
     assert typ.Bool('false') is False
+    assert typ.Bool('False') is False
     assert typ.Bool('no') is False
+    assert typ.Bool('n') is False
+    assert typ.Bool('nO') is False
 
 
 def test_duration_type():


### PR DESCRIPTION
And also string comparisons are case-insensitive when converting to boolean.

Closing #2971.