### PR TITLE
Propagate module path option to script creation

### DIFF
--- a/reframe/core/runtime.py
+++ b/reframe/core/runtime.py
@@ -241,6 +241,7 @@ def loadenv(*environs):
     modules_system = runtime().modules_system
     env_snapshot = snapshot()
     commands = []
+    commands += modules_system.emit_extra_module_paths
     for env in environs:
         for cmd in env.prepare_cmds:
             commands.append(cmd)


### PR DESCRIPTION
The `module-path` option is not considered when creating the shell script. This causes issues with schedulers such as SLURM.