### PR TITLE
[doc] Fix typo in `file` log handler docs

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -1188,7 +1188,7 @@ The additional properties for the ``file`` handler are the following:
 
 .. py:attribute:: logging.handlers..file..append
 
-.. py:attribute:: logging.handlers_perflog..file..ppend
+.. py:attribute:: logging.handlers_perflog..file..append
 
    :required: No
    :default: ``false``


### PR DESCRIPTION
Closes #3030.