### PR TITLE
[bugfix] Do not pass the stdout/stderr options to `srun` when using the `srunalloc` launcher

### DIFF
--- a/reframe/core/launchers/mpi.py
+++ b/reframe/core/launchers/mpi.py
@@ -126,12 +126,6 @@ class SrunAllocationLauncher(JobLauncher):
             h, m, s = seconds_to_hms(job.time_limit)
             ret += ['--time=%d:%d:%d' % (h, m, s)]
 
-        if job.stdout:
-            ret += ['--output=%s' % job.stdout]
-
-        if job.stderr:
-            ret += ['--error=%s' % job.stderr]
-
         if job.num_tasks:
             ret += ['--ntasks=%s' % str(job.num_tasks)]
 

--- a/unittests/test_launchers.py
+++ b/unittests/test_launchers.py
@@ -130,8 +130,6 @@ def test_run_command(job):
         assert command == ('srun '
                            '--job-name=fake_job '
                            '--time=0:10:0 '
-                           '--output=fake_stdout '
-                           '--error=fake_stderr '
                            '--ntasks=4 '
                            '--ntasks-per-node=2 '
                            '--ntasks-per-core=1 '
@@ -177,8 +175,6 @@ def test_run_command_minimal(minimal_job):
     elif launcher_name == 'srunalloc':
         assert command == ('srun '
                            '--job-name=fake_job '
-                           '--output=fake_job.out '
-                           '--error=fake_job.err '
                            '--ntasks=1 '
                            '--foo')
     elif launcher_name == 'ssh':


### PR DESCRIPTION
Closes #3044.