### PR TITLE
[bugfix] Fix crash when `--distribute` option is applied to a run-only test

### DIFF
--- a/reframe/frontend/testgenerators.py
+++ b/reframe/frontend/testgenerators.py
@@ -90,7 +90,7 @@ def distribute_tests(testcases, node_map):
 
     def _rfm_pin_build_nodes(obj):
         pin_nodes = getattr(obj, '$nid')
-        if not obj.local and not obj.build_locally:
+        if obj.build_job and not obj.local and not obj.build_locally:
             obj.build_job.pin_nodes = pin_nodes
 
     def _make_dist_test(testcase):

--- a/unittests/resources/checks_unlisted/distribute.py
+++ b/unittests/resources/checks_unlisted/distribute.py
@@ -13,7 +13,8 @@ import os
 class Simple(rfm.RunOnlyRegressionTest):
     valid_systems = ['*']
     valid_prog_environs = ['*']
-    executable = '/bin/true'
+    executable = 'true'
+    sanity_patterns = sn.assert_true(1)
 
 
 class MyFixture(rfm.RunOnlyRegressionTest):
@@ -30,7 +31,7 @@ class Complex(rfm.RunOnlyRegressionTest):
     valid_systems = ['*']
     valid_prog_environs = ['*']
     f = fixture(MyFixture, scope='session')
-    executable = '/bin/true'
+    executable = 'true'
 
     @sanity_function
     def inspect_fixture(self):

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -962,6 +962,18 @@ def test_maxfail_negative(run_reframe):
     assert returncode == 1
 
 
+def test_distribute_build_remotely_runonly(run_reframe, run_action):
+    returncode, stdout, stderr = run_reframe(
+        local=False,
+        more_options=['--distribute', '-S', 'build_locally=0'],
+        checkpath=['unittests/resources/checks_unlisted/distribute.py'],
+        action=run_action
+    )
+    assert 'Traceback' not in stdout
+    assert 'Traceback' not in stderr
+    assert returncode == 0
+
+
 def test_repeat_option(run_reframe, run_action):
     returncode, stdout, stderr = run_reframe(
         more_options=['--repeat', '2', '-n', '^HelloTest'],


### PR DESCRIPTION
Closes #3074.