### PR TITLE
[enhancement] Allow `always_last` to be defined in multiple hooks and add a note about users' workaround code for enforcing hook execution order

### DIFF
--- a/docs/regression_test_api.rst
+++ b/docs/regression_test_api.rst
@@ -112,7 +112,7 @@ the post-init hook will execute *right after* the test is initialized.
 The framework will then continue with other activities and it will execute the pre-setup hook *just before* it schedules the test for executing its setup stage.
 
 Pipeline hooks are normally executed in reverse MRO order, i.e., the hooks of the least specialized class will be executed first.
-In the following exampel, :func:`BaseTest.x` will execute before :func:`DerivedTest.y`:
+In the following example, :func:`BaseTest.x` will execute before :func:`DerivedTest.y`:
 
 .. code-block:: python
 

--- a/docs/regression_test_api.rst
+++ b/docs/regression_test_api.rst
@@ -111,10 +111,10 @@ So although a "post-init" and a "pre-setup" hook will both run *after* a test ha
 the post-init hook will execute *right after* the test is initialized.
 The framework will then continue with other activities and it will execute the pre-setup hook *just before* it schedules the test for executing its setup stage.
 
-Pipeline hooks are executed in reverse MRO order, i.e., the hooks of the least specialized class will be executed first.
+Pipeline hooks are normally executed in reverse MRO order, i.e., the hooks of the least specialized class will be executed first.
 In the following example, :func:`BaseTest.x` will execute before :func:`DerivedTest.y`:
 
-.. code:: python
+.. code-block:: python
 
    class BaseTest(rfm.RegressionTest):
        @run_after('setup')
@@ -125,6 +125,34 @@ In the following example, :func:`BaseTest.x` will execute before :func:`DerivedT
        @run_after('setup')
        def y(self):
            '''Hook y'''
+
+
+This order can be altered using the ``always_last`` argument of the :func:`@run_before <reframe.core.builtins.run_before>` and :func:`@run_after <reframe.core.builtins.run_after>` decorators.
+In this case, all hooks of the same stage defined with ``always_last=True`` will be executed in MRO order at the end of the stage's hook chain.
+For example, given the following hierarchy:
+
+ .. code-block:: python
+
+    class X(rfm.RunOnlyRegressionTest):
+        @run_before('run', always_last=True)
+        def hook_a(self): pass
+
+        @run_before('run')
+        def hook_b(self): pass
+
+    class Y(X):
+        @run_before('run', always_last=True)
+        def hook_c(self): pass
+
+        @run_before('run')
+        def hook_d(self): pass
+
+
+the run hooks of :class:`Y` will be executed as follows:
+
+.. code-block:: console
+
+   X.hook_b, Y.hook_d, Y.hook_c, X.hook_a
 
 
 .. seealso::

--- a/docs/regression_test_api.rst
+++ b/docs/regression_test_api.rst
@@ -112,7 +112,7 @@ the post-init hook will execute *right after* the test is initialized.
 The framework will then continue with other activities and it will execute the pre-setup hook *just before* it schedules the test for executing its setup stage.
 
 Pipeline hooks are normally executed in reverse MRO order, i.e., the hooks of the least specialized class will be executed first.
-In the following example, :func:`BaseTest.x` will execute before :func:`DerivedTest.y`:
+In the following exampel, :func:`BaseTest.x` will execute before :func:`DerivedTest.y`:
 
 .. code-block:: python
 
@@ -173,6 +173,12 @@ the run hooks of :class:`Y` will be executed as follows:
              # Access the stage directory
              with osext.change_dir(self.stagedir):
                  ...
+
+.. note::
+   In versions prior to 4.3.4, overriding a pipeline hook in a subclass would re-attach it from scratch in the stage, therefore changing its execution order relative to other hooks of the superclass.
+   This is fixed in versions >= 4.3.4 where the execution order of the hook is not changed.
+   However, the fix may break existing workaround code that used to call explicitly the base class' hook from the derived one.
+   Check issue `#3012 <https://github.com/reframe-hpc/reframe/issues/3012>`__ for details on how to properly address this.
 
 .. warning::
    .. versionchanged:: 3.7.0

--- a/reframe/core/builtins.py
+++ b/reframe/core/builtins.py
@@ -48,14 +48,17 @@ def run_before(stage, *, always_last=False):
     :param stage: The pipeline stage where this function will be attached to.
         See :ref:`pipeline-hooks` for the list of valid stage values.
 
-    :param always_last: Run this hook always as the last one of the stage. In
-        a whole test hierarchy, only a single hook can be explicitly pinned at
-        the end of the same-stage sequence of hooks. If another hook is
-        declared as ``always_last`` in the same stage, an error will be
-        issued.
+    :param always_last: Run this hook at the end of the stage's hook chain
+        instead of the beginning. If multiple tests set this flag for a hook
+        in the same stage, then all ``always_last`` hooks will be executed in
+        MRO order at the end of stage's hook chain. See :ref:`pipeline-hooks`
+        for an example execution.
 
     .. versionchanged:: 4.4
        The ``always_last`` argument was added.
+
+    .. versionchanged:: 4.5
+       Multiple tests can set ``always_last`` in the same stage.
 
     '''
 

--- a/unittests/test_pipeline.py
+++ b/unittests/test_pipeline.py
@@ -1208,17 +1208,21 @@ def test_pinned_hooks():
 def test_pinned_hooks_multiple_last():
     class X(rfm.RunOnlyRegressionTest):
         @run_before('run', always_last=True)
-        def hook_a(self): pass
+        def hook_a(self):
+            pass
 
         @run_before('run')
-        def hook_b(self): pass
+        def hook_b(self):
+            pass
 
     class Y(X):
         @run_before('run', always_last=True)
-        def hook_c(self): pass
+        def hook_c(self):
+            pass
 
         @run_before('run')
-        def hook_d(self): pass
+        def hook_d(self):
+            pass
 
     test = Y()
     assert test.pipeline_hooks() == {


### PR DESCRIPTION
Closes #3057.
Closes #3012.