### PR TITLE
[bugfix] Do not ignore the `use_login_shell` configuration option when generation the auto-detection script

### DIFF
--- a/reframe/frontend/autodetect.py
+++ b/reframe/frontend/autodetect.py
@@ -131,6 +131,8 @@ def _is_part_local(part):
 
 
 def _remote_detect(part):
+    use_login_shell = runtime.runtime().get_option('general/0/use_login_shell')
+
     def _emit_script_for_source(job, env):
         commands = [
             './bootstrap.sh',
@@ -138,7 +140,7 @@ def _remote_detect(part):
         ]
         job.prepare(
             commands, env, trap_errors=True,
-            login=runtime.runtime().get_option('general/0/use_login_shell')
+            login=use_login_shell
         )
 
     def _emit_script_for_pip(job, env):
@@ -152,7 +154,7 @@ def _remote_detect(part):
         ]
         job.prepare(
             commands, env, trap_errors=True,
-            login=runtime.runtime().get_option('general/0/use_login_shell')
+            login=use_login_shell
         )
 
     getlogger().info(

--- a/reframe/frontend/autodetect.py
+++ b/reframe/frontend/autodetect.py
@@ -136,7 +136,10 @@ def _remote_detect(part):
             './bootstrap.sh',
             './bin/reframe --detect-host-topology=topo.json'
         ]
-        job.prepare(commands, env, trap_errors=True)
+        job.prepare(
+            commands, env, trap_errors=True,
+            login=runtime.runtime().get_option('general/0/use_login_shell')
+        )
 
     def _emit_script_for_pip(job, env):
         commands = [
@@ -147,7 +150,10 @@ def _remote_detect(part):
             'reframe --detect-host-topology=topo.json',
             'deactivate'
         ]
-        job.prepare(commands, env, trap_errors=True)
+        job.prepare(
+            commands, env, trap_errors=True,
+            login=runtime.runtime().get_option('general/0/use_login_shell')
+        )
 
     getlogger().info(
         f'Detecting topology of remote partition {part.fullname!r}: '

--- a/reframe/frontend/autodetect.py
+++ b/reframe/frontend/autodetect.py
@@ -138,10 +138,7 @@ def _remote_detect(part):
             './bootstrap.sh',
             './bin/reframe --detect-host-topology=topo.json'
         ]
-        job.prepare(
-            commands, env, trap_errors=True,
-            login=use_login_shell
-        )
+        job.prepare(commands, env, trap_errors=True, login=use_login_shell)
 
     def _emit_script_for_pip(job, env):
         commands = [
@@ -152,10 +149,7 @@ def _remote_detect(part):
             'reframe --detect-host-topology=topo.json',
             'deactivate'
         ]
-        job.prepare(
-            commands, env, trap_errors=True,
-            login=use_login_shell
-        )
+        job.prepare(commands, env, trap_errors=True, login=use_login_shell)
 
     getlogger().info(
         f'Detecting topology of remote partition {part.fullname!r}: '


### PR DESCRIPTION
This is useful for the firecrest scheduler, but probably also for other schedulers.