### PR TITLE
[bugfix] Detect missing `curl` in `bootstrap.sh`

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -106,7 +106,7 @@ else
 fi
 
 if ! type "curl" > /dev/null 2>&1; then
-    echo "curl is missing; install curl and try again"
+    echo -e "could not find \`curl': please install curl and try again"
     exit 1
 fi
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -105,6 +105,11 @@ else
     get_pip_url="https://bootstrap.pypa.io/pip/3.6/get-pip.py"
 fi
 
+if ! type "curl" > /dev/null 2>&1; then
+    echo "curl is missing; install curl and try again"
+    exit 1
+fi
+
 INFO "curl -s $get_pip_url | $python"
 curl -s $get_pip_url | $python
 


### PR DESCRIPTION
Curl is not a default package on most Linux distributions, and is not listed as a requirement for reFrame.

When curl is missing, bootstrap.sh will blow right past the curl failure and continue to attempt to execute commands.

Add a check for curl, and print a meaningful message + exit if it is not found.