### PR TITLE
[feat] Add `nvcc` as an environment configuration parameter

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -898,6 +898,16 @@ They are associated with `system partitions <#system-partition-configuration>`__
    A list of linker flags to be used with this environment by default.
 
 
+.. py:attribute:: environments.nvcc
+
+   :required: No
+   :default: ``"nvcc"``
+
+   The NVIDIA CUDA compiler to be used with this environment.
+
+   .. versionadded:: 4.6
+
+
 .. py:attribute:: environments.target_systems
 
    :required: No

--- a/reframe/core/environments.py
+++ b/reframe/core/environments.py
@@ -321,7 +321,7 @@ class ProgEnvironment(Environment):
 
     @property
     def nvcc(self):
-        '''The NVIDIA nvcc compiler of this programming environment.
+        '''The NVIDIA CUDA compiler of this programming environment.
 
         :type: :class:`str`
         '''

--- a/reframe/core/environments.py
+++ b/reframe/core/environments.py
@@ -219,6 +219,7 @@ class ProgEnvironment(Environment):
     _cc = fields.TypedField(str)
     _cxx = fields.TypedField(str)
     _ftn = fields.TypedField(str)
+    _nvcc = fields.TypedField(str)
     _cppflags = fields.TypedField(typ.List[str])
     _cflags = fields.TypedField(typ.List[str])
     _cxxflags = fields.TypedField(typ.List[str])
@@ -320,4 +321,8 @@ class ProgEnvironment(Environment):
 
     @property
     def nvcc(self):
+        '''The NVIDIA nvcc compiler of this programming environment.
+
+        :type: :class:`str`
+        '''
         return self._nvcc

--- a/reframe/core/systems.py
+++ b/reframe/core/systems.py
@@ -538,6 +538,7 @@ class System(jsonext.JSONSerializable):
                     cc=site_config.get(f'environments/@{e}/cc'),
                     cxx=site_config.get(f'environments/@{e}/cxx'),
                     ftn=site_config.get(f'environments/@{e}/ftn'),
+                    nvcc=site_config.get(f'environments/@{e}/nvcc', 'nvcc'),
                     cppflags=site_config.get(f'environments/@{e}/cppflags'),
                     cflags=site_config.get(f'environments/@{e}/cflags'),
                     cxxflags=site_config.get(f'environments/@{e}/cxxflags'),

--- a/reframe/core/systems.py
+++ b/reframe/core/systems.py
@@ -538,7 +538,7 @@ class System(jsonext.JSONSerializable):
                     cc=site_config.get(f'environments/@{e}/cc'),
                     cxx=site_config.get(f'environments/@{e}/cxx'),
                     ftn=site_config.get(f'environments/@{e}/ftn'),
-                    nvcc=site_config.get(f'environments/@{e}/nvcc', 'nvcc'),
+                    nvcc=site_config.get(f'environments/@{e}/nvcc'),
                     cppflags=site_config.get(f'environments/@{e}/cppflags'),
                     cflags=site_config.get(f'environments/@{e}/cflags'),
                     cxxflags=site_config.get(f'environments/@{e}/cxxflags'),

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -529,6 +529,7 @@
         "environments/cc": "cc",
         "environments/cxx": "CC",
         "environments/ftn": "ftn",
+        "environments/nvcc": "nvcc",
         "environments/cppflags": [],
         "environments/cflags": [],
         "environments/cxxflags": [],

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -371,6 +371,7 @@
                     "cc": {"type": "string"},
                     "cxx": {"type": "string"},
                     "ftn": {"type": "string"},
+                    "nvcc": {"type": "string"},
                     "cppflags": {
                         "type": "array",
                         "items": {"type": "string"}

--- a/unittests/test_config.py
+++ b/unittests/test_config.py
@@ -270,6 +270,7 @@ def test_select_subconfig(site_config):
     assert site_config.get('systems/0/partitions/0/max_jobs') == 8
     assert len(site_config['environments']) == 7
     assert site_config.get('environments/@PrgEnv-gnu/cc') == 'gcc'
+    assert site_config.get('environments/@PrgEnv-gnu/nvcc') == 'nvcc'
     assert site_config.get('environments/1/cxx') == 'g++'
     assert site_config.get('environments/@PrgEnv-cray/cc') == 'cc'
     assert site_config.get('environments/2/cxx') == 'CC'


### PR DESCRIPTION
This commit allows you to specify the path to nvidia's nvcc a part of a system environment. This allows for multiple environments with different paths to nvcc without the use of modules or the PATH environment. It allows for nvcc being unset in the environment and will default to 'nvcc'.