### PR TITLE
[feat] Adding support for CMake + Ninja

### DIFF
--- a/reframe/core/buildsystems.py
+++ b/reframe/core/buildsystems.py
@@ -584,7 +584,7 @@ class CMake(ConfigureBasedBuildSystem):
         else:
             cmake_cmd += ['.']
 
-        make_cmd = ['make -j']
+        make_cmd = ['cmake --build . -j']
         if self.max_concurrency is not None:
             make_cmd += [str(self.max_concurrency)]
 


### PR DESCRIPTION
Previously the CMake config would just run 'make'. 
This commit runs 'cmake --build .' which enables you to specify different build systems within cmake. Specifically this is useful for Ninja, using the 'cmake -GNinja' flag. If no build system is set it will fall back to make.