### PR TITLE
[feat] Add CPU vendor and model name to topology files

### DIFF
--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -218,6 +218,8 @@
             "type": "object",
             "properties": {
                 "arch": {"type": "string"},
+                "vendor": {"type": "string"},
+                "model": {"type": "string"},
                 "num_cpus": {"type": "number"},
                 "num_cpus_per_core": {"type": "number"},
                 "num_cpus_per_socket": {"type": "number"},

--- a/reframe/utility/cpuinfo.py
+++ b/reframe/utility/cpuinfo.py
@@ -283,8 +283,8 @@ def cpuinfo():
     ret = {
         'arch': archspec.cpu.host().name,
         'vendor': archspec.cpu.host().vendor,
-        'model':
-            archspec.cpu.detect.raw_info_dictionary().get("model name", "N/A")
+        'model': archspec.cpu.detect.raw_info_dictionary().get('model name',
+                                                               'N/A')
     }
 
     # Try first to get information from the filesystem

--- a/reframe/utility/cpuinfo.py
+++ b/reframe/utility/cpuinfo.py
@@ -281,7 +281,10 @@ def _sysctl_topo():
 
 def cpuinfo():
     ret = {
-        'arch': archspec.cpu.host().name
+        'arch': archspec.cpu.host().name,
+        'vendor': archspec.cpu.host().vendor,
+        'model':
+            archspec.cpu.detect.raw_info_dictionary().get("model name", "N/A")
     }
 
     # Try first to get information from the filesystem


### PR DESCRIPTION
By having the CPU vendor identifier available, test authors can use "GeniuneIntel", "AuthenticAMD", etc. as a logic condition where high-level characterization is acceptable. There are cases where this may actually be more useful than the particular CPU model name.

Fixes #https://github.com/reframe-hpc/reframe/issues/2995