### PR TITLE
[feat] Enable multiple inheritance of test variables

### DIFF
--- a/unittests/test_variables.py
+++ b/unittests/test_variables.py
@@ -622,3 +622,19 @@ def test_inherit_mutable_aliases_deprecated():
     assert y.x == [2]
     with pytest.warns(ReframeDeprecationWarning):
         assert y.y == [2]
+
+def test_combine_base_vars():
+    class Mixin(rfm.RegressionMixin):
+        x = variable(typ.List[int], value=[],
+                     combine=lambda x, y: list(map(max, zip(x, y))))
+
+    class X(Mixin):
+        x = [3, 4]
+
+    class Y(Mixin):
+        x = [10, 1]
+
+    class Z(X, Y):
+        pass
+
+    assert Z.x == [10, 4]


### PR DESCRIPTION
Currently, multiple inheritance of test or mixin variables is prohibited leads to a test load error. This is restrictive, especially in case of mixins, which may be inherited multiple times in a complex setup. For example, the following would cause an error when reframe is processing the `Z` class:

```python
    class Mixin(rfm.RegressionMixin):
        x = variable(typ.List[int], value=[])

    class X(Mixin):
        x = [3, 4]

    class Y(Mixin):
        x = [10, 1]

    class Z(X, Y):
        pass
```

This PR introduces a new variable argument, `combine`, that defines how the default values of the parent variables can be combined in case of multiple inheritance. Since `combine=None` by default, the default behaviour of variables does not change. It just that we now offer the extra flexibility to users to define the variable behaviour in case of multiple inheritance.

In the example above, if we define `x` as follows:

```python
    class Mixin(rfm.RegressionMixin):
        x = variable(typ.List[int], value=[],
                     combine=lambda x, y: list(map(max, zip(x, y))))

    class X(Mixin):
        x = [3, 4]

    class Y(Mixin):
        x = [10, 1]

    class Z(X, Y):
        pass
```

its value in `Z` class will be `[10, 4]`.

### Todos
- [ ] Write docs