### PR TITLE
[feat] Enable default value type checking and implicit conversions at the variable declaration level

### DIFF
--- a/docs/regression_test_api.rst
+++ b/docs/regression_test_api.rst
@@ -41,6 +41,13 @@ These are called *builtins* because they are directly available for use inside t
 However, almost all of these builtins are also available from the :obj:`reframe.core.builtins` module.
 The use of this module is required only when creating new tests programmatically using the :func:`~reframe.core.meta.make_test` function.
 
+.. versionchanged:: 3.7.0
+   Expose :func:`@deferrable <reframe.core.builtins.deferrable>` as a builtin.
+
+.. versionchanged:: 3.11.0
+   Builtins are now available also through the :obj:`reframe.core.builtins` module.
+
+
 .. py:method:: reframe.core.pipeline.RegressionMixin.bind(func, name=None)
 
    Bind a free function to a regression test.
@@ -78,13 +85,6 @@ The use of this module is required only when creating new tests programmatically
 .. autodecorator:: reframe.core.builtins.sanity_function
 
 .. autofunction:: reframe.core.builtins.variable
-
-
-.. versionchanged:: 3.7.0
-   Expose :func:`@deferrable <reframe.core.builtins.deferrable>` as a builtin.
-
-.. versionchanged:: 3.11.0
-   Builtins are now available also through the :obj:`reframe.core.builtins` module.
 
 
 .. _pipeline-hooks:

--- a/reframe/core/buildsystems.py
+++ b/reframe/core/buildsystems.py
@@ -981,4 +981,4 @@ class BuildSystemField(fields.TypedField):
             except KeyError:
                 raise ValueError(f'unknown build system: {value}') from None
 
-        super().__set__(obj, value)
+        return super().__set__(obj, value)

--- a/reframe/core/containers.py
+++ b/reframe/core/containers.py
@@ -287,4 +287,4 @@ class ContainerPlatformField(fields.TypedField):
         if isinstance(value, str):
             value = ContainerPlatform.create(value)
 
-        super().__set__(obj, value)
+        return super().__set__(obj, value)

--- a/reframe/core/decorators.py
+++ b/reframe/core/decorators.py
@@ -123,7 +123,6 @@ class TestRegistry:
         # candidate tests; the leaf tests are consumed at the end of the
         # traversal and all instantiated tests (including fixtures) are stored
         # in `final_tests`.
-        unset_vars = {}
         final_tests = []
         fixture_registry = FixtureRegistry()
         while leaf_tests:

--- a/reframe/core/variables.py
+++ b/reframe/core/variables.py
@@ -305,8 +305,10 @@ class TestVar:
     def _default_value(self, value):
         if self.is_alias():
             self._target._default_value = value
-        else:
+        elif value is Undefined:
             self._p_default_value = value
+        else:
+            self._p_default_value = self._p_field.__set__(None, value)
 
     @property
     def default_value(self):
@@ -348,6 +350,17 @@ class TestVar:
 
     def __set_name__(self, owner, name):
         self._name = name
+        self._p_field.__set_name__(owner, name)
+
+        # Type check and convert the variable's value if defined
+        if self.is_defined():
+            if isinstance(self._p_default_value, TestVar):
+                value = self._p_default_value._p_default_value
+            else:
+                value = self._p_default_value
+
+            with suppress_deprecations():
+                self._p_default_value = self._p_field.__set__(None, value)
 
     def __setattr__(self, name, value):
         '''Set any additional variable attribute into the default value.'''

--- a/reframe/core/variables.py
+++ b/reframe/core/variables.py
@@ -355,6 +355,7 @@ class TestVar:
         # Type check and convert the variable's value if defined
         if self.is_defined():
             if isinstance(self._p_default_value, TestVar):
+                # Treat shadow variables
                 value = self._p_default_value._p_default_value
             else:
                 value = self._p_default_value
@@ -891,12 +892,16 @@ class VarSpace(namespaces.Namespace):
 
     def _inject(self, obj, cls):
         for name, var in self.items():
+            # Replace the variable with its descriptor
             setattr(cls, name, var.field)
             getattr(cls, name).__set_name__(obj, name)
 
             # If the var is defined, set its value
             if var.is_defined():
-                setattr(obj, name, var.default_value)
+                # Variable's value is already validated and converted,
+                # so we bypass completely the descriptor logic by not calling
+                # `setattr()`
+                obj.__dict__[name] = var.default_value
 
             # Track the variables that have been injected.
             self._injected_vars.add(name)

--- a/unittests/test_pipeline.py
+++ b/unittests/test_pipeline.py
@@ -1607,11 +1607,9 @@ def test_reference_deferrable(dummy_perftest):
     with pytest.raises(TypeError):
         dummy_perftest.reference = {'*': {'value1': (sn.defer(1), -0.1, -0.1)}}
 
-    class T(rfm.RegressionTest):
-        reference = {'*': {'value1': (sn.defer(1), -0.1, -0.1)}}
-
     with pytest.raises(TypeError):
-        T()
+        class T(rfm.RegressionTest):
+            reference = {'*': {'value1': (sn.defer(1), -0.1, -0.1)}}
 
 
 def test_performance_invalid_value(dummytest, sanity_file,

--- a/unittests/test_variables.py
+++ b/unittests/test_variables.py
@@ -146,11 +146,9 @@ def test_set_var(OneVarTest):
 
 
 def test_var_type(OneVarTest):
-    class MyTest(OneVarTest):
-        foo = 'bananas'
-
     with pytest.raises(TypeError):
-        MyTest()
+        class MyTest(OneVarTest):
+            foo = 'bananas'
 
 
 def test_require_var(OneVarTest):
@@ -358,7 +356,7 @@ def test_var_div_operator():
         v = variable(int, value=4)
         assert (v / 3) == 4/3
         assert (3 / v) == 3/4
-        v /= 2
+        v //= 2
         assert v == 2
 
 


### PR DESCRIPTION
Currently, the default values of variables or the values assigned to them in the test class body are not type checked and no implicit conversions are applied to the value being assigned. This is deferred at the class instantiation time where the default values of variables are injected to the newly created test object and type checked through the associated descriptor.

This PR moves the type checking and implicit conversions, i.e., the functionality of the descriptors at the class level. We do so, with two tricks:

1. We extend the Python descriptor model by having `__set__()` return the value that the descriptor would write into the object if the object passed to `__set__()` is `None`.
2. We anticipate the call to the descriptor's `__set_name__()` at the same time that this function is called for the variable. And it is at this point that we also call the descriptor's `__set__()` method to force the type checking and any type conversion. For type conversions we do respect the `allow_implicit` argument of variables.

The advantages of this method are

- Variables before and after the test's instantiation behave the same way.
- Type errors during variable assignments are now more precise as the source file information is included in the error message.

Todos

- [x] Remove unnecessary conversions and type checking (type checking in `inject()` should not be needed)
- [x] Double-check the `setvar()` impl. for redundant operations.