### PR TITLE
[testlib] Added QuantumESPRESSO scalability test for `pw.x`

### DIFF
--- a/docs/hpctestlib.rst
+++ b/docs/hpctestlib.rst
@@ -102,6 +102,9 @@ Scientific Applications
    :members:
    :show-inheritance:
 
+.. automodule:: hpctestlib.sciapps.qespresso.benchmarks
+   :members:
+   :show-inheritance:
 
 System
 =======================

--- a/hpctestlib/sciapps/qespresso/benchmarks.py
+++ b/hpctestlib/sciapps/qespresso/benchmarks.py
@@ -53,20 +53,20 @@ class QEspressoPWCheck(rfm.RunOnlyRegressionTest):
 
     The benchmarks consist of one input file templated inside the code and
     a pseudo-potential file that is downloaded from the official repository.
-    
+
     This tests aims at measuring the scalability of the pw.x executable, in
     particular the FFT and diagonalization algorithms, by running a simple
-    silicon calculation with high `ecut` (increases size of FFTs) and `nbnd` 
+    silicon calculation with high `ecut` (increases size of FFTs) and `nbnd`
     (increases size of matrices to diagonalize) values."""
 
-    #: Parametert to tests the performance of the FFTW algorithm, 
+    #: Parametert to tests the performance of the FFTW algorithm,
     #: higher `ecut` implicates more FFTs
     #:
     #: :type: :class:`int`
     #: :values: ``[50, 150]``
     ecut = parameter([50, 150], loggable=True)
 
-    #: Parameter to Tests the performance of the diagonalization algorithm, higher ecut -> more FFTs
+    #: Parameter to Tests the performance of the diagonalization algorithm,
     #: higher `nbnd` implicates bigger matrices
     #:
     #: :type: :class:`int`
@@ -84,7 +84,7 @@ class QEspressoPWCheck(rfm.RunOnlyRegressionTest):
     #: :default: ``'Si.scf.in'``
     input_name: str = variable(str, value='Si.scf.in')
 
-    #: The pseudo-potential file to be used check 
+    #: The pseudo-potential file to be used check
     #: https://www.quantum-espresso.org/pseudopotentials/ for more info
     #:
     #: :type: :class:`str`

--- a/hpctestlib/sciapps/qespresso/benchmarks.py
+++ b/hpctestlib/sciapps/qespresso/benchmarks.py
@@ -59,10 +59,18 @@ class QEspressoPWCheck(rfm.RunOnlyRegressionTest):
     silicon calculation with high `ecut` (increases size of FFTs) and `nbnd` 
     (increases size of matrices to diagonalize) values."""
 
-    # Tests the performance of the FFTW algorithm, higher ecut -> more FFTs
+    #: Parametert to tests the performance of the FFTW algorithm, 
+    #: higher `ecut` implicates more FFTs
+    #:
+    #: :type: :class:`int`
+    #: :values: ``[50, 150]``
     ecut = parameter([50, 150], loggable=True)
-    # Tests the performance of the diagonalization algorithm,
-    # higher nbnd -> bigger matrices
+
+    #: Parameter to Tests the performance of the diagonalization algorithm, higher ecut -> more FFTs
+    #: higher `nbnd` implicates bigger matrices
+    #:
+    #: :type: :class:`int`
+    #: :values: ``[10, 200]``
     nbnd = parameter([10, 200], loggable=True)
 
     executable = 'pw.x'
@@ -70,7 +78,17 @@ class QEspressoPWCheck(rfm.RunOnlyRegressionTest):
 
     descr = 'QuantumESPRESSO pw.x benchmark'
 
+    #: The name of the input file used.
+    #:
+    #: :type: :class:`str`
+    #: :default: ``'Si.scf.in'``
     input_name: str = variable(str, value='Si.scf.in')
+
+    #: The pseudo-potential file to be used check 
+    #: https://www.quantum-espresso.org/pseudopotentials/ for more info
+    #:
+    #: :type: :class:`str`
+    #: :default: ``'Si.pbe-n-kjpaw_psl.1.0.0.UPF'``
     pp_name: str = variable(str, value='Si.pbe-n-kjpaw_psl.1.0.0.UPF')
 
     @run_after('init')

--- a/hpctestlib/sciapps/qespresso/benchmarks.py
+++ b/hpctestlib/sciapps/qespresso/benchmarks.py
@@ -51,7 +51,13 @@ class QEspressoPWCheck(rfm.RunOnlyRegressionTest):
     suite of Open-Source computer codes for electronic-structure calculations
     and materials modeling at the nanoscale.
 
-    The benchmarks consist on a set of different inputs files ..."""
+    The benchmarks consist of one input file templated inside the code and
+    a pseudo-potential file that is downloaded from the official repository.
+    
+    This tests aims at measuring the scalability of the pw.x executable, in
+    particular the FFT and diagonalization algorithms, by running a simple
+    silicon calculation with high `ecut` (increases size of FFTs) and `nbnd` 
+    (increases size of matrices to diagonalize) values."""
 
     # Tests the performance of the FFTW algorithm, higher ecut -> more FFTs
     ecut = parameter([50, 150], loggable=True)

--- a/hpctestlib/sciapps/qespresso/benchmarks.py
+++ b/hpctestlib/sciapps/qespresso/benchmarks.py
@@ -101,12 +101,12 @@ class QEspressoPWCheck(rfm.RunOnlyRegressionTest):
         elif kind == 'wall':
             tag = 2
         else:
-            raise ValueError(f'unknown kind: {kind}')  
-         
+            raise ValueError(f'unknown kind: {kind}')
+
         return sn.extractsingle(
             fr'{name}\s+:\s+([\d\.]+)s\s+CPU\s+([\d\.]+)s\s+WALL', self.stdout, tag, float
             )
-    
+
     @run_before('performance')
     def set_perf_variables(self):
         """Build a dictionary of performance variables"""

--- a/hpctestlib/sciapps/qespresso/benchmarks.py
+++ b/hpctestlib/sciapps/qespresso/benchmarks.py
@@ -8,7 +8,7 @@ from reframe.core.builtins import (performance_function, run_after, run_before,
 from reframe.core.parameters import TestParam as parameter
 from reframe.core.variables import TestVar as variable
 
-input_template = """&CONTROL
+INPUT_TEMPLATE = """&CONTROL
   calculation  = "scf",
   prefix       = "Si",
   pseudo_dir   = ".",
@@ -39,7 +39,7 @@ K_POINTS {{automatic}}
 """
 
 @rfm.simple_test
-class qespresso_pw_check(rfm.RunOnlyRegressionTest):
+class QEspressoPWCheck(rfm.RunOnlyRegressionTest):
     """QuantumESPRESSO benchmark test.
 
     `QuantumESPRESSO <https://www.quantum-espresso.org/>`__ is an integrated
@@ -74,7 +74,7 @@ class qespresso_pw_check(rfm.RunOnlyRegressionTest):
         """Write the input file for the calculation"""
         inp_file = os.path.join(self.stagedir, self.input_name)
         with open(inp_file, 'w', encoding='utf-8') as file:
-            file.write(input_template.format(
+            file.write(INPUT_TEMPLATE.format(
                 ecut=self.ecut,
                 nbnd=self.nbnd,
                 pseudo=self.pp_name,

--- a/hpctestlib/sciapps/qespresso/benchmarks.py
+++ b/hpctestlib/sciapps/qespresso/benchmarks.py
@@ -1,0 +1,104 @@
+"""ReFrame benchmark for QuantumESPRESSO"""
+import os
+
+import reframe as rfm
+import reframe.utility.sanity as sn
+
+from reframe.core.builtins import performance_function, run_before, run_after, sanity_function
+from reframe.core.parameters import TestParam as parameter
+from reframe.core.variables import TestVar as variable
+
+input_template = """&CONTROL
+  calculation  = "scf",
+  prefix       = "Si",
+  pseudo_dir   = ".",
+  outdir       = "./out",
+  restart_mode = "from_scratch"
+  verbosity    = 'high'
+/
+&SYSTEM
+  ibrav     = 2,
+  celldm(1) = 10.2,
+  nat       = 2,
+  ntyp      = 1,
+  nbnd      = {nbnd}
+  ecutwfc   = {ecut} 
+/
+&ELECTRONS
+  conv_thr    = 1.D-8,
+  mixing_beta = 0.7D0,
+/
+ATOMIC_SPECIES
+ Si  28.086  Si.pbe-n-kjpaw_psl.1.0.0.UPF
+ATOMIC_POSITIONS
+ Si 0.00 0.00 0.00
+ Si 0.25 0.25 0.25
+K_POINTS {{automatic}}
+ 15 15 15   0 0 0
+
+"""
+
+@rfm.simple_test
+class qespresso_pw_check(rfm.RunOnlyRegressionTest):
+    """QuantumESPRESSO benchmark test.
+
+    `QuantumESPRESSO <https://www.quantum-espresso.org/>`__ is an integrated
+    suite of Open-Source computer codes for electronic-structure calculations
+    and materials modeling at the nanoscale.
+
+    The benchmarks consist on a set of different inputs files ..."""
+
+    # Tests the performance of the FFTW algorithm, higher ecut -> more FFTs
+    ecut = parameter([50,150], loggable=True)
+    # Tests the performance of the diagonalization algorithm, higher nbnd -> bigger matrices
+    nbnd = parameter([10,200], loggable=True)
+
+    executable = 'pw.x'
+    tags = {'sciapp', 'chemistry'}
+
+    descr = 'QuantumESPRESSO pw.x benchmark'
+
+    input_name: str = variable(str, value='Si.scf.in')
+
+    @run_after('init')
+    def prepare_test(self):
+        """Hook to the set the downloading of the pseudo-potentials"""
+        self.prerun_cmds = [
+            'wget -q http://pseudopotentials.quantum-espresso.org/upf_files/Si.pbe-n-kjpaw_psl.1.0.0.UPF'
+        ]
+        self.executable_opts += [f'-in {self.input_name}']
+
+    @run_after('setup')
+    def write_input(self):
+        """Write the input file for the calculation"""
+        inp_file = os.path.join(self.stagedir, self.input_name)
+        with open(inp_file, 'w') as file:
+            file.write(input_template.format(ecut=self.ecut, nbnd=self.nbnd))
+
+
+    @performance_function('s')
+    def extract_report_time(self, name: str = None, kind: str = None) -> float:
+        kind = kind.lower()
+        if kind == 'cpu':
+            tag = 1
+        elif kind == 'wall':
+            tag = 2
+        else:
+            raise ValueError(f'unknown kind: {kind}')  
+         
+        return sn.extractsingle(
+            fr'{name}\s+:\s+([\d\.]+)s\s+CPU\s+([\d\.]+)s\s+WALL', self.stdout, tag, float
+            )
+    
+    @run_before('performance')
+    def set_perf_variables(self):
+        """Build a dictionary of performance variables"""
+
+        for name in ['PWSCF', 'electrons', 'c_bands', 'sum_bands', 'cegterg', 'calbec', 'fft', 'ffts', 'fftw']:
+            for kind in ['cpu', 'wall']:
+                self.perf_variables[f'{name}_{kind}'] = self.extract_report_time(name, kind)
+
+    @sanity_function
+    def assert_job_finished(self):
+        """Check if the job finished successfully"""
+        return sn.assert_found(r'JOB DONE', self.stdout)


### PR DESCRIPTION
This PR adds a reframe reusable test for QuantumESPRESSO, aimed at testing the scaling  `pw.x` executable.

The parameters `ecut` and `nbnd` can be tuned in order to increase the usage of either FFTW or diagonalization routines.

For now the input file is baked into the source code, but it could be easily moved to a separate repo, like for the GROMACS test 