### PR TITLE
[packaging] Stricter install requirements in `setup.cfg`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,13 +26,16 @@ packages = find_namespace:
 python_requires = >=3.6
 scripts = bin/reframe
 install_requires =
-    archspec
+    archspec <= 0.2.2
     argcomplete
+    argcomplete <= 3.1.2; python_version < '3.8'
     jsonschema
     lxml
     PyYAML
     requests
+    requests <= 2.27.1; python_version == '3.6'
     semver
+    semver <= 2.13.0; python_version == '3.6'
 
 [options.packages.find]
 include = reframe,reframe.*,hpctestlib.*


### PR DESCRIPTION
This fixes the failures of the "wheelvalidation" GH action in random PRs after archspec 0.2.3 release which breaks ReFrame. The problem is the following:

The `install_requires` in our `setup.cfg` is too loose, stating only the package names not versions. When the CI tries to create the wheel, it fetches the latest archspec which then breaks us. I've made the `install_requires` stricter to avoid such problems. We should make sure to update also `setup.cfg` in the next release of archspec.