### PR TITLE
[bugfix] Fix logging crash when the `check_#ALL` placeholder is used

### DIFF
--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -305,6 +305,7 @@ class CheckFieldFormatter(logging.Formatter):
 
         self.__fmt = fmt
         self.__fmtperf = perffmt[:-1] if perffmt else ''
+        self.__specs = re.findall(r'\%\((\S+?)\)s', fmt)
         self.__delim = perffmt[-1] if perffmt else ''
         self.__expand_vars = '%(check_#ALL)s' in self.__fmt
         self.__expanded_fmt = {}
@@ -349,6 +350,10 @@ class CheckFieldFormatter(logging.Formatter):
 
     def formatMessage(self, record):
         fmt = self._expand_fmt(record)
+        for s in self.__specs:
+            if s != 'check_#ALL' and not hasattr(record, s):
+                setattr(record, s, None)
+
         record_proxy = dict(record.__dict__)
         for k, v in record_proxy.items():
             if k == 'check_perfvalues':

--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -178,15 +178,17 @@ class MultiFileHandler(logging.FileHandler):
         # Expand the special check_#ALL specifier
         if '%(check_#ALL)s' in self.__fmt:
             delim = _guess_delim(self.__fmt)
-            self.__fmt = self.__fmt.replace(
+            fmt = self.__fmt.replace(
                 '%(check_#ALL)s',
                 delim.join(f'%({x})s'
                            for x in sorted(record.__rfm_loggable_attrs__)
                            if x not in self.__ignore_keys)
             )
+        else:
+            fmt = self.__fmt
 
         header = ''
-        for m in self.__attr_patt.finditer(self.__fmt):
+        for m in self.__attr_patt.finditer(fmt):
             attr = m.group(1)
             delim = m.group(2)
             if attr == 'check_perfvalues':
@@ -303,22 +305,27 @@ class CheckFieldFormatter(logging.Formatter):
 
         self.__fmt = fmt
         self.__fmtperf = perffmt[:-1] if perffmt else ''
-        self.__specs = re.findall(r'\%\((\S+?)\)s', fmt)
         self.__delim = perffmt[-1] if perffmt else ''
         self.__expand_vars = '%(check_#ALL)s' in self.__fmt
-        self.__expanded = False
+        self.__expanded_fmt = {}
         self.__ignore_keys = set(ignore_keys) if ignore_keys else set()
 
-    def _expand_fmt(self, attrs):
-        if not self.__expand_vars or self.__expanded:
+    def _expand_fmt(self, record):
+        if not self.__expand_vars:
             return self.__fmt
 
-        delim = _guess_delim(self.__fmt)
-        self.__fmt = self.__fmt.replace(
-            '%(check_#ALL)s', delim.join(f'%({x})s' for x in attrs
-                                         if x not in self.__ignore_keys)
-        )
-        self.__expanded = True
+        key = id(record.__rfm_check__)
+        attrs = sorted(record.__rfm_loggable_attrs__)
+        try:
+            return self.__expanded_fmt[key]
+        except KeyError:
+            delim = _guess_delim(self.__fmt)
+            fmt = self.__fmt.replace(
+                '%(check_#ALL)s', delim.join(f'%({x})s' for x in attrs
+                                             if x not in self.__ignore_keys)
+            )
+            self.__expanded_fmt[key] = fmt
+            return fmt
 
     def _format_perf(self, perfvars):
         chunks = []
@@ -341,11 +348,7 @@ class CheckFieldFormatter(logging.Formatter):
         return self.__delim.join(chunks)
 
     def formatMessage(self, record):
-        self._expand_fmt(sorted(record.__rfm_loggable_attrs__))
-        for s in self.__specs:
-            if not hasattr(record, s):
-                setattr(record, s, None)
-
+        fmt = self._expand_fmt(record)
         record_proxy = dict(record.__dict__)
         for k, v in record_proxy.items():
             if k == 'check_perfvalues':
@@ -362,7 +365,7 @@ class CheckFieldFormatter(logging.Formatter):
             )
 
         try:
-            return self.__fmt % record_proxy
+            return fmt % record_proxy
         except ValueError:
             return ("<error formatting the log message: "
                     "please check the 'format' string>")


### PR DESCRIPTION
I hit this subtle and nasty bug while working on the new tutorial. It is exposed more easily now that the variables and parameters are by default loggable. The problem is the following:

When a series of tests that define different variables is set, ReFrame's logging will crash with an error like this:

```console
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.10/logging/__init__.py", line 1100, in emit
    msg = self.format(record)
  File "/usr/lib/python3.10/logging/__init__.py", line 943, in format
    return fmt.format(record)
  File "/usr/lib/python3.10/logging/__init__.py", line 681, in format
    s = self.formatMessage(record)
  File "/usr/local/share/reframe/reframe/core/logging.py", line 366, in formatMessage
    return self.__fmt % record_proxy
KeyError: 'check_nthr'
...
```

The problem was that the message's format was calculated once from the `check_#ALL` special placeholder, so when trying to format the message from another test with different variables, it would cause this crash. I have added a unit test that reproduces this error exactly.

This PR fixes this problem by keeping the expanded format strings for each test. Also, it fixes a similar problem that was causing ReFrame to generate wrong perflog headers for subsequent tests.