### PR TITLE
[feat] Make processor model available through `ProcessorInfo`

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -1914,6 +1914,15 @@ A *processor info object* in ReFrame's configuration is used to hold information
    The microarchitecture of the processor.
 
 
+.. attribute:: systems.partitions.processor.model
+
+   :required: No
+   :default: ``None``
+
+   The model of the processor.
+
+   .. versionadded:: 4.6
+
 .. attribute:: systems.partitions.processor.num_cpus
 
    :required: No
@@ -2017,6 +2026,15 @@ A *device info object* in ReFrame's configuration is used to hold information ab
 
    The microarchitecture of the device.
 
+.. attribute:: systems.partitions.devices.model
+   :noindex:
+
+   :required: No
+   :default: ``None``
+
+   The model of the device.
+
+   .. versionadded:: 4.6
 
 .. attribute:: systems.partitions.devices.num_devices
 

--- a/reframe/core/systems.py
+++ b/reframe/core/systems.py
@@ -56,7 +56,7 @@ class ProcessorInfo(_ReadOnlyInfo, jsonext.JSONSerializable):
 
     __slots__ = ()
     _known_attrs = (
-        'arch', 'num_cpus', 'num_cpus_per_core',
+        'arch', 'model', 'num_cpus', 'num_cpus_per_core',
         'num_cpus_per_socket', 'num_sockets', 'topology'
     )
 

--- a/unittests/resources/config/settings.py
+++ b/unittests/resources/config/settings.py
@@ -75,6 +75,7 @@ site_configuration = {
                     },
                     'processor': {
                         'arch': 'skylake',
+                        'model': 'Intel Skylake',
                         'num_cpus': 8,
                         'num_cpus_per_core': 2,
                         'num_cpus_per_socket': 8,

--- a/unittests/test_config.py
+++ b/unittests/test_config.py
@@ -465,6 +465,7 @@ def test_system_create(site_config):
     assert partition.processor.info is not None
     assert partition.processor.topology is not None
     assert partition.processor.arch == 'skylake'
+    assert partition.processor.model == 'Intel Skylake'
     assert partition.processor.num_cpus == 8
     assert partition.processor.num_cpus_per_core == 2
     assert partition.processor.num_cpus_per_socket == 8


### PR DESCRIPTION
This is a follow up of #3107 and defines the `model` attribute in `ProcessorInfo`.