### PR TITLE
[feat] Add support for associating scheduler resources with an environment

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -684,7 +684,7 @@ ReFrame can launch containerized applications, but you need to configure properl
 Custom Job Scheduler Resources
 ==============================
 
-ReFrame allows you to define custom scheduler resources for each partition that you can then transparently access through the :attr:`~reframe.core.pipeline.RegressionTest.extra_resources` attribute of a regression test.
+ReFrame allows you to define custom scheduler resources for each partition that you can then transparently access through the :attr:`~reframe.core.pipeline.RegressionTest.extra_resources` attribute of a regression test or the environment.
 
 .. py:attribute:: systems.partitions.resources.name
 
@@ -764,6 +764,27 @@ ReFrame allows you to define custom scheduler resources for each partition that 
  .. note::
     For the ``pbs`` and ``torque`` backends, options accepted in the :attr:`~config.systems.partitions.access` and :attr:`~config.systems.partitions.resources` parameters may either refer to actual ``qsub`` options or may just be resources specifications to be passed to the ``-l`` option.
     The backend assumes a ``qsub`` option, if the options passed in these attributes start with a ``-``.
+
+
+.. py:attribute:: systems.partitions.env_resources.name
+
+   :required: Yes
+
+  The name of this resources.
+  This name will be used to request this resource in a programming environment :attr:`~environments.resources`.
+
+   .. versionadded:: 4.6
+
+
+.. py:attribute:: systems.partitions.env_resources.options
+
+   :required: No
+   :default: ``[]``
+
+   A list of options to be passed to this partition’s job scheduler.
+   This is very similar to the :attr:`~config.systems.partitions.resources.options` parameter, but it is used to define resources that are specific to a programming environment.
+
+   .. versionadded:: 4.6
 
 
 Environment Configuration
@@ -946,6 +967,16 @@ They are associated with `system partitions <#system-partition-configuration>`__
    However, if the current system was ``daint:gpu``, the first definition would be selected, despite the fact that the second definition is relevant for another partition of the same system.
    To better understand this, ReFrame resolves definitions in a hierarchical way.
    It first looks for definitions for the current partition, then for the containing system and, finally, for global definitions (the ``*`` pseudo-system).
+
+
+.. py:attribute:: environments.resources
+
+   :required: No
+   :default: ``{}``
+
+   This is similar to a regression test's :attr:`~reframe.core.pipeline.RegressionTest.extra_resources`.
+
+   .. versionadded:: 4.6
 
 
 .. _logging-config-reference:

--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -689,7 +689,7 @@ ReFrame can launch containerized applications, but you need to configure properl
 Custom Job Scheduler Resources
 ==============================
 
-ReFrame allows you to define custom scheduler resources for each partition/environment that can then be transparently accessed through the :attr:`~reframe.core.pipeline.RegressionTest.extra_resources` attribute of a regression test or the environment.
+ReFrame allows you to define custom scheduler resources for each partition that can then be transparently accessed through the :attr:`~reframe.core.pipeline.RegressionTest.extra_resources` attribute of a test or from an environment.
 
 .. py:attribute:: systems.partitions.resources.name
 
@@ -958,7 +958,9 @@ They are associated with `system partitions <#system-partition-configuration>`__
    :required: No
    :default: ``{}``
 
-   This is similar to a regression test's :attr:`~reframe.core.pipeline.RegressionTest.extra_resources`.
+   Scheduler resources associated with this environments.
+   
+   This is the equivalent of a test's :attr:`~reframe.core.pipeline.RegressionTest.extra_resources`.
 
    .. versionadded:: 4.6
 

--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -771,27 +771,6 @@ ReFrame allows you to define custom scheduler resources for each partition that 
     The backend assumes a ``qsub`` option, if the options passed in these attributes start with a ``-``.
 
 
-.. py:attribute:: systems.partitions.env_resources.name
-
-   :required: Yes
-
-  The name of this resources.
-  This name will be used to request this resource in a programming environment :attr:`~environments.resources`.
-
-   .. versionadded:: 4.6
-
-
-.. py:attribute:: systems.partitions.env_resources.options
-
-   :required: No
-   :default: ``[]``
-
-   A list of options to be passed to this partition’s job scheduler.
-   This is very similar to the :attr:`~config.systems.partitions.resources.options` parameter, but it is used to define resources that are specific to a programming environment.
-
-   .. versionadded:: 4.6
-
-
 Environment Configuration
 =========================
 

--- a/reframe/core/environments.py
+++ b/reframe/core/environments.py
@@ -39,7 +39,8 @@ class Environment(jsonext.JSONSerializable):
     '''
 
     def __init__(self, name, modules=None, env_vars=None,
-                 extras=None, features=None, prepare_cmds=None):
+                 extras=None, features=None, prepare_cmds=None,
+                 resources=None):
         modules = modules or []
         env_vars = env_vars or []
         self._name = name
@@ -57,6 +58,7 @@ class Environment(jsonext.JSONSerializable):
         self._extras = extras or {}
         self._features = features or []
         self._prepare_cmds = prepare_cmds or []
+        self._resources = resources or {}
 
     @property
     def name(self):
@@ -145,6 +147,16 @@ class Environment(jsonext.JSONSerializable):
         :type: :class:`List[str]`
         '''
         return util.SequenceView(self._prepare_cmds)
+
+    @property
+    def resources(self):
+        '''The resources associated with this environment.
+
+        .. versionadded:: 4.6.0
+
+        :type: :class:`Dict[str, object]`
+        '''
+        return self._resources
 
     def __eq__(self, other):
         if not isinstance(other, type(self)):

--- a/reframe/core/environments.py
+++ b/reframe/core/environments.py
@@ -39,8 +39,7 @@ class Environment(jsonext.JSONSerializable):
     '''
 
     def __init__(self, name, modules=None, env_vars=None,
-                 extras=None, features=None, prepare_cmds=None,
-                 resources=None):
+                 extras=None, features=None, prepare_cmds=None):
         modules = modules or []
         env_vars = env_vars or []
         self._name = name
@@ -58,7 +57,6 @@ class Environment(jsonext.JSONSerializable):
         self._extras = extras or {}
         self._features = features or []
         self._prepare_cmds = prepare_cmds or []
-        self._resources = resources or {}
 
     @property
     def name(self):
@@ -147,16 +145,6 @@ class Environment(jsonext.JSONSerializable):
         :type: :class:`List[str]`
         '''
         return util.SequenceView(self._prepare_cmds)
-
-    @property
-    def resources(self):
-        '''The resources associated with this environment.
-
-        .. versionadded:: 4.6.0
-
-        :type: :class:`Dict[str, object]`
-        '''
-        return self._resources
 
     def __eq__(self, other):
         if not isinstance(other, type(self)):
@@ -254,6 +242,7 @@ class ProgEnvironment(Environment):
                  cxxflags=None,
                  fflags=None,
                  ldflags=None,
+                 resources=None,
                  **kwargs):
         super().__init__(name, modules, env_vars, extras, features,
                          prepare_cmds)
@@ -266,6 +255,7 @@ class ProgEnvironment(Environment):
         self._cxxflags = cxxflags or []
         self._fflags   = fflags   or []
         self._ldflags  = ldflags  or []
+        self._resources = resources or {}
 
     @property
     def cc(self):
@@ -338,3 +328,13 @@ class ProgEnvironment(Environment):
         :type: :class:`str`
         '''
         return self._nvcc
+
+    @property
+    def resources(self):
+        '''The resources associated with this environment.
+
+        .. versionadded:: 4.6.0
+
+        :type: :class:`Dict[str, object]`
+        '''
+        return self._resources

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -1863,9 +1863,8 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
         # build_job_opts. We want any user supplied options to be able to
         # override those set by the framework.
         resources_opts = self._map_resources_to_jobopts()
-        env_resources_opts = self._map_env_resources_to_jobopts()
         self._build_job.options = (
-            env_resources_opts + resources_opts + self._build_job.options
+            resources_opts + self._build_job.options
         )
         with osext.change_dir(self._stagedir):
             # Prepare build job
@@ -2014,9 +2013,8 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
         # job_opts. We want any user supplied options to be able to
         # override those set by the framework.
         resources_opts = self._map_resources_to_jobopts()
-        env_resources_opts = self._map_env_resources_to_jobopts()
         self._job.options = (
-            env_resources_opts + resources_opts + self._job.options
+            resources_opts + self._job.options
         )
         with osext.change_dir(self._stagedir):
             try:
@@ -2042,15 +2040,11 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
 
     def _map_resources_to_jobopts(self):
         resources_opts = []
-        for r, v in self.extra_resources.items():
+        # Combine all resources into one dictionary, where extra_resources
+        # can overwrite _current_environ.resources
+        combined_resources = {**self._current_environ.resources, **self.extra_resources}
+        for r, v in combined_resources.items():
             resources_opts += self._current_partition.get_resource(r, **v)
-
-        return resources_opts
-
-    def _map_env_resources_to_jobopts(self):
-        resources_opts = []
-        for r, v in self._current_environ.resources.items():
-            resources_opts += self._current_partition.get_env_resource(r, **v)
 
         return resources_opts
 

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -1863,9 +1863,7 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
         # build_job_opts. We want any user supplied options to be able to
         # override those set by the framework.
         resources_opts = self._map_resources_to_jobopts()
-        self._build_job.options = (
-            resources_opts + self._build_job.options
-        )
+        self._build_job.options = resources_opts + self._build_job.options
         with osext.change_dir(self._stagedir):
             # Prepare build job
             build_commands = [
@@ -2013,9 +2011,7 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
         # job_opts. We want any user supplied options to be able to
         # override those set by the framework.
         resources_opts = self._map_resources_to_jobopts()
-        self._job.options = (
-            resources_opts + self._job.options
-        )
+        self._job.options = resources_opts + self._job.options
         with osext.change_dir(self._stagedir):
             try:
                 self.logger.debug('Generating the run script')
@@ -2042,7 +2038,10 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
         resources_opts = []
         # Combine all resources into one dictionary, where extra_resources
         # can overwrite _current_environ.resources
-        combined_resources = {**self._current_environ.resources, **self.extra_resources}
+        combined_resources = {
+            **self._current_environ.resources,
+            **self.extra_resources
+        }
         for r, v in combined_resources.items():
             resources_opts += self._current_partition.get_resource(r, **v)
 

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -1859,7 +1859,10 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
         # build_job_opts. We want any user supplied options to be able to
         # override those set by the framework.
         resources_opts = self._map_resources_to_jobopts()
-        self._build_job.options = resources_opts + self._build_job.options
+        env_resources_opts = self._map_env_resources_to_jobopts()
+        self._build_job.options = (
+            env_resources_opts + resources_opts + self._build_job.options
+        )
         with osext.change_dir(self._stagedir):
             # Prepare build job
             build_commands = [
@@ -2007,7 +2010,10 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
         # job_opts. We want any user supplied options to be able to
         # override those set by the framework.
         resources_opts = self._map_resources_to_jobopts()
-        self._job.options = resources_opts + self._job.options
+        env_resources_opts = self._map_env_resources_to_jobopts()
+        self._job.options = (
+            env_resources_opts + resources_opts + self._job.options
+        )
         with osext.change_dir(self._stagedir):
             try:
                 self.logger.debug('Generating the run script')
@@ -2034,6 +2040,13 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
         resources_opts = []
         for r, v in self.extra_resources.items():
             resources_opts += self._current_partition.get_resource(r, **v)
+
+        return resources_opts
+
+    def _map_env_resources_to_jobopts(self):
+        resources_opts = []
+        for r, v in self._current_environ.resources.items():
+            resources_opts += self._current_partition.get_env_resource(r, **v)
 
         return resources_opts
 

--- a/reframe/core/systems.py
+++ b/reframe/core/systems.py
@@ -167,8 +167,7 @@ class SystemPartition(jsonext.JSONSerializable):
     def __init__(self, *, parent, name, sched_type, launcher_type,
                  descr, access, container_runtime, container_environs,
                  resources, local_env, environs, max_jobs, prepare_cmds,
-                 processor, devices, extras, features, time_limit,
-                 env_resources):
+                 processor, devices, extras, features, time_limit):
         getlogger().debug(f'Initializing system partition {name!r}')
         self._parent_system = parent
         self._name = name
@@ -184,7 +183,6 @@ class SystemPartition(jsonext.JSONSerializable):
         self._max_jobs = max_jobs
         self._prepare_cmds = prepare_cmds
         self._resources = {r['name']: r['options'] for r in resources}
-        self._env_resources = {r['name']: r['options'] for r in env_resources}
         self._processor = ProcessorInfo(processor)
         self._devices = [DeviceInfo(d) for d in devices]
         self._extras = extras
@@ -351,21 +349,6 @@ class SystemPartition(jsonext.JSONSerializable):
 
         return ret
 
-    def get_env_resource(self, name, **values):
-        '''Instantiate managed environment resource ``name`` with ``value``.
-
-        :meta private:
-        '''
-
-        ret = []
-        for r in self._env_resources.get(name, []):
-            try:
-                ret.append(r.format(**values))
-            except KeyError:
-                pass
-
-        return ret
-
     def environment(self, name):
         '''Return the partition environment named ``name``.'''
 
@@ -469,14 +452,7 @@ class SystemPartition(jsonext.JSONSerializable):
                     'options': options
                 }
                 for name, options in self._resources.items()
-            ],
-            'env_resources': [
-                {
-                    'name': name,
-                    'options': options
-                }
-                for name, options in self._env_resources.items()
-            ],
+            ]
         }
 
     def __str__(self):
@@ -602,7 +578,6 @@ class System(jsonext.JSONSerializable):
                     extras=site_config.get(f'{partid}/extras'),
                     features=site_config.get(f'{partid}/features'),
                     time_limit=site_config.get(f'{partid}/time_limit'),
-                    env_resources=site_config.get(f'{partid}/env_resources')
                 )
             )
 

--- a/reframe/core/systems.py
+++ b/reframe/core/systems.py
@@ -167,7 +167,7 @@ class SystemPartition(jsonext.JSONSerializable):
     def __init__(self, *, parent, name, sched_type, launcher_type,
                  descr, access, container_runtime, container_environs,
                  resources, local_env, environs, max_jobs, prepare_cmds,
-                 processor, devices, extras, features, time_limit):
+                 processor, devices, extras, features, time_limit, env_resources):
         getlogger().debug(f'Initializing system partition {name!r}')
         self._parent_system = parent
         self._name = name
@@ -183,6 +183,7 @@ class SystemPartition(jsonext.JSONSerializable):
         self._max_jobs = max_jobs
         self._prepare_cmds = prepare_cmds
         self._resources = {r['name']: r['options'] for r in resources}
+        self._env_resources = {r['name']: r['options'] for r in env_resources}
         self._processor = ProcessorInfo(processor)
         self._devices = [DeviceInfo(d) for d in devices]
         self._extras = extras
@@ -349,6 +350,21 @@ class SystemPartition(jsonext.JSONSerializable):
 
         return ret
 
+    def get_env_resource(self, name, **values):
+        '''Instantiate managed environment resource ``name`` with ``value``.
+
+        :meta private:
+        '''
+
+        ret = []
+        for r in self._env_resources.get(name, []):
+            try:
+                ret.append(r.format(**values))
+            except KeyError:
+                pass
+
+        return ret
+
     def environment(self, name):
         '''Return the partition environment named ``name``.'''
 
@@ -452,7 +468,14 @@ class SystemPartition(jsonext.JSONSerializable):
                     'options': options
                 }
                 for name, options in self._resources.items()
-            ]
+            ],
+            'env_resources': [
+                {
+                    'name': name,
+                    'options': options
+                }
+                for name, options in self._env_resources.items()
+            ],
         }
 
     def __str__(self):
@@ -576,7 +599,8 @@ class System(jsonext.JSONSerializable):
                     devices=site_config.get(f'{partid}/devices'),
                     extras=site_config.get(f'{partid}/extras'),
                     features=site_config.get(f'{partid}/features'),
-                    time_limit=site_config.get(f'{partid}/time_limit')
+                    time_limit=site_config.get(f'{partid}/time_limit'),
+                    env_resources=site_config.get(f'{partid}/env_resources')
                 )
             )
 

--- a/reframe/core/systems.py
+++ b/reframe/core/systems.py
@@ -167,7 +167,8 @@ class SystemPartition(jsonext.JSONSerializable):
     def __init__(self, *, parent, name, sched_type, launcher_type,
                  descr, access, container_runtime, container_environs,
                  resources, local_env, environs, max_jobs, prepare_cmds,
-                 processor, devices, extras, features, time_limit, env_resources):
+                 processor, devices, extras, features, time_limit,
+                 env_resources):
         getlogger().debug(f'Initializing system partition {name!r}')
         self._parent_system = parent
         self._name = name

--- a/reframe/core/systems.py
+++ b/reframe/core/systems.py
@@ -577,7 +577,7 @@ class System(jsonext.JSONSerializable):
                     devices=site_config.get(f'{partid}/devices'),
                     extras=site_config.get(f'{partid}/extras'),
                     features=site_config.get(f'{partid}/features'),
-                    time_limit=site_config.get(f'{partid}/time_limit'),
+                    time_limit=site_config.get(f'{partid}/time_limit')
                 )
             )
 

--- a/reframe/core/systems.py
+++ b/reframe/core/systems.py
@@ -572,7 +572,8 @@ class System(jsonext.JSONSerializable):
                     cflags=site_config.get(f'environments/@{e}/cflags'),
                     cxxflags=site_config.get(f'environments/@{e}/cxxflags'),
                     fflags=site_config.get(f'environments/@{e}/fflags'),
-                    ldflags=site_config.get(f'environments/@{e}/ldflags')
+                    ldflags=site_config.get(f'environments/@{e}/ldflags'),
+                    resources=site_config.get(f'environments/@{e}/resources')
                 ) for e in site_config.get(f'{partid}/environs')
                 if any(re.match(pattern, e) for pattern in env_patt)
             ]

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -351,21 +351,6 @@
                                         "required": ["name"],
                                         "additionalProperties": false
                                     }
-                                },
-                                "env_resources": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "name": {"type": "string"},
-                                            "options": {
-                                                "type": "array",
-                                                "items": {"type": "string"}
-                                            }
-                                        },
-                                        "required": ["name"],
-                                        "additionalProperties": false
-                                    }
                                 }
                             },
                             "required": ["name", "scheduler", "launcher"],
@@ -641,8 +626,6 @@
         "systems/partitions/features": [],
         "systems/partitions/resources": [],
         "systems/partitions/resources/options": [],
-        "systems/partitions/env_resources": [],
-        "systems/partitions/env_resources/options": [],
         "systems/partitions/modules": [],
         "systems/partitions/env_vars": [],
         "systems/partitions/variables": [],

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -350,6 +350,21 @@
                                         "required": ["name"],
                                         "additionalProperties": false
                                     }
+                                },
+                                "env_resources": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {"type": "string"},
+                                            "options": {
+                                                "type": "array",
+                                                "items": {"type": "string"}
+                                            }
+                                        },
+                                        "required": ["name"],
+                                        "additionalProperties": false
+                                    }
                                 }
                             },
                             "required": ["name", "scheduler", "launcher"],
@@ -408,6 +423,16 @@
                     "features": {
                         "type": "array",
                         "items": {"$ref": "#/defs/alphanum_string"}
+                    },
+                    "resources": {
+                        "type": "object",
+                        "propertyNames": {
+                            "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$"
+                        },
+                        "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
                     },
                     "target_systems": {"$ref": "#/defs/system_ref"}
                 },
@@ -615,6 +640,8 @@
         "systems/partitions/features": [],
         "systems/partitions/resources": [],
         "systems/partitions/resources/options": [],
+        "systems/partitions/env_resources": [],
+        "systems/partitions/env_resources/options": [],
         "systems/partitions/modules": [],
         "systems/partitions/env_vars": [],
         "systems/partitions/variables": [],

--- a/unittests/resources/config/settings.py
+++ b/unittests/resources/config/settings.py
@@ -61,16 +61,14 @@ site_configuration = {
                                 '#DW jobdw capacity={capacity}',
                                 '#DW stage_in source={stagein_src}'
                             ]
-                        }
-                    ],
-                    'env_resources': [
+                        },
                         {
                             'name': 'uenv',
                             'options': [
                                 '--mount={mount}',
                                 '--file={file}'
                             ],
-                        },
+                        }
                     ],
                     'features': ['cuda', 'mpi'],
                     'extras': {

--- a/unittests/resources/config/settings.py
+++ b/unittests/resources/config/settings.py
@@ -67,7 +67,7 @@ site_configuration = {
                             'options': [
                                 '--mount={mount}',
                                 '--file={file}'
-                            ],
+                            ]
                         }
                     ],
                     'features': ['cuda', 'mpi'],

--- a/unittests/resources/config/settings.py
+++ b/unittests/resources/config/settings.py
@@ -63,6 +63,15 @@ site_configuration = {
                             ]
                         }
                     ],
+                    'env_resources': [
+                        {
+                            'name': 'uenv',
+                            'options': [
+                                '--mount={mount}',
+                                '--file={file}'
+                            ],
+                        },
+                    ],
                     'features': ['cuda', 'mpi'],
                     'extras': {
                         'gpu_arch': 'a100'

--- a/unittests/test_config.py
+++ b/unittests/test_config.py
@@ -465,7 +465,7 @@ def test_system_create(site_config):
         'uenv', mount='mount_point', file='file_path'
     )
     assert env_resources_spec == ['--mount=mount_point',
-                              '--file=file_path']
+                                  '--file=file_path']
 
     # Check processor info
     assert partition.processor.info is not None

--- a/unittests/test_config.py
+++ b/unittests/test_config.py
@@ -293,7 +293,7 @@ def test_select_subconfig(site_config):
     assert (site_config.get('systems/0/partitions/0/environs') ==
             ['PrgEnv-gnu', 'builtin'])
     assert site_config.get('systems/0/partitions/0/descr') == 'GPU partition'
-    assert len(site_config.get('systems/0/partitions/0/resources')) == 2
+    assert len(site_config.get('systems/0/partitions/0/resources')) == 3
     assert (site_config.get('systems/0/partitions/0/resources/@gpu/name') ==
             'gpu')
     assert site_config.get('systems/0/partitions/0/modules') == [
@@ -461,7 +461,7 @@ def test_system_create(site_config):
     assert resources_spec == ['#DW jobdw capacity=100GB',
                               '#DW stage_in source=/foo']
 
-    env_resources_spec = partition.get_env_resource(
+    env_resources_spec = partition.get_resource(
         'uenv', mount='mount_point', file='file_path'
     )
     assert env_resources_spec == ['--mount=mount_point',

--- a/unittests/test_config.py
+++ b/unittests/test_config.py
@@ -461,6 +461,12 @@ def test_system_create(site_config):
     assert resources_spec == ['#DW jobdw capacity=100GB',
                               '#DW stage_in source=/foo']
 
+    env_resources_spec = partition.get_env_resource(
+        'uenv', mount='mount_point', file='file_path'
+    )
+    assert env_resources_spec == ['--mount=mount_point',
+                              '--file=file_path']
+
     # Check processor info
     assert partition.processor.info is not None
     assert partition.processor.topology is not None


### PR DESCRIPTION
This is a second attempt for this issue. ~I am missing the documentation + unittests but I would like first to agree on the api.~

It would be very similar to the resources of the test. And the configuration would look like this.

```python
site_configuration = {
    'systems': [
        {
            ...
            'partitions': [
                {
                    'resources': [
                        {
                            'name': 'switches',
                            'options': ['--switches={num_switches}']
                        },
                        {
                            'name': 'gres',
                            'options': ['--gres={gres}']
                        },
                        {
                            'name': 'uenv',
                            'options': [
                                '--uenv-file={file}',
                                '--uenv-mount={mount}',
                            ]
                        }
                    ]
                }
            ]
        }
    ],
    'environments': [
        {
            'name': 'myenv',
            'resources': {
                'uenv': {
                    'mount': 'one',
                    'file': 'two',
                }
            }
        }
    ]
}
```

That would translate to the following options in the job script:
```bash
#SBATCH --uenv-file=two
#SBATCH --uenv_mount=one
```

Closes #2991 .