### PR TITLE
[bugfix] Hide disabled hooks from `--describe` option's output

### DIFF
--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -176,6 +176,10 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
         '''
         self._disabled_hooks.add(hook_name)
 
+    @property
+    def disabled_hooks(self):
+        return self._disabled_hooks
+
     @classmethod
     def pipeline_hooks(cls):
         ret = {}

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -156,8 +156,9 @@ def describe_checks(testcases, printer):
             rec['variant_num'] = tc.check.variant_num
             for stage, hooks in tc.check.pipeline_hooks().items():
                 for hk in hooks:
-                    rec['pipeline_hooks'].setdefault(stage, [])
-                    rec['pipeline_hooks'][stage].append(hk.__name__)
+                    if hk.__name__ not in tc.check.disabled_hooks:
+                        rec['pipeline_hooks'].setdefault(stage, [])
+                        rec['pipeline_hooks'][stage].append(hk.__name__)
 
             for attr in list(rec.keys()):
                 if attr == '__rfm_class__':


### PR DESCRIPTION
Although `--disable-hook` works fine, the `--describe` option still lists the disabled hooks.