### PR TITLE
[feat] Skip by default flexible tests when not enough nodes found

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -976,7 +976,7 @@ They are associated with `system partitions <#system-partition-configuration>`__
    :default: ``{}``
 
    Scheduler resources associated with this environments.
-   
+
    This is the equivalent of a test's :attr:`~reframe.core.pipeline.RegressionTest.extra_resources`.
 
    .. versionadded:: 4.6
@@ -1632,14 +1632,6 @@ General Configuration
    .. versionadded:: 3.12.0
 
 
-.. py:attribute:: general.git_timeout
-
-  :required: No
-  :default: 5
-
-  Timeout value in seconds used when checking if a git repository exists.
-
-
 .. py:attribute:: general.dump_pipeline_progress
 
    Dump pipeline progress for the asynchronous execution policy in ``pipeline-progress.json``.
@@ -1649,6 +1641,24 @@ General Configuration
    :default: ``False``
 
    .. versionadded:: 3.10.0
+
+
+.. py:attribute:: general.flex_alloc_strict
+
+   :required: No
+   :default: ``False``
+
+   Fail flexible tests if their minimum task requirement is not satisfied.
+
+   .. versionadded:: 4.7
+
+
+.. py:attribute:: general.git_timeout
+
+   :required: No
+   :default: 5
+
+   Timeout value in seconds used when checking if a git repository exists.
 
 
 .. py:attribute:: general.pipeline_timeout

--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -752,6 +752,18 @@ If no node can be selected, the test will be marked as a failure with an appropr
 
       Slurm OR constraints and parenthesized expressions are supported in flexible node allocation.
 
+   .. versionchanged:: 4.7
+      The test is not failed if not enough nodes are available, but it is skipped instead.
+      To enforce a failure, use :option:`--flex-alloc-strict`
+
+.. option:: --flex-alloc-strict
+
+   Fail flexible tests if their minimum task requirement is not satisfied.
+   Otherwise the tests will be skipped.
+
+   .. versionadded:: 4.7
+
+
 ---------------------------------------
 Options controlling ReFrame environment
 ---------------------------------------
@@ -1408,6 +1420,21 @@ Whenever an environment variable is associated with a configuration option, its 
       ================================== ==================
 
    .. versionadded:: 4.0.0
+
+
+.. envvar:: RFM_FLEX_ALLOC_STRICT
+
+   Fail flexible tests if their minimum task requirement is not satisfied.
+
+   .. table::
+      :align: left
+
+      ================================== ==================
+      Associated command line option     :option:`--flex-alloc-strict`
+      Associated configuration parameter :attr:`~config.general.flex_alloc_strict`
+      ================================== ==================
+
+   .. versionadded:: 4.7
 
 
 .. envvar:: RFM_GIT_TIMEOUT

--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -753,7 +753,7 @@ If no node can be selected, the test will be marked as a failure with an appropr
       Slurm OR constraints and parenthesized expressions are supported in flexible node allocation.
 
    .. versionchanged:: 4.7
-      The test is not failed if not enough nodes are available, but it is skipped instead.
+      The test is not marked as a failure if not enough nodes are available, but it is skipped instead.
       To enforce a failure, use :option:`--flex-alloc-strict`
 
 .. option:: --flex-alloc-strict

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -2018,6 +2018,7 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
                 self._job.prepare(
                     commands, environs,
                     self._current_partition.prepare_cmds,
+                    rt.runtime().get_option('general/flex_alloc_strict'),
                     login=rt.runtime().get_option('general/0/use_login_shell'),
                     trap_errors=rt.runtime().get_option(
                         'general/0/trap_job_errors'

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -423,6 +423,12 @@ def main():
         help='Set strategy for the flexible node allocation (default: "idle").'
     )
     run_options.add_argument(
+        '--flex-alloc-strict', action='store_true',
+        envvar='RFM_FLEX_ALLOC_STRICT',
+        configvar='general/flex_alloc_strict',
+        help='Fail the flexible tests if not enough nodes can be found'
+    )
+    run_options.add_argument(
         '-J', '--job-option', action='append', metavar='OPT',
         dest='job_options', default=[],
         help='Pass option OPT to job scheduler'

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -15,7 +15,7 @@ import unittests.utility as test_util
 from reframe.core.backends import (getlauncher, getscheduler)
 from reframe.core.environments import Environment
 from reframe.core.exceptions import (
-    ConfigError, JobError, JobNotStartedError, JobSchedulerError
+    ConfigError, JobError, JobNotStartedError, JobSchedulerError, SkipTestError
 )
 from reframe.core.schedulers import Job
 from reframe.core.schedulers.slurm import _SlurmNode, _create_nodes
@@ -124,7 +124,7 @@ def fake_job(make_job):
 
 def prepare_job(job, command='hostname',
                 pre_run=None, post_run=None,
-                prepare_cmds=None):
+                prepare_cmds=None, strict_flex=True):
     environs = [Environment(name='foo', modules=['testmod_foo'])]
     pre_run = pre_run or ['echo prerun']
     post_run = post_run or ['echo postrun']
@@ -137,7 +137,8 @@ def prepare_job(job, command='hostname',
                 post_run
             ],
             environs,
-            prepare_cmds
+            prepare_cmds,
+            strict_flex,
         )
 
 
@@ -1146,11 +1147,16 @@ def test_flex_alloc_no_num_tasks_per_node(make_flexible_job):
     assert job.num_tasks == 1
 
 
-def test_flex_alloc_not_enough_idle_nodes(make_flexible_job):
+@pytest.fixture(params=['skip', 'error'])
+def strict_flex(request):
+    return request.param == 'error'
+
+
+def test_flex_alloc_not_enough_idle_nodes(make_flexible_job, strict_flex):
     job = make_flexible_job('idle')
     job.num_tasks = -12
-    with pytest.raises(JobError):
-        prepare_job(job)
+    with pytest.raises(JobError if strict_flex else SkipTestError):
+        prepare_job(job, strict_flex=strict_flex)
 
 
 def test_flex_alloc_maintenance_nodes(make_flexible_job):


### PR DESCRIPTION
Flexible tests are now by default skipped when not enough nodes are found. We introduce a new option, `--flex-alloc-strict` that will cause the test to fail instead (the current default).

Closes #3164.