### PR TITLE
[feat] Update `archspec` and topology file call for CPU model name

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-archspec==0.2.2
+archspec==0.2.4
 docutils==0.18.1
 jsonschema==3.2.0
 semver==2.13.0; python_version == '3.6'

--- a/reframe/utility/cpuinfo.py
+++ b/reframe/utility/cpuinfo.py
@@ -284,8 +284,7 @@ def cpuinfo():
     ret = {
         'arch': archspec.cpu.host().name,
         'vendor': archspec.cpu.host().vendor,
-        'model': archspec.cpu.detect.raw_info_dictionary().get('model name',
-                                                               'N/A'),
+        'model': archspec.cpu.brand_string(),
         'platform': platform.machine()
     }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-archspec==0.2.2
+archspec==0.2.4
 argcomplete==3.1.2; python_version < '3.8'
 argcomplete==3.2.3; python_version >= '3.8'
 importlib_metadata==4.0.1; python_version < '3.8'

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ packages = find_namespace:
 python_requires = >=3.6
 scripts = bin/reframe
 install_requires =
-    archspec <= 0.2.4
+    archspec >= 0.2.4
     argcomplete
     argcomplete <= 3.1.2; python_version < '3.8'
     jsonschema

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ packages = find_namespace:
 python_requires = >=3.6
 scripts = bin/reframe
 install_requires =
-    archspec <= 0.2.2
+    archspec <= 0.2.4
     argcomplete
     argcomplete <= 3.1.2; python_version < '3.8'
     jsonschema


### PR DESCRIPTION
This follows https://github.com/reframe-hpc/reframe/pull/3107 and https://github.com/reframe-hpc/reframe/pull/3132 to adopt the new function from [archspec v0.2.4](https://github.com/archspec/archspec/releases/tag/v0.2.4) returning a CPU brand string.