### PR TITLE
[doc] Display Python imports in the first tutorial example

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -85,7 +85,7 @@ Here is the full ReFrame test:
 
 .. literalinclude:: ../examples/tutorial/stream/stream_runonly.py
    :caption:
-   :pyobject: stream_test
+   :lines: 5-
 
 ReFrame tests are specially decorated classes that ultimately derive from the :class:`~reframe.core.pipeline.RegressionTest` class.
 Since we only want to run an executable in this first test, we derive from the :class:`~reframe.core.pipeline.RunOnlyRegressionTest` class, which essentially short-circuits the "compile" stage of the test.


### PR DESCRIPTION
The tutorial was skipping the two imports

    import reframe as rfm
    import reframe.utility.sanity as sn

by using the :pyobject: option to only highlight stream_test. This is the first example shown in the tutorial and it is important that the entire file is displayed.

Presumably this technique is used to avoid the license notice; we can use :start-at: instead.