### PR TITLE
[bugfix] Fix logging crash when log format is `%(check_#ALL)s`

### DIFF
--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -301,8 +301,8 @@ class CheckFieldFormatter(logging.Formatter):
     # NOTE: This formatter will work only for the '%' style
     def __init__(self, fmt=None, datefmt=None, perffmt=None,
                  ignore_keys=None, style='%'):
-        super().__init__(fmt, datefmt, style)
-
+        super().__init__(fmt, datefmt, style,
+                         validate=(fmt != '%(check_#ALL)s'))
         self.__fmt = fmt
         self.__fmtperf = perffmt[:-1] if perffmt else ''
         self.__specs = re.findall(r'\%\((\S+?)\)s', fmt)

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -1345,9 +1345,14 @@ def test_perf_logging_lazy(make_runner, make_exec_ctx, lazy_perf_test,
     assert os.path.exists(logfile)
 
 
+@pytest.fixture(params=['%(check_result)s|%(check_#ALL)s', '%(check_#ALL)s'])
+def perflog_fmt(request):
+    return request.param
+
+
 def test_perf_logging_all_attrs(make_runner, make_exec_ctx, perf_test,
-                                config_perflog, tmp_path):
-    make_exec_ctx(config_perflog(fmt='%(check_result)s|%(check_#ALL)s'))
+                                config_perflog, tmp_path, perflog_fmt):
+    make_exec_ctx(config_perflog(fmt=perflog_fmt))
     logging.configure_logging(rt.runtime().site_config)
     runner = make_runner()
     testcases = executors.generate_testcases([perf_test])
@@ -1359,7 +1364,8 @@ def test_perf_logging_all_attrs(make_runner, make_exec_ctx, perf_test,
         header = fp.readline()
 
     loggable_attrs = type(perf_test).loggable_attrs()
-    assert len(header.split('|')) == len(loggable_attrs) + 1
+    assert (len(header.split('|')) ==
+            len(loggable_attrs) + (perflog_fmt != '%(check_#ALL)s'))
 
 
 def test_perf_logging_custom_vars(make_runner, make_exec_ctx,


### PR DESCRIPTION
Fixes #3176.