### PR TITLE
[bugfix] Fix logging crash when `timestamp=True` for the `file` log handler

### DIFF
--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -428,6 +428,10 @@ def _create_file_handler(site_config, config_prefix):
     timestamp = site_config.get(f'{config_prefix}/timestamp')
     if timestamp:
         basename, ext = os.path.splitext(filename)
+        if not isinstance(timestamp, str):
+            # Use the default value from `datefmt`
+            timestamp = site_config.get(f'{config_prefix}/datefmt')
+
         filename = f'{basename}_{time.strftime(timestamp)}{ext}'
 
     append = site_config.get(f'{config_prefix}/append')


### PR DESCRIPTION
Closes #3128.