### PR TITLE
Revert "Bump setuptools from 70.1.1 to 70.0.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,6 @@ semver==2.13.0; python_version == '3.6'
 semver==3.0.2; python_version >= '3.7'
 setuptools==59.6.0; python_version == '3.6'
 setuptools==68.0.0; python_version == '3.7'
-setuptools==70.0.0; python_version >= '3.8'
+setuptools==70.1.1; python_version >= '3.8'
 wcwidth==0.2.13
 #+pygelf%pygelf==0.4.0


### PR DESCRIPTION
Reverts reframe-hpc/reframe#3235

This is not needed, we are already in the latest and most secure version.