### PR TITLE
[feat] Introduce new option `--table-hide-columns` for hiding columns in tabular data output

### DIFF
--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -1132,13 +1132,19 @@ Miscellaneous options
 
 .. option:: --table-format=csv|plain|pretty
 
-   Set the formatting of tabular output printed by options :option:`--performance-compare`, :option:`--performance-report` and the options controlling the stored sessions.
+   Set the formatting of tabular output printed by the options :option:`--performance-compare`, :option:`--performance-report` and the options controlling the stored sessions.
 
    The acceptable values are the following:
 
    - ``csv``: Generate CSV output
    - ``plain``: Generate a plain table without any lines
    - ``pretty``: (default) Generate a pretty table
+
+   .. versionadded:: 4.7
+
+.. option:: --table-hide-columns=COLUMNS
+
+   Hide the specified comma-separated list of columns from the tabular output printed by the options :option:`--performance-compare`, :option:`--performance-report` and the options controlling the stored sessions.
 
    .. versionadded:: 4.7
 

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -632,6 +632,11 @@ def main():
         envvar='RFM_TABLE_FORMAT', configvar='general/table_format'
     )
     misc_options.add_argument(
+        '--table-hide-columns', metavar='COLS', action='store',
+        help='Hide specific columns from the final table',
+        envvar='RFM_TABLE_HIDE_COLUMNS', configvar='general/table_hide_columns'
+    )
+    misc_options.add_argument(
         '-v', '--verbose', action='count',
         help='Increase verbosity level of output',
         envvar='RFM_VERBOSE', configvar='general/verbose'

--- a/reframe/frontend/printer.py
+++ b/reframe/frontend/printer.py
@@ -276,4 +276,14 @@ class PrettyPrinter:
 
         kwargs.setdefault('headers', 'firstrow')
         kwargs.setdefault('tablefmt', tablefmt)
-        self.info(tabulate(data, **kwargs))
+        hide_columns = rt.runtime().get_option('general/0/table_hide_columns')
+        if hide_columns and kwargs['headers'] == 'firstrow' and data:
+            hide_columns = hide_columns.split(',')
+            colidx = [i for i, col in enumerate(data[0])
+                      if col not in hide_columns]
+
+            tab_data = [[rec[col] for col in colidx] for rec in data]
+        else:
+            tab_data = data
+
+        self.info(tabulate(tab_data, **kwargs))

--- a/reframe/frontend/printer.py
+++ b/reframe/frontend/printer.py
@@ -276,6 +276,7 @@ class PrettyPrinter:
 
         kwargs.setdefault('headers', 'firstrow')
         kwargs.setdefault('tablefmt', tablefmt)
+        kwargs.setdefault('numalign', 'right')
         hide_columns = rt.runtime().get_option('general/0/table_hide_columns')
         if hide_columns and kwargs['headers'] == 'firstrow' and data:
             hide_columns = hide_columns.split(',')

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -1298,6 +1298,15 @@ def test_storage_options(run_reframe, tmp_path, table_format):
         *run_reframe2(action=f'--describe-stored-testcases={uuid}')
     )
 
+    # Check hiding of table column
+    stdout = assert_no_crash(*run_reframe2(
+        action=f'--list-stored-testcases={uuid}',
+        more_options=['--table-hide-columns=SysEnv,Nodelist,UUID']
+    ))[1]
+    assert 'SysEnv' not in stdout
+    assert 'Nodelist' not in stdout
+    assert 'UUID' not in stdout
+
     # List test cases by time period
     ts_start = session_json['session_info']['time_start']
     assert_no_crash(


### PR DESCRIPTION
This is a follow up of #3227 as a means to let users reduce the size of the produced tables on-demand. For example, `sysenv` is essential for uniquely identifying test cases and grouping them together, but users may not want to list this column in certain contexts.

This PR also introduces some minor fixes in the profiling of the storage options and removes alignment of numbers on the dot in tables.