### PR TITLE
[bugfix] Optimize testcase queries over time period

### DIFF
--- a/reframe/frontend/reporting/storage.py
+++ b/reframe/frontend/reporting/storage.py
@@ -171,12 +171,12 @@ class _SqliteStorage(StorageBackend):
 
     @time_function
     def _fetch_testcases_raw(self, condition):
-        getprofiler().enter_region('sqlite query')
+        # Retrieve relevant session info and index it in Python
+        getprofiler().enter_region('sqlite session query')
         with self._db_connect(self._db_file()) as conn:
-            query = ('SELECT session_uuid, testcases.uuid as uuid, json_blob '
-                     'FROM testcases '
-                     'JOIN sessions ON session_uuid == sessions.uuid '
-                     f'WHERE {condition}')
+            query = ('SELECT uuid, json_blob FROM sessions WHERE uuid IN '
+                     '(SELECT DISTINCT session_uuid FROM testcases '
+                     f'WHERE {condition})')
             getlogger().debug(query)
 
             # Create SQLite function for filtering using name patterns
@@ -185,10 +185,9 @@ class _SqliteStorage(StorageBackend):
 
         getprofiler().exit_region()
 
-        # Retrieve session info
         sessions = {}
-        for session_uuid, uuid, json_blob in results:
-            sessions.setdefault(session_uuid, json_blob)
+        for uuid, json_blob in results:
+            sessions.setdefault(uuid, json_blob)
 
         # Join all sessions and decode them at once
         reports_blob = '[' + ','.join(sessions.values()) + ']'
@@ -200,10 +199,20 @@ class _SqliteStorage(StorageBackend):
         for rpt in reports:
             sessions[rpt['session_info']['uuid']] = rpt
 
-        # Extract the test case data
+        # Extract the test case data by extracting their UUIDs
+        getprofiler().enter_region('sqlite testcase query')
+        with self._db_connect(self._db_file()) as conn:
+            query = f'SELECT uuid FROM testcases WHERE {condition}'
+            getlogger().debug(query)
+            conn.create_function('REGEXP', 2, self._db_matches)
+            results = conn.execute(query).fetchall()
+
+        getprofiler().exit_region()
         testcases = []
-        for session_uuid, uuid, json_blob in results:
-            run_index, test_index = [int(x) for x in uuid.split(':')[1:]]
+        for uuid, *_ in results:
+            session_uuid, run_index, test_index = uuid.split(':')
+            run_index = int(run_index)
+            test_index = int(test_index)
             report = sessions[session_uuid]
             testcases.append(
                 report['runs'][run_index]['testcases'][test_index],
@@ -286,6 +295,9 @@ class _SqliteStorage(StorageBackend):
         prefix = os.path.dirname(self.__db_file)
         with FileLock(os.path.join(prefix, '.db.lock')):
             with self._db_connect(self._db_file()) as conn:
+                # Enable foreign keys for delete action to have cascade effect
+                conn.execute('PRAGMA foreign_keys = ON')
+
                 # Check first if the uuid exists
                 query = f'SELECT * FROM sessions WHERE uuid == "{uuid}"'
                 getlogger().debug(query)
@@ -301,6 +313,8 @@ class _SqliteStorage(StorageBackend):
         prefix = os.path.dirname(self.__db_file)
         with FileLock(os.path.join(prefix, '.db.lock')):
             with self._db_connect(self._db_file()) as conn:
+                # Enable foreign keys for delete action to have cascade effect
+                conn.execute('PRAGMA foreign_keys = ON')
                 query = (f'DELETE FROM sessions WHERE uuid == "{uuid}" '
                          'RETURNING *')
                 getlogger().debug(query)

--- a/reframe/frontend/reporting/storage.py
+++ b/reframe/frontend/reporting/storage.py
@@ -213,10 +213,16 @@ class _SqliteStorage(StorageBackend):
             session_uuid, run_index, test_index = uuid.split(':')
             run_index = int(run_index)
             test_index = int(test_index)
-            report = sessions[session_uuid]
-            testcases.append(
-                report['runs'][run_index]['testcases'][test_index],
-            )
+            try:
+                report = sessions[session_uuid]
+            except KeyError:
+                # Since we do two separate queries, new testcases may have been
+                # inserted to the DB meanwhile, so we ignore unknown sessions
+                continue
+            else:
+                testcases.append(
+                    report['runs'][run_index]['testcases'][test_index],
+                )
 
         return testcases
 


### PR DESCRIPTION
This is a follow up fix on #3227 and build on top of #3253.

This PR eliminates the JOIN between the `testcases` and `sessions` arrays as is this very detrimental to performance for sessions that run many testcases. The problem with the current implementation is that the JOIN will replicate the whole session `json_blob` for *every* testcase record bloating the memory consumption and hurting performance significantly!

The approach taken in this PR is replacing the single JOIN query with 2+1 SELECT. First we get the distinct session UUIDs that correspond to the test cases matching the selection criteria. Then we use those session UUIDs to extract their blobs from the `sessions` table decoding them and indexing them in memory. Finally, we get the testcase UUIDs matching the criteria selection and from this we are able to quickly pick the JSON data of each selected test case.

I tested this impelmentation a DB of 163 sessions and 38K test cases on two systems and we get 6-10x performance improvements on the `--performance-compare` / `--performance-report` options (from 20s to 2s and from 27s down to 4s). Now, the DB query is no more the limiting performance factor, but rather the JSON decoding and the aggregation of the results.