### PR TITLE
[enhancement] Change default values for `--performance-report` and `--list-stored-sessions` options

### DIFF
--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -349,7 +349,8 @@ There are commands that act upon the selected tests and others that have a helpe
 
    List sessions stored in the results database.
 
-   If ``TIME_PERIOD`` is not specified or if ``all`` is passed, all stored sessions will be listed.
+   If ``TIME_PERIOD`` is ``all``, all stored sessions will be listed.
+   If not specified, only the sessions of last week will be listed.
    For the exact syntax of ``TIME_PERIOD`` check the :ref:`time-period-syntax`.
 
    .. versionadded:: 4.7
@@ -1096,7 +1097,7 @@ Miscellaneous options
 
    For each test all of their performance variables are reported and optionally compared to past results based on the ``CMPSPEC`` specified.
 
-   If not specified, the default ``CMPSPEC`` is ``19700101T0000+0000:now/last:+job_nodelist/+result``, meaning that the current performance will be compared to the last run of the same test grouped additionally by the ``job_nodelist`` and showing also the obtained result (``pass`` or ``fail``).
+   If not specified, the default ``CMPSPEC`` is ``now:now/last:/+job_nodelist+result``, meaning that the current performance will not be compared to any past run and, additionally, the ``job_nodelist`` and the test result (``pass`` or ``fail``) will be listed.
 
    For the exact syntax of ``CMPSPEC``, refer to :ref:`performance-comparisons`.
 

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -431,8 +431,8 @@ def main():
               'providing more details')
     )
     action_options.add_argument(
-        '--list-stored-sessions', nargs='?', action='store', const='all',
-        metavar='PERIOD', help='List stored sessions'
+        '--list-stored-sessions', nargs='?', action='store',
+        const='now-1w:now', metavar='PERIOD', help='List stored sessions'
     )
     action_options.add_argument(
         '--list-stored-testcases', action='store',
@@ -607,7 +607,7 @@ def main():
         configvar='general/perf_report_spec',
         envvar='RFM_PERF_REPORT_SPEC',
         help=('Print a report for performance tests '
-              '(default: "19700101T0000+0000:now/last:+job_nodelist/+result")')
+              '(default: "now:now/last:+job_nodelist/+result")')
     )
 
     # Miscellaneous options

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -582,7 +582,7 @@
         "general/module_mappings": [],
         "general/non_default_craype": false,
         "general/perf_info_level": "info",
-        "general/perf_report_spec": "19700101T0000+0000:now/last:+job_nodelist/+result",
+        "general/perf_report_spec": "now:now/last:/+job_nodelist+result",
         "general/purge_environment": false,
         "general/remote_detect": false,
         "general/remote_workdir": ".",


### PR DESCRIPTION
This is a follow up of #3227.

The default for `--performance-report` is now just listing the performance of the current run. This is done to (a) to keep compatibility with current behaviour and (b) the previous default could lead to increased times for producing the report in case a large results DB had to be scanned. Now the default `--performance-report` output is O(1) time.

The default for `--list-stored-sessions` is now limited to a week back. The previous default (`all`) could lead to very long output for large results DBs.