### PR TITLE
[enhancement] Allow setting the file mode of the SQLite database

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -1651,6 +1651,16 @@ Result storage configuration
 
    The SQLite database file to use.
 
+.. py:attribute:: storage.sqlite_db_file_mode
+
+   :required: No
+   :default: ``"644"``
+
+   The permissions of the SQLite database file in octal form.
+
+   The mode will only taken into account upon creation of the DB file.
+   Permissions of an existing DB file have to be changed manually.
+
 
 General Configuration
 =====================

--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -2038,6 +2038,21 @@ Whenever an environment variable is associated with a configuration option, its 
    .. versionadded:: 4.7
 
 
+.. envvar:: RFM_SQLITE_DB_FILE_MODE
+
+   The permissions of the SQLite database file in octal form.
+
+   .. table::
+      :align: left
+
+      ================================== ==================
+      Associated command line option     N/A
+      Associated configuration parameter :attr:`~config.storage.sqlite_db_file_mode`
+      ================================== ==================
+
+   .. versionadded:: 4.7
+
+
 .. envvar:: RFM_SYSLOG_ADDRESS
 
    The address of the Syslog server to send performance logs.

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+import functools
 import inspect
 import itertools
 import json
@@ -776,6 +777,13 @@ def main():
         envvar='RFM_SQLITE_DB_FILE',
         configvar='storage/sqlite_db_file',
         help='DB file where the results database resides (SQLite backend)'
+    )
+    argparser.add_argument(
+        dest='sqlite_db_file_mode',
+        envvar='RFM_SQLITE_DB_FILE_MODE',
+        configvar='storage/sqlite_db_file_mode',
+        help='DB file permissions (SQLite backend)',
+        type=functools.partial(int, base=8)
     )
     argparser.add_argument(
         dest='syslog_address',

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -544,7 +544,8 @@
                 "properties": {
                     "backend": {"type": "string"},
                     "sqlite_conn_timeout": {"type": "number"},
-                    "sqlite_db_file": {"type": "string"}
+                    "sqlite_db_file": {"type": "string"},
+                    "sqlite_db_file_mode": {"type": "string"}
                 }
             }
         }
@@ -627,6 +628,7 @@
         "storage/backend": "sqlite",
         "storage/sqlite_conn_timeout": 60,
         "storage/sqlite_db_file": "${HOME}/.reframe/reports/results.db",
+        "storage/sqlite_db_file_mode": "644",
         "systems/descr": "",
         "systems/max_local_jobs": 8,
         "systems/modules_system": "nomod",


### PR DESCRIPTION
This PR introduces a new configuration/environment variable combo to allow setting the permissions of the SQLite database file and the associated lock file. These are the following:

- Configuration: `storage/sqlite_db_file_mode`
- Environment: `RFM_SQLITE_DB_FILE_MODE`