### PR TITLE
[enhancement] Improve performance of module backend when detecting module conflicts

### DIFF
--- a/reframe/core/modules.py
+++ b/reframe/core/modules.py
@@ -1031,7 +1031,7 @@ class LModImpl(TMod4Impl):
 
         return ret
 
-    @functools.lru_cache
+    @functools.lru_cache(maxsize=128)
     def conflicted_modules(self, module):
         if module.collection:
             # Conflicts have no meaning in module collection. The modules

--- a/reframe/core/modules.py
+++ b/reframe/core/modules.py
@@ -8,6 +8,7 @@
 #
 
 import abc
+import functools
 import os
 import re
 from collections import OrderedDict
@@ -1030,6 +1031,7 @@ class LModImpl(TMod4Impl):
 
         return ret
 
+    @functools.lru_cache
     def conflicted_modules(self, module):
         if module.collection:
             # Conflicts have no meaning in module collection. The modules


### PR DESCRIPTION
Running a typical subset of NERSC's test suite with ~500 tests, there are ~30 unique values passed to this routine and the result of call for a given input is static. `module` commands can take a surprisingly long amount of time to return.

This change reduces the time for

```
reframe -C ./nersc-config.py -c checks --dry-run --mode checkout
```

from ~735s to <600s.