### PR TITLE
[enhancement] Improve naming of automatically generated tests

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1672,7 +1672,7 @@ By inspecting the generated script files, you will notice that ReFrame emits the
 .. code-block:: bash
    :caption: Run with the Docker compose setup.
 
-   cat /scratch/rfm-stage/output/pseudo-cluster/compute/gnu/stream_test_pseudo-cluster_compute_8de19aca/rfm_job.sh
+   cat /scratch/rfm-stage/output/pseudo-cluster/compute/gnu/stream_test_584fea5f/rfm_job.sh
 
 .. code-block:: bash
 

--- a/examples/tutorial/dockerfiles/slurm-cluster/docker-compose.yml
+++ b/examples/tutorial/dockerfiles/slurm-cluster/docker-compose.yml
@@ -12,7 +12,11 @@ services:
 
   frontend:
     image: slurm-reframe
-    build: examples/tutorial/dockerfiles/slurm-cluster/reframe
+    build:
+      context: examples/tutorial/dockerfiles/slurm-cluster/reframe
+      args:
+        REFRAME_REPO: reframe-hpc
+        REFRAME_TAG: develop
     container_name: frontend
     hostname: login
     user: admin

--- a/reframe/core/meta.py
+++ b/reframe/core/meta.py
@@ -305,7 +305,6 @@ class RegressionTestMeta(type):
         '''
 
         # Collect the loggable properties
-        loggable_props = []
         namespace['_rfm_loggable_props'] = [
             v.fget._rfm_loggable for v in namespace.values()
             if hasattr(v, 'fget') and hasattr(v.fget, '_rfm_loggable')
@@ -816,7 +815,8 @@ class RegressionTestMeta(type):
     def variant_name(cls, variant_num=None):
         '''Return the name of the test variant with a specific variant number.
 
-        :param variant_num: An integer in the range of ``[0, cls.num_variants)``.
+        :param variant_num: An integer in the range of
+            ``[0, cls.num_variants)``.
         '''
 
         name = cls.__name__

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -1194,9 +1194,26 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     def name(self):
         '''The name of the test.
 
-        This is an alias of :attr:`display_name`.
+        This is an alias of :attr:`display_name` but omitting any implicit
+        parameters starting with ``$`` that are inserted by the
+        :option:`--repeat`, :option:`--distribute` and other similar options.
+
+        .. versionchanged:: 4.7
+
+           The implicit parameters starting with ``$`` are now omitted.
         '''
-        return self.display_name
+        if hasattr(self, '_rfm_name'):
+            return self._rfm_name
+
+        # Remove any special parameters starting with `$`
+        basename, *params = self.display_name.split(' ')
+        name = basename
+        for p in params:
+            if not p.startswith('%$'):
+                name += f' {p}'
+
+        self._rfm_name = name
+        return self._rfm_name
 
     @loggable
     @property

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -141,14 +141,15 @@ def describe_checks(testcases, printer):
         if tc.check.is_fixture():
             continue
 
-        if tc.check.name not in unique_names:
-            unique_names.add(tc.check.name)
+        if tc.check.display_name not in unique_names:
+            unique_names.add(tc.check.display_name)
             rec = json.loads(jsonext.dumps(tc.check))
 
             # Now manipulate the record to be more user-friendly
             #
             # 1. Add other fields that are relevant for users
             # 2. Remove all private fields
+            rec['name'] = tc.check.name
             rec['unique_name'] = tc.check.unique_name
             rec['display_name'] = tc.check.display_name
             rec['pipeline_hooks'] = {}

--- a/reframe/frontend/filters.py
+++ b/reframe/frontend/filters.py
@@ -6,7 +6,6 @@
 import re
 
 from reframe.core.exceptions import ReframeError
-from reframe.core.runtime import runtime
 
 
 def re_compile(patt):
@@ -22,7 +21,6 @@ def _have_name(patt):
     def _fn(case):
         # Match pattern, but remove spaces from the `display_name`
         display_name = case.check.display_name.replace(' ', '')
-        rt = runtime()
         if '@' in patt:
             # Do an exact match on the unique name
             return patt.replace('@', '_') == case.check.unique_name
@@ -43,7 +41,6 @@ def have_not_name(patt):
 
 
 def have_any_name(names):
-    rt = runtime()
     variant_matches = []
     hash_matches = []
     regex_matches = []


### PR DESCRIPTION
The `name` test attribute is not anymore a full alias of `display_name`. It hides all special parameters starting with `$` that are inserted by the automatic test generation options, such as `--repeat`, `--distribute` etc.

Also the test name of the parameterized test with `--distribute` does not contain any more the partition name, but instead the partition has become a special test parameter.

Finally, all the special parameters are converted to non-loggable.

The motivation behind these changes is that previously both the special parameters and the different name of the "distributed" tests were causing confusion with logging (e.g., different log files, different headers etc.) and were preventing results comparisons with the new `--performance-compare` option.