### PR TITLE
[feat] Support session annotations with a new `--session-extras` option

### DIFF
--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -1129,6 +1129,15 @@ Miscellaneous options
    .. versionadded:: 3.9.3
 
 
+.. option:: --session-extras KV_DATA
+
+   Annotate the current session with custom key/value metadata.
+
+   The key/value data is specified as a comma-separated list of `key=value` pairs.
+   When listing stored sessions with the :option:`--list-stored-sessions` option, any associated custom metadata will be presented by default.
+
+   .. versionadded:: 4.7
+
 .. option:: --system=NAME
 
    Load the configuration for system ``NAME``.

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -616,6 +616,10 @@ def main():
         help=('Print a report for performance tests '
               '(default: "now:now/last:+job_nodelist/+result")')
     )
+    reporting_options.add_argument(
+        '--session-extras', action='store', metavar='KV_DATA',
+        help='Annotate session with custom key/value data'
+    )
 
     # Miscellaneous options
     misc_options.add_argument(
@@ -1589,6 +1593,15 @@ def main():
             report.update_run_stats(runner.stats)
             if options.restore_session is not None:
                 report.update_restored_cases(restored_cases, restored_session)
+
+            if options.session_extras:
+                # Update report's extras
+                extras = {}
+                for arg in options.session_extras.split(','):
+                    k, v = arg.split('=', maxsplit=1)
+                    extras[k] = v
+
+                report.update_extras(extras)
 
             # Print a retry report if we did any retries
             if options.max_retries and runner.stats.failed(run=0):

--- a/reframe/frontend/printer.py
+++ b/reframe/frontend/printer.py
@@ -283,7 +283,14 @@ class PrettyPrinter:
             colidx = [i for i, col in enumerate(data[0])
                       if col not in hide_columns]
 
-            tab_data = [[rec[col] for col in colidx] for rec in data]
+            def _access(seq, i, default=None):
+                # Safe access of i-th element of a sequence
+                try:
+                    return seq[i]
+                except IndexError:
+                    return default
+
+            tab_data = [[_access(rec, col) for col in colidx] for rec in data]
         else:
             tab_data = data
 

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -1262,13 +1262,14 @@ def table_format(request):
     return request.param
 
 
-def test_storage_options(run_reframe, tmp_path, table_format):
-    def assert_no_crash(returncode, stdout, stderr, exitcode=0):
-        assert returncode == exitcode
-        assert 'Traceback' not in stdout
-        assert 'Traceback' not in stderr
-        return returncode, stdout, stderr
+def assert_no_crash(returncode, stdout, stderr, exitcode=0):
+    assert returncode == exitcode
+    assert 'Traceback' not in stdout
+    assert 'Traceback' not in stderr
+    return returncode, stdout, stderr
 
+
+def test_storage_options(run_reframe, tmp_path, table_format):
     run_reframe2 = functools.partial(
         run_reframe,
         checkpath=['unittests/resources/checks/frontend_checks.py'],
@@ -1326,6 +1327,19 @@ def test_storage_options(run_reframe, tmp_path, table_format):
 
     # Remove session
     assert_no_crash(*run_reframe2(action=f'--delete-stored-session={uuid}'))
+
+
+def test_session_annotations(run_reframe):
+    assert_no_crash(*run_reframe(
+        checkpath=['unittests/resources/checks/frontend_checks.py'],
+        action='-r',
+        more_options=['--session-extras', 'key1=val1,key2=val2',
+                      '-n', '^PerformanceFailureCheck']
+    ), exitcode=1)
+
+    stdout = assert_no_crash(*run_reframe(action='--list-stored-sessions'))[1]
+    for text in ['key1', 'key2', 'val1', 'val2']:
+        assert text in stdout
 
 
 def test_performance_compare(run_reframe, table_format):


### PR DESCRIPTION
This option will add arbitrary key/value pairs to the session, which allows users to append extra metadata when storing the current session (e.g., add the CI job id if the session is being run as part of a CI pipeline).