### PR TITLE
[bugfix] Let Slurm decide partition in flexible node allocation if no default partition is defined

### DIFF
--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -363,6 +363,8 @@ class SlurmJobScheduler(sched.JobScheduler):
         if partitions:
             partitions = set(partitions.strip().split(','))
         else:
+            # Use a default partition if one is configured. Otherwise,
+            # fallback to the partition Slurm chooses for this set of options.
             default_partition = (
                 self._get_default_partition() or
                 self._get_actual_partition(options)


### PR DESCRIPTION
This PR fixes an issue with flexible node allocations when no partition is specified and there is no default partition in slurm. 

At NERSC, users specify a qos rather than a partition and Slurm chooses a partition for a job based on the combination of several options. A sys admin at our site suggested using `srun --test-only` to see which partition Slurm would chose for a job with a given set of options.
