### PR TITLE
[enhancement] Do not issue warning when skipping tests during the init phase

### DIFF
--- a/reframe/core/decorators.py
+++ b/reframe/core/decorators.py
@@ -104,7 +104,7 @@ class TestRegistry:
                     kwargs['reset_sysenv'] = reset_sysenv
                     leaf_tests.append(test(*args, **kwargs))
                 except SkipTestError as e:
-                    getlogger().warning(
+                    getlogger().verbose(
                         f'skipping test {test.__qualname__!r}: {e}'
                     )
                 except Exception:


### PR DESCRIPTION
The rationale behind this is that skipping tests during initialization could be part of a parameterization pruning process. The skip message is printed in verbose mode now.

Closes #3284.