### PR TITLE
[bugfix] Allow RESERVED nodes for Slurm "avail" state

### DIFF
--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -160,7 +160,7 @@ def filter_nodes_by_state(nodelist, state):
     :arg state: The state of the nodes.
         If ``all``, the initial list is returned untouched.
         If ``avail``, only the available nodes will be returned.
-        All other values are interpretes as a state string.
+        All other values are interpreted as a state string.
         State match is exclusive unless the ``*`` is added at the end of the
         state string.
     :returns: the filtered node list
@@ -169,7 +169,7 @@ def filter_nodes_by_state(nodelist, state):
         nodelist = {n for n in nodelist if n.is_avail()}
     elif state != 'all':
         if state.endswith('*'):
-            # non-exclusive stat match
+            # non-exclusive state match
             state = state[:-1]
             nodelist = {
                 n for n in nodelist if n.in_state(state)
@@ -180,8 +180,6 @@ def filter_nodes_by_state(nodelist, state):
             }
 
     return nodelist
-    nodes[part.fullname] = [n.name for n in nodelist]
-
 
 
 class Job(jsonext.JSONSerializable, metaclass=JobMeta):
@@ -603,7 +601,13 @@ class Job(jsonext.JSONSerializable, metaclass=JobMeta):
         available_nodes = filter_nodes_by_state(
             available_nodes, self.sched_flex_alloc_nodes.lower()
         )
+        getlogger().debug(
+            f'[F] Total available in state={self.sched_flex_alloc_nodes.lower()}: {len(available_nodes)}'
+        )
         available_nodes = self.scheduler.filternodes(self, available_nodes)
+        getlogger().debug(
+            f'[F] Total available after scheduler filter: {len(available_nodes)}'
+        )
         return len(available_nodes) * num_tasks_per_node
 
     def submit(self):

--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -602,11 +602,13 @@ class Job(jsonext.JSONSerializable, metaclass=JobMeta):
             available_nodes, self.sched_flex_alloc_nodes.lower()
         )
         getlogger().debug(
-            f'[F] Total available in state={self.sched_flex_alloc_nodes.lower()}: {len(available_nodes)}'
+            f'[F] Total available in state='
+            f'{self.sched_flex_alloc_nodes.lower()}: {len(available_nodes)}'
         )
         available_nodes = self.scheduler.filternodes(self, available_nodes)
         getlogger().debug(
-            f'[F] Total available after scheduler filter: {len(available_nodes)}'
+            f'[F] Total available after scheduler filter: '
+            f'{len(available_nodes)}'
         )
         return len(available_nodes) * num_tasks_per_node
 


### PR DESCRIPTION
This PR is an implementation of the suggestions in #3216 to better handle reserved nodes in Slurm when guessing the number of nodes/tasks to use with`--flex-node-alloc`:

 * include `RESERVED` as an "avail" state for Slurm nodes (and filter out reserved nodes when no reservation is specified).
 * allow a node to be in any combination of the "avail" states

I also added a few log statements that were helpful to me while testing this interactively and cleaned up a few typos in nearby code.

Closes #3216.

