### PR TITLE
[enhancement] Report the undefined parameters if an instantiation of an abstract test or fixture is attempted

### DIFF
--- a/reframe/core/decorators.py
+++ b/reframe/core/decorators.py
@@ -104,7 +104,7 @@ class TestRegistry:
                     kwargs['reset_sysenv'] = reset_sysenv
                     leaf_tests.append(test(*args, **kwargs))
                 except SkipTestError as e:
-                    getlogger().warning(
+                    getlogger().verbose(
                         f'skipping test {test.__qualname__!r}: {e}'
                     )
                 except Exception:

--- a/reframe/core/decorators.py
+++ b/reframe/core/decorators.py
@@ -8,7 +8,6 @@
 #
 
 __all__ = ['simple_test']
-_TREAT_WARNINGS_AS_ERRORS = False
 
 import inspect
 import sys
@@ -170,22 +169,10 @@ def _validate_test(cls):
                                  'subclass of RegressionTest')
 
     if (cls.is_abstract()):
-        params = cls.param_space.params
-        undefined_params = []
-        for param in params:
-            if params[param].is_abstract():
-                undefined_params.append(param)
-        # Raise detailed warning
-        if _TREAT_WARNINGS_AS_ERRORS:
-            raise ValueError(
-                f'skipping test {cls.__qualname__!r}: ' +
-                f'test has the following undefined parameters: ' +
-                ', '.join(undefined_params)
-            )
         getlogger().warning(
             f'skipping test {cls.__qualname__!r}: ' +
-            f'test has the following undefined parameters: ' +
-            ', '.join(undefined_params)
+            'the following parameters are undefined: ' +
+            ', '.join(cls.param_space.undefined_params())
         )
 
     conditions = [VersionValidator(v) for v in cls._rfm_required_version]

--- a/reframe/core/fixtures.py
+++ b/reframe/core/fixtures.py
@@ -325,12 +325,6 @@ class FixtureRegistry:
         '''Get the uninstantiated tests of this registry'''
         return self._registry.keys()
 
-    def _filter_valid_partitions(self, candidate_parts):
-        return [p for p in candidate_parts if p in self._env_by_part]
-
-    def _filter_valid_environs(self, part, candidate_environs):
-        return [e for e in cadidate_environs if e in self._env_by_part[part]]
-
     def _is_registry(self, other):
         if not isinstance(other, FixtureRegistry):
             raise TypeError('other is not a FixtureRegistry')
@@ -775,14 +769,9 @@ class TestFixture:
 
         # Check that the fixture class is not an abstract test.
         if cls.is_abstract():
-            params = cls.param_space.params
-            undefined_params = []
-            for param in params:
-                if params[param].is_abstract():
-                    undefined_params.append(param)
             raise ValueError(
-                f'class {cls.__qualname__!r} has undefined parameters: ' +
-                ', '.join(undefined_params)
+                f'fixture {cls.__qualname__!r} has undefined parameters: ' +
+                ', '.join(cls.param_space.undefined_params())
             )
 
         # Validate the scope

--- a/reframe/core/fixtures.py
+++ b/reframe/core/fixtures.py
@@ -775,8 +775,14 @@ class TestFixture:
 
         # Check that the fixture class is not an abstract test.
         if cls.is_abstract():
+            params = cls.param_space.params
+            undefined_params = []
+            for param in params:
+                if params[param].is_abstract():
+                    undefined_params.append(param)
             raise ValueError(
-                f'class {cls.__qualname__!r} has undefined parameters'
+                f'class {cls.__qualname__!r} has undefined parameters: ' +
+                ', '.join(undefined_params)
             )
 
         # Validate the scope

--- a/reframe/core/parameters.py
+++ b/reframe/core/parameters.py
@@ -198,7 +198,7 @@ class TestParam:
                 self.values = tuple(filt_vals) + self.values
             except TypeError:
                 raise ReframeSyntaxError(
-                    f"'filter_param' must return an iterable"
+                    "'filter_param' must return an iterable"
                 ) from None
 
     def is_abstract(self):
@@ -307,7 +307,7 @@ class ParamSpace(namespaces.Namespace):
             try:
                 # Get the parameter values for the specified variant
                 param_values = self.__param_combinations[params_index]
-            except IndexError as no_params:
+            except IndexError:
                 raise RuntimeError(
                     f'parameter space index out of range for '
                     f'{obj.__class__.__qualname__}'
@@ -332,6 +332,11 @@ class ParamSpace(namespaces.Namespace):
         abstract.
         '''
         return name in self.params and not self.params[name].is_abstract()
+
+    def undefined_params(self):
+        '''Return a list of all undefined parameters.'''
+        return [name for name, param in self.params.items()
+                if param.is_abstract()]
 
     def __iter__(self):
         '''Create a generator object to iterate over the parameter space

--- a/unittests/test_fixtures.py
+++ b/unittests/test_fixtures.py
@@ -71,11 +71,9 @@ def test_abstract_fixture():
     class Foo(rfm.RegressionTest):
         p = parameter()
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(ValueError):
         class MyTest(rfm.RegressionMixin):
             f = fixture(Foo)
-
-    assert "p" in str(exc_info.value)
 
 
 def test_fixture_variants():

--- a/unittests/test_fixtures.py
+++ b/unittests/test_fixtures.py
@@ -71,9 +71,11 @@ def test_abstract_fixture():
     class Foo(rfm.RegressionTest):
         p = parameter()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc_info:
         class MyTest(rfm.RegressionMixin):
             f = fixture(Foo)
+
+    assert "p" in str(exc_info.value)
 
 
 def test_fixture_variants():

--- a/unittests/test_parameters.py
+++ b/unittests/test_parameters.py
@@ -67,12 +67,6 @@ def test_abstract_param_warning(monkeypatch):
     assert "P0" in str(execinfo.value)
 
 
-def test_abstract_check():
-    @rfm.simple_test
-    class MyTest(Abstract):
-        pass
-
-
 def test_param_override():
     class MyTest(TwoParams):
         P1 = parameter(['-'])

--- a/unittests/test_parameters.py
+++ b/unittests/test_parameters.py
@@ -10,6 +10,7 @@ import inspect
 
 import reframe as rfm
 from reframe.core.exceptions import ReframeSyntaxError
+import reframe.core.decorators as decorators
 
 
 class NoParams(rfm.RunOnlyRegressionTest):
@@ -52,6 +53,24 @@ def test_abstract_param():
 
     assert MyTest.param_space['P0'] == ()
     assert MyTest.param_space['P1'] == ('b',)
+
+
+def test_abstract_param_warning(monkeypatch):
+    monkeypatch.setattr(decorators, '_TREAT_WARNINGS_AS_ERRORS', True)
+
+    class MyTest(Abstract):
+        pass
+
+    with pytest.raises(ValueError) as execinfo:
+        decorators._validate_test(MyTest)
+
+    assert "P0" in str(execinfo.value)
+
+
+def test_abstract_check():
+    @rfm.simple_test
+    class MyTest(Abstract):
+        pass
 
 
 def test_param_override():

--- a/unittests/test_parameters.py
+++ b/unittests/test_parameters.py
@@ -49,22 +49,13 @@ def test_params_are_present():
 
 def test_abstract_param():
     class MyTest(Abstract):
-        pass
+        # Add another abstract parameter
+        P2 = parameter()
 
     assert MyTest.param_space['P0'] == ()
     assert MyTest.param_space['P1'] == ('b',)
-
-
-def test_abstract_param_warning(monkeypatch):
-    monkeypatch.setattr(decorators, '_TREAT_WARNINGS_AS_ERRORS', True)
-
-    class MyTest(Abstract):
-        pass
-
-    with pytest.raises(ValueError) as execinfo:
-        decorators._validate_test(MyTest)
-
-    assert "P0" in str(execinfo.value)
+    assert MyTest.param_space['P2'] == ()
+    assert MyTest.param_space.undefined_params() == ['P0', 'P2']
 
 
 def test_param_override():


### PR DESCRIPTION
This PR is to improve the error reporting when skipping tests or reporting ReframeSyntaxErrors.

- Tests skipped because of undefined parameters now print information regarding the undefined parameters.

Closes #3254