### PR TITLE
[enhancement] Warn instead of failing when a filter expression is invalid for test

### DIFF
--- a/reframe/frontend/executors/__init__.py
+++ b/reframe/frontend/executors/__init__.py
@@ -124,6 +124,10 @@ class TestCase:
         e = self.environ.name if self.environ else None
         return f'({c!r}, {p!r}, {e!r})'
 
+    def __str__(self):
+        check, partition, environ = self
+        return f'{check.name} @{partition.fullname}+{environ.name}'
+
     def prepare(self):
         '''Prepare test case for sending down the test pipeline'''
         if self._is_ready:

--- a/reframe/frontend/filters.py
+++ b/reframe/frontend/filters.py
@@ -6,6 +6,7 @@
 import re
 
 from reframe.core.exceptions import ReframeError
+from reframe.core.logging import getlogger
 
 
 def re_compile(patt):
@@ -118,6 +119,8 @@ def validates(expr):
         try:
             return eval(expr, None, case.check.__dict__)
         except Exception as err:
-            raise ReframeError(f'invalid expression `{expr}`') from err
+            getlogger().warning(f'error while evaluating expression `{expr}` '
+                                f'for test case `{case}`: {err}')
+            return False
 
     return _fn


### PR DESCRIPTION
Instead of failing the whole filtering process and issuing a hard error, we now issue a warning and the test is skipped. Example output:

```console
WARNING: error while evaluating expression `num_nodes > 1` for test case `TestX @generic:default+builtin`: name 'num_nodes' is not defined
```