### PR TITLE
[enhancement] Issue a more compact message when JSON schema validation fails

### DIFF
--- a/reframe/core/config.py
+++ b/reframe/core/config.py
@@ -447,8 +447,10 @@ class _SiteConfig:
         try:
             jsonschema.validate(site_config, self._schema)
         except jsonschema.ValidationError as e:
-            raise ConfigError(f"could not validate configuration files: "
-                              f"'{self._sources}'") from e
+            getlogger().debug(str(e))
+            sources = ', '.join(f'`{f}`' for f in self._sources)
+            raise ConfigError('could not validate configuration files: '
+                              f'{sources}') from e
 
         def _warn_variables(config, opt_path):
             opt_path = '/'.join(opt_path + ['variables'])

--- a/reframe/core/exceptions.py
+++ b/reframe/core/exceptions.py
@@ -8,6 +8,7 @@
 #
 
 import inspect
+import jsonschema
 import os
 
 import reframe
@@ -54,7 +55,10 @@ class ReframeBaseError(BaseException):
     def __str__(self):
         ret = self._message or ''
         if self.__cause__ is not None:
-            ret += ': ' + str(self.__cause__)
+            if isinstance(self.__cause__, jsonschema.ValidationError):
+                ret += ': ' + self.__cause__.message
+            else:
+                ret += ': ' + str(self.__cause__)
 
         return ret
 

--- a/reframe/frontend/autodetect.py
+++ b/reframe/frontend/autodetect.py
@@ -106,6 +106,7 @@ def _load_info(filename, schema=None):
         )
         return {}
     except jsonschema.ValidationError as e:
+        getlogger().debug(str(e))
         raise ConfigError(
             f'could not validate meta-config file {filename!r}'
         ) from e

--- a/reframe/frontend/reporting/__init__.py
+++ b/reframe/frontend/reporting/__init__.py
@@ -215,12 +215,12 @@ def _restore_session(filename):
         except KeyError:
             found_ver = 'n/a'
 
-        getlogger().verbose(f'JSON validation error: {e}')
+        getlogger().debug(str(e))
         raise ReframeError(
             f'failed to validate report {filename!r}: {e.args[0]} '
             f'(check report data version: required {DATA_VERSION}, '
             f'found: {found_ver})'
-        ) from None
+        ) from e
 
     return _RestoredSessionInfo(report)
 

--- a/unittests/resources/config/settings.py
+++ b/unittests/resources/config/settings.py
@@ -227,12 +227,6 @@ site_configuration = {
             'features': ['cxx14', 'mpi'],
         },
         {
-            'name': 'builtin',
-            'cc': 'cc',
-            'cxx': '',
-            'ftn': ''
-        },
-        {
             'name': 'e0',
             'modules': ['m0']
         },


### PR DESCRIPTION
We modify our core code for chaining exception message to only print the `message` of the validation error and not its verbose string representation. This is now printed in debug mode at the error site.

Closes #3168.