### PR TITLE
[feat] Allow partition/environment extras to be used also as feature constraints in `valid_systems` and `valid_prog_environs`

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -601,7 +601,7 @@ System Partition Configuration
    :required: No
    :default: ``[]``
 
-   A list of job scheduler `resource specification <#custom-job-scheduler-resources>`__ objects.
+   A list of job scheduler :ref:`resource specification <scheduler-resources>` objects.
 
 
 .. py:attribute:: systems.partitions.processor
@@ -746,6 +746,8 @@ ReFrame can launch containerized applications, but you need to configure properl
       Please use :attr:`~systems.partitions.container_platforms.env_vars` instead.
       If specified in conjunction with :attr:`~systems.partitions.container_platforms.env_vars`, it will be ignored.
 
+
+.. _scheduler-resources:
 
 Custom Job Scheduler Resources
 ==============================

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -261,11 +261,18 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #: of the :attr:`valid_systems` list, in which case an AND operation on
     #: these constraints is implied. For example, the test defining the
     #: following will be valid for all systems that have define both ``feat1``
-    #: and ``feat2`` and set ``foo=1``
+    #: and ``feat2`` and set ``foo=1``:
     #:
     #: .. code-block:: python
     #:
-    #:    valid_systems = ['+feat1 +feat2 %foo=1']
+    #:    valid_systems = [r'+feat1 +feat2 %foo=1']
+    #:
+    #: Any partition/environment extra or
+    #: :ref:`partition resource <scheduler-resources>` can be specified as a
+    #: feature constraint without having to explicitly state this in the
+    #: partition's/environment's feature list. For example, if ``key1`` is part
+    #: of the partition/environment extras list, then ``+key1`` will select
+    #: that partition or environment.
     #:
     #: For key/value pairs comparisons, ReFrame will automatically convert the
     #: value in the key/value spec to the type of the value of the

--- a/reframe/core/runtime.py
+++ b/reframe/core/runtime.py
@@ -311,11 +311,13 @@ def _is_valid_part(part, valid_systems):
                     props[key] = val
 
             have_plus_feats = all(
-                ft in part.features or ft in part.resources
+                (ft in part.features or
+                 ft in part.resources or ft in part.extras)
                 for ft in plus_feats
             )
             have_minus_feats = any(
-                ft in part.features or ft in part.resources
+                (ft in part.features or
+                 ft in part.resources or ft in part.extras)
                 for ft in minus_feats
             )
             try:
@@ -357,8 +359,9 @@ def _is_valid_env(env, valid_prog_environs):
                     key, val = subspec[1:].split('=')
                     props[key] = val
 
-            have_plus_feats = all(ft in env.features for ft in plus_feats)
-            have_minus_feats = any(ft in env.features
+            have_plus_feats = all(ft in env.features or ft in env.extras
+                                  for ft in plus_feats)
+            have_minus_feats = any(ft in env.features or ft in env.extras
                                    for ft in minus_feats)
             try:
                 have_props = True

--- a/unittests/test_pipeline.py
+++ b/unittests/test_pipeline.py
@@ -556,7 +556,7 @@ def test_supports_sysenv(testsys_exec_ctx):
 
     # Check AND in features and extras
     _assert_supported(
-        valid_systems=['+cuda +mpi %gpu_arch=v100'],
+        valid_systems=[r'+cuda +mpi %gpu_arch=v100'],
         valid_prog_environs=['*'],
         expected={}
     )
@@ -566,9 +566,18 @@ def test_supports_sysenv(testsys_exec_ctx):
         expected={}
     )
 
-    # Check OR in features ad extras
+    # Check OR in features and extras
     _assert_supported(
-        valid_systems=['+cuda +mpi', '%gpu_arch=v100'],
+        valid_systems=['+cuda +mpi', r'%gpu_arch=v100'],
+        valid_prog_environs=['*'],
+        expected={
+            'testsys:gpu': ['PrgEnv-gnu', 'builtin']
+        }
+    )
+
+    # Check that extra keys can used as features
+    _assert_supported(
+        valid_systems=['+cuda +mpi', '+gpu_arch'],
         valid_prog_environs=['*'],
         expected={
             'testsys:gpu': ['PrgEnv-gnu', 'builtin']
@@ -640,7 +649,7 @@ def test_supports_sysenv(testsys_exec_ctx):
     )
     _assert_supported(
         valid_systems=['*'],
-        valid_prog_environs=['%bar=x'],
+        valid_prog_environs=[r'%bar=x'],
         expected={
             'testsys:gpu': [],
             'testsys:login': ['PrgEnv-gnu']
@@ -648,7 +657,7 @@ def test_supports_sysenv(testsys_exec_ctx):
     )
     _assert_supported(
         valid_systems=['*'],
-        valid_prog_environs=['%foo=2'],
+        valid_prog_environs=[r'%foo=2'],
         expected={
             'testsys:gpu': ['PrgEnv-gnu'],
             'testsys:login': []
@@ -656,7 +665,7 @@ def test_supports_sysenv(testsys_exec_ctx):
     )
     _assert_supported(
         valid_systems=['*'],
-        valid_prog_environs=['%foo=bar'],
+        valid_prog_environs=[r'%foo=bar'],
         expected={
             'testsys:gpu': [],
             'testsys:login': []
@@ -667,6 +676,24 @@ def test_supports_sysenv(testsys_exec_ctx):
         valid_prog_environs=['-cxx14'],
         expected={
             'testsys:gpu': ['PrgEnv-gnu', 'builtin'],
+            'testsys:login': []
+        }
+    )
+
+    # Check that extra keys can used as features
+    _assert_supported(
+        valid_systems=['*'],
+        valid_prog_environs=['+foo +bar'],
+        expected={
+            'testsys:gpu': ['PrgEnv-gnu'],
+            'testsys:login': ['PrgEnv-gnu']
+        }
+    )
+    _assert_supported(
+        valid_systems=['*'],
+        valid_prog_environs=['+foo -bar'],
+        expected={
+            'testsys:gpu': [],
             'testsys:login': []
         }
     )


### PR DESCRIPTION
We do this already for partition resources but I think it makes sense to do it for extras as sometimes a test cares that an extra is defined so as to take its value rather than constrain the test to a specific value, such as `%key=val`.