### PR TITLE
[feat] Make directory prefix for topology files configurable

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -639,11 +639,18 @@ System Partition Configuration
 
       In case of errors during auto-detection, ReFrame will simply issue a warning and continue.
 
+      .. note::
+
+         The directory prefix for storing topology information is configurable through the :attr:`~config.general.topology_prefix` configuration option.
+
 
    .. versionadded:: 3.5.0
 
    .. versionchanged:: 3.7.0
       ReFrame is now able to detect the processor information automatically.
+
+   .. versionchanged:: 4.7
+      Directory prefix for topology files is now configurable.
 
 
 .. py:attribute:: systems.partitions.devices
@@ -1855,6 +1862,16 @@ General Configuration
 
 
 
+.. py:attribute:: general.topology_prefix
+
+   :required: No
+   :default: ``"${HOME}/.reframe/topology"``
+
+   Directory prefix for storing the auto-detected processor topology.
+
+   .. versionadded:: 4.7
+
+
 .. py:attribute:: general.trap_job_errors
 
    :required: No
@@ -1863,7 +1880,6 @@ General Configuration
    Trap command errors in the generated job scripts and let them exit immediately.
 
    .. versionadded:: 3.2
-
 
 .. py:attribute:: general.keep_stage_files
 

--- a/reframe/frontend/autodetect.py
+++ b/reframe/frontend/autodetect.py
@@ -204,7 +204,7 @@ def _remote_detect(part):
 def detect_topology():
     rt = runtime.runtime()
     detect_remote_systems = rt.get_option('general/0/remote_detect')
-    topo_prefix = os.path.join(os.getenv('HOME'), '.reframe/topology')
+    topo_prefix = rt.get_option('general/0/topology_prefix')
     for part in rt.system.partitions:
         getlogger().debug(f'detecting topology info for {part.fullname}')
         found_procinfo = False

--- a/reframe/frontend/autodetect.py
+++ b/reframe/frontend/autodetect.py
@@ -204,7 +204,7 @@ def _remote_detect(part):
 def detect_topology():
     rt = runtime.runtime()
     detect_remote_systems = rt.get_option('general/0/remote_detect')
-    topo_prefix = rt.get_option('general/0/topology_prefix')
+    topo_prefix = osext.expandvars(rt.get_option('general/0/topology_prefix'))
     for part in rt.system.partitions:
         getlogger().debug(f'detecting topology info for {part.fullname}')
         found_procinfo = False

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -601,6 +601,7 @@
         "general/save_log_files": false,
         "general/table_format": "pretty",
         "general/target_systems": ["*"],
+        "general/topology_prefix": "${HOME}/.reframe/topology",
         "general/timestamp_dirs": "%Y%m%dT%H%M%S%z",
         "general/trap_job_errors": false,
         "general/unload_modules": [],


### PR DESCRIPTION
This was the only place (excluding the module systems backends) where access to an environment variable (`$HOME`) was hardcoded. Now this configurable and assigned a default value.

Closes #3091.