### PR TITLE
Automatic detection of the system configuration

### DIFF
--- a/autodetect_config.py
+++ b/autodetect_config.py
@@ -1,0 +1,9 @@
+import reframe.core.config as config
+
+site_configuration = config.detect_config(
+    exclude_feats=['colum*'],
+    detect_containers=False,
+    sched_options=[],
+    time_limit=200,
+    filename='system_config'
+)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,8 @@
 archspec==0.2.5
+autopep8
 docutils==0.18.1
 jsonschema==3.2.0
+jinja2
 semver==2.13.0; python_version == '3.6'
 semver==3.0.2; python_version >= '3.7'
 Sphinx==5.3.0; python_version < '3.8'

--- a/reframe/core/backends.py
+++ b/reframe/core/backends.py
@@ -9,22 +9,24 @@ import functools
 
 import reframe.core.fields as fields
 from reframe.core.exceptions import ConfigError
+from reframe.core.modules import ModulesSystem
+from reframe.core.logging import getlogger
 
 _launcher_backend_modules = [
     'reframe.core.launchers.local',
-    'reframe.core.launchers.mpi',
-    'reframe.core.launchers.rsh'
+    'reframe.core.launchers.rsh',
+    'reframe.core.launchers.mpi'
 ]
 _launchers = {}
 _scheduler_backend_modules = [
-    'reframe.core.schedulers.flux',
     'reframe.core.schedulers.local',
+    'reframe.core.schedulers.ssh',
+    'reframe.core.schedulers.flux',
     'reframe.core.schedulers.lsf',
     'reframe.core.schedulers.pbs',
     'reframe.core.schedulers.oar',
     'reframe.core.schedulers.sge',
-    'reframe.core.schedulers.slurm',
-    'reframe.core.schedulers.ssh'
+    'reframe.core.schedulers.slurm'
 ]
 _schedulers = {}
 
@@ -62,6 +64,26 @@ def _get_backend(name, *, backend_type):
         return cls
 
 
+def _detect_backend(backend_type: str):
+    backend_modules = globals()[f'_{backend_type}_backend_modules']
+    backend_found = []
+    for mod in backend_modules:
+        importlib.import_module(mod)
+
+    for bcknd in globals()[f'_{backend_type}s']:
+        bcknd, _ = globals()[f'_{backend_type}s'][bcknd]
+        backend = bcknd.validate()
+        if not backend:
+            pass
+        else:
+            backend_found.append((bcknd, backend))
+            getlogger().info(f'Found {backend_type}: {backend}')
+    if len(backend_found) == 1:
+        getlogger().warning(f'No remote {backend_type} detected')
+    # By default, select the last one detected
+    return backend_found[-1]
+
+
 register_scheduler = functools.partial(
     _register_backend, backend_type='scheduler'
 )
@@ -70,3 +92,7 @@ register_launcher = functools.partial(
 )
 getscheduler = functools.partial(_get_backend, backend_type='scheduler')
 getlauncher  = functools.partial(_get_backend, backend_type='launcher')
+detect_scheduler = functools.partial(_detect_backend, backend_type='scheduler')
+detect_launcher = functools.partial(_detect_backend, backend_type='launcher')
+# TODO find a better place for this function
+detect_modules_system = ModulesSystem.detect

--- a/reframe/core/launchers/__init__.py
+++ b/reframe/core/launchers/__init__.py
@@ -7,6 +7,7 @@ import abc
 import reframe.utility.typecheck as typ
 from reframe.core.meta import RegressionTestMeta
 from reframe.core.warnings import user_deprecation_warning
+from typing import Union
 
 
 class _JobLauncherMeta(RegressionTestMeta, abc.ABCMeta):
@@ -86,6 +87,20 @@ class JobLauncher(metaclass=_JobLauncherMeta):
         cmd_tokens += self.command(job) + self.options
         return ' '.join(cmd_tokens)
 
+    @property
+    def name(self):
+        return self.registered_name
+
+    @classmethod
+    @abc.abstractmethod
+    # Will not raise an error if not defined until instantiation
+    def validate(cls) -> Union[str, bool]:
+        '''Check if the launcher is in the system
+
+        :returns: False if the launcher is not present and
+        the name of the launcher backend if it is
+        '''
+
 
 class LauncherWrapper(JobLauncher):
     '''Wrap a launcher object so as to modify its invocation.
@@ -134,3 +149,7 @@ class LauncherWrapper(JobLauncher):
 
     def command(self, job):
         return self._wrapper_command + self._target_launcher.command(job)
+
+    @classmethod
+    def validate(cls):
+        return cls._target_launcher.validate()

--- a/reframe/core/launchers/local.py
+++ b/reframe/core/launchers/local.py
@@ -16,3 +16,7 @@ class LocalLauncher(JobLauncher):
         # `self.options`.
         self.options = []
         return []
+
+    @classmethod
+    def validate(cls) -> str:
+        return cls.registered_name

--- a/reframe/core/launchers/mpi.py
+++ b/reframe/core/launchers/mpi.py
@@ -3,14 +3,19 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+import functools
 import semver
 import re
+from typing import Union
 
 import reframe.utility.osext as osext
 from reframe.core.backends import register_launcher
+from reframe.core.exceptions import SpawnedProcessError
 from reframe.core.launchers import JobLauncher
 from reframe.core.logging import getlogger
 from reframe.utility import seconds_to_hms
+
+_run_strict = functools.partial(osext.run_command, check=True)
 
 
 @register_launcher('srun')
@@ -50,6 +55,14 @@ class SrunLauncher(JobLauncher):
 
         return ret
 
+    @classmethod
+    def validate(cls) -> Union[str, bool]:
+        try:
+            _run_strict('which srun')
+            return cls.registered_name
+        except SpawnedProcessError:
+            return False
+
 
 @register_launcher('ibrun')
 class IbrunLauncher(JobLauncher):
@@ -57,6 +70,14 @@ class IbrunLauncher(JobLauncher):
 
     def command(self, job):
         return ['ibrun']
+
+    @classmethod
+    def validate(cls) -> Union[str, bool]:
+        try:
+            _run_strict('which ibrun')
+            return cls.registered_name
+        except SpawnedProcessError:
+            return False
 
 
 @register_launcher('upcrun')
@@ -72,6 +93,14 @@ class UpcrunLauncher(JobLauncher):
         cmd += ['-n', str(job.num_tasks)]
         return cmd
 
+    @classmethod
+    def validate(cls) -> Union[str, bool]:
+        try:
+            _run_strict('which upcrun')
+            return cls.registered_name
+        except SpawnedProcessError:
+            return False
+
 
 @register_launcher('upcxx-run')
 class UpcxxrunLauncher(JobLauncher):
@@ -85,6 +114,14 @@ class UpcxxrunLauncher(JobLauncher):
 
         cmd += ['-n', str(job.num_tasks)]
         return cmd
+
+    @classmethod
+    def validate(cls) -> Union[str, bool]:
+        try:
+            _run_strict('which upcxx-run')
+            return cls.registered_name
+        except SpawnedProcessError:
+            return False
 
 
 @register_launcher('alps')
@@ -102,17 +139,41 @@ class AlpsLauncher(JobLauncher):
 
         return cmd
 
+    @classmethod
+    def validate(cls) -> Union[str, bool]:
+        try:
+            _run_strict('which aprun')
+            return cls.registered_name
+        except SpawnedProcessError:
+            return False
+
 
 @register_launcher('mpirun')
 class MpirunLauncher(JobLauncher):
     def command(self, job):
         return ['mpirun', '-np', str(job.num_tasks)]
 
+    @classmethod
+    def validate(cls) -> Union[str, bool]:
+        try:
+            _run_strict('which mpirun')
+            return cls.registered_name
+        except SpawnedProcessError:
+            return False
+
 
 @register_launcher('mpiexec')
 class MpiexecLauncher(JobLauncher):
     def command(self, job):
         return ['mpiexec', '-n', str(job.num_tasks)]
+
+    @classmethod
+    def validate(cls) -> Union[str, bool]:
+        try:
+            _run_strict('which mpiexec')
+            return cls.registered_name
+        except SpawnedProcessError:
+            return False
 
 
 @register_launcher('srunalloc')
@@ -156,6 +217,11 @@ class SrunAllocationLauncher(JobLauncher):
 
         return ret
 
+    @classmethod
+    # The srun launcher would be detected
+    def validate(cls) -> bool:
+        return False
+
 
 @register_launcher('lrun')
 class LrunLauncher(JobLauncher):
@@ -167,6 +233,14 @@ class LrunLauncher(JobLauncher):
         return ['lrun', '-N', str(num_nodes),
                 '-T', str(num_tasks_per_node)]
 
+    @classmethod
+    def validate(cls) -> Union[str, bool]:
+        try:
+            _run_strict('which lrun')
+            return cls.registered_name
+        except SpawnedProcessError:
+            return False
+
 
 @register_launcher('lrun-gpu')
 class LrungpuLauncher(LrunLauncher):
@@ -174,3 +248,8 @@ class LrungpuLauncher(LrunLauncher):
 
     def command(self, job):
         return super().command(job) + ['-M "-gpu"']
+
+    @classmethod
+    def validate(cls) -> bool:
+        # The lrun launcher would be detected
+        return False

--- a/reframe/core/launchers/rsh.py
+++ b/reframe/core/launchers/rsh.py
@@ -3,10 +3,17 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+import functools
+from typing import Union
+
+import reframe.utility.osext as osext
 from reframe.core.backends import register_launcher
+from reframe.core.exceptions import SpawnedProcessError
 from reframe.core.launchers import JobLauncher
 
 # Remote shell launchers
+
+_run_strict = functools.partial(osext.run_command, check=True)
 
 
 @register_launcher('clush')
@@ -14,11 +21,27 @@ class ClushLauncher(JobLauncher):
     def command(self, job):
         return ['clush', *job.sched_access]
 
+    @classmethod
+    def validate(cls) -> Union[str, bool]:
+        try:
+            _run_strict('which clush')
+            return cls.registered_name
+        except SpawnedProcessError:
+            return False
+
 
 @register_launcher('pdsh')
 class PdshLauncher(JobLauncher):
     def command(self, job):
         return ['pdsh', *job.sched_access]
+
+    @classmethod
+    def validate(cls) -> Union[str, bool]:
+        try:
+            _run_strict('which pdsh')
+            return cls.registered_name
+        except SpawnedProcessError:
+            return False
 
 
 @register_launcher('ssh')
@@ -37,3 +60,11 @@ class SSHLauncher(JobLauncher):
         # self.options is processed specially above
         cmd_tokens += self.command(job)
         return ' '.join(cmd_tokens)
+
+    @classmethod
+    def validate(cls) -> Union[str, bool]:
+        try:
+            _run_strict('which ssh')
+            return cls.registered_name
+        except SpawnedProcessError:
+            return False

--- a/reframe/core/schedulers/local.py
+++ b/reframe/core/schedulers/local.py
@@ -91,6 +91,16 @@ class LocalJobScheduler(sched.JobScheduler):
     def filternodes(self, job, nodes):
         return [sched.AlwaysIdleNode(socket.gethostname())]
 
+    def feats_access_option(self, node_feats):
+        raise NotImplementedError(
+            'local backend does not support configuration autodetection'
+        )
+
+    def build_context(self, node_feats):
+        raise NotImplementedError(
+            'local backend does not support configuration autodetection'
+        )
+
     def _kill_all(self, job):
         '''Send SIGKILL to all the processes of the spawned job.'''
         try:
@@ -207,3 +217,7 @@ class LocalJobScheduler(sched.JobScheduler):
         elif os.WIFSIGNALED(status):
             job._state = 'FAILURE'
             job._signal = os.WTERMSIG(status)
+
+    @classmethod
+    def validate(cls) -> str:
+        return cls.registered_name

--- a/reframe/core/schedulers/lsf.py
+++ b/reframe/core/schedulers/lsf.py
@@ -13,10 +13,11 @@
 import functools
 import re
 import time
+from typing import Union
 
 import reframe.utility.osext as osext
 from reframe.core.backends import register_scheduler
-from reframe.core.exceptions import JobSchedulerError
+from reframe.core.exceptions import JobSchedulerError, SpawnedProcessError
 from reframe.core.schedulers.pbs import PbsJobScheduler
 
 _run_strict = functools.partial(osext.run_command, check=True)
@@ -151,3 +152,11 @@ class LsfJobScheduler(PbsJobScheduler):
             raise job.exception
 
         return job.state == 'COMPLETED'
+
+    @classmethod
+    def validate(cls) -> Union[str, bool]:
+        try:
+            _run_strict('which bsub')
+            return cls.registered_name
+        except SpawnedProcessError:
+            return False

--- a/reframe/core/schedulers/ssh.py
+++ b/reframe/core/schedulers/ssh.py
@@ -3,13 +3,17 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+import functools
 import os
 import time
+from typing import Union
 
 import reframe.utility.osext as osext
 from reframe.core.backends import register_scheduler
 from reframe.core.exceptions import ConfigError, SpawnedProcessError
 from reframe.core.schedulers import Job, JobScheduler, AlwaysIdleNode
+
+_run_strict = functools.partial(osext.run_command, check=True)
 
 
 class _SSHJob(Job):
@@ -229,3 +233,21 @@ class SSHJobScheduler(JobScheduler):
                 return [AlwaysIdleNode(host)]
         else:
             return [AlwaysIdleNode(h) for h in self._free_hosts]
+
+    def feats_access_option(self, node_feats):
+        raise NotImplementedError(
+            'ssh backend does not support configuration autodetection'
+        )
+
+    def build_context(self, node_feats):
+        raise NotImplementedError(
+            'ssh backend does not support configuration autodetection'
+        )
+
+    @classmethod
+    def validate(cls) -> Union[str, bool]:
+        try:
+            _run_strict('which ssh')
+            return cls.registered_name
+        except SpawnedProcessError:
+            return False

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -438,6 +438,12 @@ def main():
         help=('Detect the local host topology and exit, '
               'optionally saving it in FILE')
     )
+    # CONFIGURATION
+    action_options.add_argument(
+        '--detect-configuration', metavar='FILE', action='store',
+        help=('Detect the configuration of the system. The content '
+              'in FILE must call the detect_config method from core/config')
+    )
     action_options.add_argument(
         '--dry-run', action='store_true',
         help='Dry run the tests without submitting them for execution'
@@ -871,6 +877,13 @@ def main():
     printer.colorize = site_config.get('general/0/colorize')
     if not restrict_logging():
         printer.adjust_verbosity(calc_verbosity(site_config, options.quiet))
+
+    if options.detect_configuration:
+        runtime.init_runtime(site_config)
+        site_config = config.load_config(
+            options.detect_configuration, validate=False
+        )
+        sys.exit(0)
 
     # Now configure ReFrame according to the user configuration file
     try:

--- a/reframe/schemas/reframe_config_template.j2
+++ b/reframe/schemas/reframe_config_template.j2
@@ -1,0 +1,74 @@
+# Copyright 2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# ReFrame Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# This is a generated ReFrame configuration file
+# The values in this file are dynamically filled in using the system's current configuration
+
+site_configuration = {
+    'systems': [
+        {
+            'name': '{{ name }}',  # Name of the system
+            'descr': 'System description for {{ name }}',  # Description of the system
+            'hostnames': {{hostnames}},  # Hostname used by this system
+            'modules_system': '{{modules_system}}',
+            {% if modules %}
+            # Specify the modules to be loaded in the system when running reframe (if any)
+            # https://reframe-hpc.readthedocs.io/en/stable/config_reference.html#config.systems.modules
+            'modules': {{ modules }},
+            {% endif %}
+            {% if resourcesdir %}
+            # https://reframe-hpc.readthedocs.io/en/stable/config_reference.html#config.systems.resourcesdir
+            'resourcesdir': '{{ resourcesdir }}',  # Directory path for system resources
+            {% endif %}
+            # Define the partitions of the system (based on node type or reservations)
+            # !!Partition autodetection is only available for the slurm scheduler
+            'partitions': [
+                {% for partition in partitions %}
+                {
+                    'name': '{{partition.name}}',
+                    'descr': '{{partition.descr}}',
+                    'launcher': '{{partition.launcher}}', # Launcher for parallel jobs
+                    'environs': {{partition.environs}},   # Check 'environments' config below
+                    'scheduler': '{{partition.scheduler}}',
+                    'time_limit': '{{partition.time_limit}}',
+                    'max_jobs': {{partition.max_jobs}},
+                    {% if partition.features | length > 1 %}
+                    # https://reframe-hpc.readthedocs.io/en/stable/config_reference.html#config.systems.partitions.extras
+                    'extras': {{partition.extras}},
+                    # https://reframe-hpc.readthedocs.io/en/stable/config_reference.html#config.systems.partitions.env_vars
+                    'env_vars': {{partition.env_vars}},
+                    {% if partition.container_platforms %}
+                    # Check if any container platforms are available in these nodes and add them
+                    # https://reframe-hpc.readthedocs.io/en/stable/config_reference.html#container-platform-configuration
+                    'container_platforms': [
+                    {% for c_p in partition.container_platforms %}
+                        { 'type': '{{c_p.type}}', # Type of container platform
+                        {% if c_p.modules %}
+                        # Specify here the modules required to run the container platforms (if any)
+                          'modules': {{c_p.modules}}
+                        {% endif %}
+                        },
+                    {% endfor %}
+                    ],
+                    {% endif %}
+                    {% endif %}
+                    {% if partition.access %}
+                    # Options passed to the job scheduler in order to submit a job to the specific nodes in this partition
+                    'access': {{partition.access}},
+                    {% endif %}
+                    {% if partition.features %}
+                    # Node features detected in slurm
+                    'features': {{partition.features}},
+                    {% endif %}
+                },
+                {% endfor %}
+            ],
+        },
+    ],
+    # The environments cannot be automatically detected, check the following links for reference
+    # 'https://github.com/eth-cscs/cscs-reframe-tests/tree/alps/config/systems': CSCS github repo
+    # 'https://reframe-hpc.readthedocs.io/en/stable/config_reference.html#environment-configuration': ReFrame documentation
+    'environments': []
+}

--- a/reframe/utility/config_detection.py
+++ b/reframe/utility/config_detection.py
@@ -1,0 +1,103 @@
+# Copyright 2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# ReFrame Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+containers_detect_bash = '''
+# List of containers to check
+CONTAINERS=(
+    "Sarus:sarus"
+    "Apptainer:apptainer"
+    "Docker:docker"
+    "Singularity:singularity"
+    "Shifter:shifter"
+)
+
+# Array to hold installed containers
+installed=()
+
+# Function to check for module existence (with lmod)
+check_module_spider() {
+    output=$(module spider "$1" 2>&1)
+    if echo $output | grep -q "error"; then
+        return 1
+    else
+        return 0
+    fi
+}
+
+# Function to check for module existence (with tmod)
+check_module_avail() {
+    output=$(module avail "$1" 2>&1)
+    if echo $output | grep -q "$1"; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+check_lmod() {
+    if [[ -n "$LMOD_CMD" ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+check_tmod() {
+    if [[ -n "modulecmd -V" ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Check each container command
+for container in "${CONTAINERS[@]}"; do
+    IFS=":" read -r name cmd <<< "$container"
+
+    # Check if the command exists via 'which'
+    found_via_command=false
+    found_via_module=false
+
+    if which "$cmd" > /dev/null 2>&1; then
+        found_via_command=true
+    fi
+
+    if check_lmod; then
+        # Check if it is available as a module, regardless of 'which' result
+        if check_module_spider "$cmd"; then
+            output=$(module spider "$cmd" 2>&1)
+            modules_load=$(echo $output | grep -oP '\
+                (?<=available to load.).*?(?= Help)')
+            found_via_module=true
+        fi
+    fi
+
+    if check_tmod; then
+        # Check if it is available as a module, regardless of 'which' result
+        if check_module_avail "$cmd"; then
+            output=$(module avail "$cmd" 2>&1)
+            modules_load=""
+            found_via_module=true
+        fi
+    fi
+
+    # Determine the status of the container
+    if $found_via_command && $found_via_module; then
+        installed+=("$name modules: $modules_load")
+    elif $found_via_command; then
+        installed+=("$name")
+    elif $found_via_module; then
+        installed+=("$name modules: $modules_load")
+    else
+        echo "$name is not installed."
+    fi
+done
+
+# Output installed containers
+echo "Installed containers:"
+for name in "${installed[@]}"; do
+    echo "$name"
+done
+'''

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,14 @@
 archspec==0.2.5
 argcomplete==3.1.2; python_version < '3.8'
 argcomplete==3.5.1; python_version >= '3.8'
+autopep8==2.0.4
 filelock==3.4.1; python_version == '3.6'
 filelock==3.12.2; python_version == '3.7'
 filelock==3.16.1; python_version >= '3.8'
 importlib_metadata==4.0.1; python_version < '3.8'
 jsonschema==3.2.0
+jinja2==3.0; python_version < '3.7'
+jinja2==3.1.2; python_version >= '3.7'
 lxml==5.2.0; python_version < '3.8' and platform_machine == 'aarch64'
 lxml==5.3.0; python_version >= '3.8' or platform_machine != 'aarch64'
 pytest==7.0.1; python_version < '3.8'

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,9 +29,11 @@ install_requires =
     archspec >= 0.2.4
     argcomplete
     argcomplete <= 3.1.2; python_version < '3.8'
+    autopep8
     filelock
     filelock<=3.12.2; python_version == '3.7'
     filelock<=3.4.1; python_version == '3.6'
+    jinja2
     jsonschema
     lxml==5.2.0; python_version < '3.8' and platform_machine == 'aarch64'
     lxml==5.3.0; python_version >= '3.8' or platform_machine != 'aarch64'

--- a/unittests/test_launchers.py
+++ b/unittests/test_launchers.py
@@ -56,7 +56,19 @@ def make_job():
         def filternodes(self, job, nodes):
             pass
 
+        def feats_access_option(self, node_feats):
+            pass
+
+        def build_context(self, modules_system, launcher,
+                          exclude_feats, detect_containers,
+                          prefix, sched_options, time_limit):
+            pass
+
         def poll(self, *jobs):
+            pass
+
+        @classmethod
+        def validate(cls):
             pass
 
     def _make_job(launcher, *args, **kwargs):


### PR DESCRIPTION
This PR introduces the option of detecting the system configuration automatically and writing the corresponding ReFrame config file. 

- The system's partitions are created based on the node features detected with **Slurm** .
- It is only implemented for Slurm
- ReFrame must be run with the **new action option**: `reframe --detect-configuration=autodetect_config.py` (an example of the `autodetect_config.py` is included). In the `detect_config()` the optional arguments are 

1. `detect_containers`: submits jobs to each partition to detect container platforms
2. `sched_options`: additional scheduler access options that must be included for all partitions
3. `time_limit`: time limit for the remote detection jobs (container platforms)
4. `exclude_feats`: node features to be ignored in the filtering of the nodes to determine the partitions, patterns like `row*` are accepted
5. `filename`: name of the configuration file that will be generated

- For the job submissions, a shared directory with the compute nodes must/can be specified using the `RFM_REMOTE_WORKDIR`

Ideas/todo's

- [ ] Move the detection of _container platforms_ in the remote partitions to `--detect-topology`
- [ ] Combine the configuration detection with  `reframe --detect-topology`
- [x] Fix tests
- [ ] Add documentation
- [ ] Add unit tests