### PR TITLE
[enhancement] Prefix special (generated) parameters with `.` instead of `$`

### DIFF
--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -1043,7 +1043,7 @@ The way the tests are generated and how they interact with the test filtering op
 
    Parameterize a test on an existing variable.
 
-   This option will create a new test with a parameter named ``$VAR`` with the values given in the comma-separated list ``VAL0,VAL1,...``.
+   The test will behave as if the variable ``VAR`` was a paramter taking the values ``VAL0,VAL1,...``.
    The values will be converted based on the type of the target variable ``VAR``.
    The ``TEST.`` prefix will only parameterize the variable ``VAR`` of test ``TEST``.
 

--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -1043,7 +1043,7 @@ The way the tests are generated and how they interact with the test filtering op
 
    Parameterize a test on an existing variable.
 
-   The test will behave as if the variable ``VAR`` was a paramter taking the values ``VAL0,VAL1,...``.
+   The test will behave as if the variable ``VAR`` was a parameter taking the values ``VAL0,VAL1,...``.
    The values will be converted based on the type of the target variable ``VAR``.
    The ``TEST.`` prefix will only parameterize the variable ``VAR`` of test ``TEST``.
 

--- a/reframe/frontend/testgenerators.py
+++ b/reframe/frontend/testgenerators.py
@@ -77,12 +77,12 @@ def _generate_tests(testcases, gen_fn):
 @time_function
 def distribute_tests(testcases, node_map):
     def _rfm_pin_run_nodes(obj):
-        nodelist = getattr(obj, '$nid')
+        nodelist = getattr(obj, '.nid')
         if not obj.local:
             obj.job.pin_nodes = nodelist
 
     def _rfm_pin_build_nodes(obj):
-        pin_nodes = getattr(obj, '$nid')
+        pin_nodes = getattr(obj, '.nid')
         if obj.build_job and not obj.local and not obj.build_locally:
             obj.build_job.pin_nodes = pin_nodes
 
@@ -99,9 +99,9 @@ def distribute_tests(testcases, node_map):
                 'valid_systems': [partition.fullname],
                 # We add a partition parameter so as to differentiate the test
                 # in case another test has the same nodes in another partition
-                '$part': builtins.parameter([partition.fullname],
+                '.part': builtins.parameter([partition.fullname],
                                             loggable=False),
-                '$nid': builtins.parameter(
+                '.nid': builtins.parameter(
                     [[n] for n in node_map[partition.fullname]],
                     fmt=util.nodelist_abbrev, loggable=False
                 )
@@ -113,7 +113,7 @@ def distribute_tests(testcases, node_map):
                 # will not be overwritten by a parent post-init hook
                 builtins.run_after('init')(_rfm_set_valid_systems),
             ]
-        ), ['$part', '$nid']
+        ), ['.part', '.nid']
 
     return _generate_tests(testcases, _make_dist_test)
 
@@ -127,10 +127,10 @@ def repeat_tests(testcases, num_repeats):
         return make_test(
             cls.__name__, (cls,),
             {
-                '$repeat_no': builtins.parameter(range(num_repeats),
+                '.repeat_no': builtins.parameter(range(num_repeats),
                                                  loggable=False)
             }
-        ), ['$repeat_no']
+        ), ['.repeat_no']
 
     return _generate_tests(testcases, _make_repeat_test)
 
@@ -164,7 +164,7 @@ def parameterize_tests(testcases, paramvars):
                 )
                 continue
 
-            body[f'${var}'] = builtins.parameter(values, loggable=False)
+            body[f'.{var}'] = builtins.parameter(values, loggable=False)
 
         def _set_vars(self):
             for var in body.keys():

--- a/unittests/test_testgenerators.py
+++ b/unittests/test_testgenerators.py
@@ -51,7 +51,7 @@ def test_distribute_testcases(sys0_exec_ctx):
 
     nodelist_iter = sys0p0_nodes()
     for tc in new_cases:
-        nodes = getattr(tc.check, '$nid')
+        nodes = getattr(tc.check, '.nid')
         if tc.partition.fullname == 'sys0:p0':
             assert nodes == next(nodelist_iter)
         else:


### PR DESCRIPTION
The problem with `$` is two-fold: it has a special meaning both for shells and for the regex pattern, so it makes it tricky to select a generated test's name with `-n`. 