### PR TITLE
[bugfix] Fix relative imports in deeply nested tests

### DIFF
--- a/reframe/frontend/loader.py
+++ b/reframe/frontend/loader.py
@@ -193,17 +193,31 @@ class RegressionCheckLoader:
 
         try:
             dirname = os.path.dirname(filename)
-            with osext.change_dir(dirname):
-                with util.temp_sys_path(dirname):
-                    if os.path.exists(os.path.join(dirname, '__init__.py')):
-                        # If the containing directory is a package,
-                        # import it, too.
-                        parent = util.import_module_from_file(dirname).__name__
-                    else:
-                        parent = None
 
+            # Load all parent modules of test file
+            parents = []
+            while os.path.exists(os.path.join(dirname, '__init__.py')):
+                parents.append(os.path.join(dirname))
+                dirname = os.path.split(dirname)[0]
+
+            parent_module = None
+            for pdir in reversed(parents):
+                with osext.change_dir(pdir):
+                    with util.temp_sys_path(pdir):
+                        package_path = os.path.join(pdir, '__init__.py')
+                        parent_module = util.import_module_from_file(
+                            package_path, parent=parent_module
+                        ).__name__
+
+            # Now load the actual test file
+            if not parents:
+                pdir = dirname
+
+            with osext.change_dir(pdir):
+                with util.temp_sys_path(pdir):
                     return self.load_from_module(
-                        util.import_module_from_file(filename, force, parent)
+                        util.import_module_from_file(filename, force,
+                                                     parent_module)
                     )
         except Exception:
             exc_info = sys.exc_info()

--- a/unittests/resources/checks_unlisted/testlib/nested/dummy.py
+++ b/unittests/resources/checks_unlisted/testlib/nested/dummy.py
@@ -1,0 +1,17 @@
+# Copyright 2016-2024 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# ReFrame Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import reframe as rfm
+import reframe.utility.sanity as sn
+from ..utility import dummy_fixture
+
+
+@rfm.simple_test
+class dummy_test(rfm.RunOnlyRegressionTest):
+    valid_systems = ['*']
+    valid_prog_environs = ['*']
+    executable = 'true'
+    sanity_patterns = sn.assert_true(1)
+    dummy = fixture(dummy_fixture)

--- a/unittests/resources/checks_unlisted/testlib/simple.py
+++ b/unittests/resources/checks_unlisted/testlib/simple.py
@@ -16,7 +16,7 @@ class simple_echo_check(rfm.RunOnlyRegressionTest, pin_prefix=True):
     executable = 'echo'
     executable_opts = ['Hello']
     message = variable(str, value='World')
-    dummy = fixture(dummy_fixture, scope='environment')
+    dummy = fixture(dummy_fixture)
 
     @run_before('run')
     def set_executable_opts(self):

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -1263,7 +1263,7 @@ def test_testlib_inherit_fixture_in_different_files(run_reframe):
         action='run',
     )
     assert returncode == 0
-    assert 'Ran 3/3 test case(s)' in stdout
+    assert 'Ran 4/4 test case(s)' in stdout
     assert 'FAILED' not in stdout
 
 

--- a/unittests/test_loader.py
+++ b/unittests/test_loader.py
@@ -154,3 +154,9 @@ def test_relative_import_outside_rfm_prefix(loader, tmp_path):
     )
     tests = loader.load_from_file(str(tmp_path / 'testlib' / 'simple.py'))
     assert len(tests) == 2
+
+    # Test nested library tests
+    tests = loader.load_from_file(
+        str(tmp_path / 'testlib' / 'nested' / 'dummy.py')
+    )
+    assert len(tests) == 2


### PR DESCRIPTION
This is practically a follow up of #3110 by fixing relative imports of deeply nested tests. Currently, given the following structure:

```console
unittests/resources/checks_unlisted/testlib/
├── __init__.py
├── nested
│   ├── __init__.py
│   └── dummy.py
├── simple.py
└── utility
    └── __init__.py
```

the following import in  `nested/dummy.py` will crash:

```python
from ..utility import dummy_fixture
```