### PR TITLE
[bugfix] Fix nodelist abbreviation when last node number is a multiple of 10

### DIFF
--- a/reframe/utility/__init__.py
+++ b/reframe/utility/__init__.py
@@ -866,7 +866,7 @@ def count_digits(n):
     '''
 
     num_digits = 1
-    while n > 10:
+    while n >= 10:
         n /= 10
         num_digits += 1
 

--- a/unittests/test_utility.py
+++ b/unittests/test_utility.py
@@ -2070,6 +2070,14 @@ def test_nodelist_utilities():
     assert nodelist(nodes) == 'nid0[00-99]-x,nid100-y'
     assert expand('nid0[00-99]-x,nid100-y') == nodes
 
+    # Test edge condition when node lists jump from N to N+1 digits
+    # See GH issue #3338
+    nodes = ['vs-std-0009', 'vs-std-0010', 'vs-std-0099', 'vs-std-0100']
+    assert nodelist(nodes) == 'vs-std-00[09-10],vs-std-0[099-100]'
+    assert expand('vs-std-00[09-10],vs-std-0[099-100]') == [
+        'vs-std-0009', 'vs-std-0010', 'vs-std-0099', 'vs-std-0100'
+    ]
+
     # Test node duplicates
     assert nodelist(['nid001', 'nid001', 'nid002']) == 'nid001,nid00[1-2]'
     assert expand('nid001,nid00[1-2]') == ['nid001', 'nid001', 'nid002']


### PR DESCRIPTION
Closes #3338.