### PR TITLE
[ci] Update GH actions for Python 3.7 after the move of runners to Ubuntu 24.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -33,6 +33,24 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.6']
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies and docs
+      run: |
+        ./bootstrap.sh +docs
+    - name: Generic Unittests
+      run: |
+        ./test_reframe.py
+
+  unittest-py37:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        python-version: ['3.7']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -120,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
       - name: Setup up Python ${{ matrix.python-version }}
@@ -143,7 +161,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
GH actions move Ubuntu latest to 24.04 where Python 3.7 is not available. So I am creating a new GH action for that, exactly as we do for Python 3.6. 

For `docvalidation` and `wheelvalidation` I'm simply removing Python 3.7.