### PR TITLE
[bugfix] Fix treatment of Slurm constraints in `job.options` and system partition's `access` parameter

### DIFF
--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -234,7 +234,7 @@ class SlurmJobScheduler(sched.JobScheduler):
                 job._cli_options = other_cli_opts
 
             arg = '&'.join(f'({c.strip()})' for c in constraints)
-            job._sched_access = [f'--constraint={arg}']
+            job._sched_access = [f'--constraint={arg}'] + access_other
 
         if not self._sched_access_in_submit:
             for opt in job.sched_access:
@@ -244,8 +244,10 @@ class SlurmJobScheduler(sched.JobScheduler):
         prefix_patt = re.compile(r'(#\w+)')
         for opt in job.options + job.cli_options:
             if opt.strip().startswith(('-C', '--constraint')):
-                # Constraints are already processed
-                continue
+                if access.constraint:
+                    # Constraints are already combined with the `sched_access`
+                    # and processed
+                    continue
 
             if not prefix_patt.match(opt):
                 preamble.append('%s %s' % (self._prefix, opt))


### PR DESCRIPTION
This PR fixes a couple of bugs introduced in ReFrame 4.7 and more specifically in 4.7.0-dev.2

Unit tests that reproduce both bugs are added.

Fixes #3348
Fixes #3349 