### PR TITLE
[bugfix] Check response status in the `httpjson` log handler and retry in case of `TOO_MANY_REQUESTS`

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -1603,9 +1603,9 @@ This handler transmits the whole log record, meaning that all the information wi
 
    .. versionadded:: 4.1
 
-.. py:attribute:: logging.handlers_perflog..httpjson..sleep_times
+.. py:attribute:: logging.handlers_perflog..httpjson..sleep_intervals
 
-   In the case that the http request gets a response 429 (TOO_MANY_REQUESTS), Reframe will cycle over this list of sleep times until it succeeds, gets a different code or exceeds the timeout (when it is set).
+   In the case that the http request gets a response 429 (TOO_MANY_REQUESTS), Reframe will cycle over this list of sleep waiting intervals until it gets a different code or exceeds the timeout (when it is set).
 
    .. versionadded:: 4.7.3
 

--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -1603,19 +1603,24 @@ This handler transmits the whole log record, meaning that all the information wi
 
    .. versionadded:: 4.1
 
-.. py:attribute:: logging.handlers_perflog..httpjson..sleep_intervals
 
-   In the case that the http request gets a response 429 (TOO_MANY_REQUESTS), Reframe will cycle over this list of sleep waiting intervals until it gets a different code or exceeds the timeout (when it is set).
+.. py:attribute:: logging.handlers_perflog..httpjson..backoff_intervals
+
+   List of wait intervals in seconds when server responds with HTTP error 429 (``TOO_MANY_REQUESTS``).
+
+   In this case, ReFrame will retry contacting the server after waiting an amount of time that is determined by cyclically iterating this list of intervals.
+
+   ReFrame will keep trying contacting the server, until a different HTTP resonse is received (either success or error) or the corresponding :attr:`~config.logging.handlers_perflog..httpjson..timeout` is exceeded.
 
    .. versionadded:: 4.7.3
+
 
 .. py:attribute:: logging.handlers_perflog..httpjson..timeout
 
-   In the case that the http request gets a response 429 (TOO_MANY_REQUESTS), Reframe will keep trying until it succeeds, gets a different error or exceeds the timeout (in seconds).
-   When this parameter is set to 0, Reframe will keep retrying until it gets a different status code.
+   Timeout in seconds for retrying when server responds with HTTP error 429 (``TOO_MANY_REQUESTS``).
+
 
    .. versionadded:: 4.7.3
-
 
 
 .. _exec-mode-config:

--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -1606,6 +1606,9 @@ This handler transmits the whole log record, meaning that all the information wi
 
 .. py:attribute:: logging.handlers_perflog..httpjson..backoff_intervals
 
+   :required: No
+   :default: ``[0.1, 0.2, 0.4, 0.8, 1.6, 3.2]``
+
    List of wait intervals in seconds when server responds with HTTP error 429 (``TOO_MANY_REQUESTS``).
 
    In this case, ReFrame will retry contacting the server after waiting an amount of time that is determined by cyclically iterating this list of intervals.
@@ -1615,9 +1618,14 @@ This handler transmits the whole log record, meaning that all the information wi
    .. versionadded:: 4.7.3
 
 
-.. py:attribute:: logging.handlers_perflog..httpjson..timeout
+.. py:attribute:: logging.handlers_perflog..httpjson..retry_timeout
+
+   :required: No
+   :default: ``0``
 
    Timeout in seconds for retrying when server responds with HTTP error 429 (``TOO_MANY_REQUESTS``).
+
+   If set to zero, ReFrame will retry until another HTTP response (success or error) is received.
 
 
    .. versionadded:: 4.7.3

--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -1603,6 +1603,19 @@ This handler transmits the whole log record, meaning that all the information wi
 
    .. versionadded:: 4.1
 
+.. py:attribute:: logging.handlers_perflog..httpjson..sleep_times
+
+   In the case that the http request gets a response 429 (TOO_MANY_REQUESTS), Reframe will cycle over this list of sleep times until it succeeds, gets a different code or exceeds the timeout (when it is set).
+
+   .. versionadded:: 4.7.3
+
+.. py:attribute:: logging.handlers_perflog..httpjson..timeout
+
+   In the case that the http request gets a response 429 (TOO_MANY_REQUESTS), Reframe will keep trying until it succeeds, gets a different error or exceeds the timeout (in seconds).
+   When this parameter is set to 0, Reframe will keep retrying until it gets a different status code.
+
+   .. versionadded:: 4.7.3
+
 
 
 .. _exec-mode-config:

--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import abc
+import itertools
 import logging
 import logging.handlers
 import numbers
@@ -688,20 +689,21 @@ class HTTPJSONHandler(logging.Handler):
             return
 
         try:
+            sleep_times = itertools.cycle([.1, .2, .4, .8, 1.6, 3.2])
             while True:
                 response = requests.post(
                     self._url, data=json_record,
                     headers=self._headers
                 )
-                if response.status_code == 200:
+                if response.ok:
                     break
 
                 if response.status_code == 429:
-                    time.sleep(1)
+                    time.sleep(next(sleep_times))
                     continue
 
                 raise LoggingError(
-                    f'logging failed: HTTP response code '
+                    f'HTTPJSONhandler logging failed: HTTP response code '
                     f'{response.status_code}'
                 )
         except requests.exceptions.RequestException as e:

--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -680,7 +680,6 @@ class HTTPJSONHandler(logging.Handler):
             return
 
         if self._debug:
-            import time
             ts = int(time.time() * 1_000)
             dump_file = f'httpjson_record_{ts}.json'
             with open(dump_file, 'w') as fp:

--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -689,11 +689,18 @@ class HTTPJSONHandler(logging.Handler):
             return
 
         try:
-            response = requests.post(
-                self._url, data=json_record,
-                headers=self._headers
-            )
-            if response.status_code != 200:
+            while True:
+                response = requests.post(
+                    self._url, data=json_record,
+                    headers=self._headers
+                )
+                if response.status_code == 200:
+                    break
+
+                if response.status_code == 429:
+                    time.sleep(1)
+                    continue
+
                 raise LoggingError(
                     f'logging failed: HTTP response code '
                     f'{response.status_code}'

--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -555,7 +555,7 @@ def _create_httpjson_handler(site_config, config_prefix):
     json_formatter = site_config.get(f'{config_prefix}/json_formatter')
     extra_headers = site_config.get(f'{config_prefix}/extra_headers')
     debug = site_config.get(f'{config_prefix}/debug')
-    sleep_times = site_config.get(f'{config_prefix}/sleep_times')
+    sleep_intervals = site_config.get(f'{config_prefix}/sleep_intervals')
     timeout = site_config.get(f'{config_prefix}/timeout')
 
     parsed_url = urllib.parse.urlparse(url)
@@ -598,7 +598,7 @@ def _create_httpjson_handler(site_config, config_prefix):
                             'no data will be sent to the server')
 
     return HTTPJSONHandler(url, extras, ignore_keys, json_formatter,
-                           extra_headers, debug, sleep_times, timeout)
+                           extra_headers, debug, sleep_intervals, timeout)
 
 
 def _record_to_json(record, extras, ignore_keys):
@@ -648,7 +648,7 @@ class HTTPJSONHandler(logging.Handler):
 
     def __init__(self, url, extras=None, ignore_keys=None,
                  json_formatter=None, extra_headers=None,
-                 debug=False, sleep_times=[.1, .2, .4, .8, 1.6, 3.2],
+                 debug=False, sleep_intervals=[.1, .2, .4, .8, 1.6, 3.2],
                  timeout=0):
         super().__init__()
         self._url = url
@@ -674,7 +674,7 @@ class HTTPJSONHandler(logging.Handler):
 
         self._debug = debug
         self._timeout = timeout
-        self._sleep_times = sleep_times
+        self._sleep_intervals = sleep_intervals
 
     def emit(self, record):
         # Convert tags to a list to make them JSON friendly
@@ -695,7 +695,7 @@ class HTTPJSONHandler(logging.Handler):
 
         timeout_time = time.time() + self._timeout
         try:
-            sleep_times = itertools.cycle(self._sleep_times)
+            sleep_intervals = itertools.cycle(self._sleep_intervals)
             while True:
                 response = requests.post(
                     self._url, data=json_record,
@@ -711,7 +711,7 @@ class HTTPJSONHandler(logging.Handler):
                         time.time() < timeout_time
                     )
                 ):
-                    time.sleep(next(sleep_times))
+                    time.sleep(next(sleep_intervals))
                     continue
 
                 raise LoggingError(

--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -689,10 +689,15 @@ class HTTPJSONHandler(logging.Handler):
             return
 
         try:
-            requests.post(
+            response = requests.post(
                 self._url, data=json_record,
                 headers=self._headers
             )
+            if response.status_code != 200:
+                raise LoggingError(
+                    f'logging failed: HTTP response code '
+                    f'{response.status_code}'
+                )
         except requests.exceptions.RequestException as e:
             raise LoggingError('logging failed') from e
 

--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -556,7 +556,7 @@ def _create_httpjson_handler(site_config, config_prefix):
     extra_headers = site_config.get(f'{config_prefix}/extra_headers')
     debug = site_config.get(f'{config_prefix}/debug')
     backoff_intervals = site_config.get(f'{config_prefix}/backoff_intervals')
-    timeout = site_config.get(f'{config_prefix}/timeout')
+    retry_timeout = site_config.get(f'{config_prefix}/retry_timeout')
 
     parsed_url = urllib.parse.urlparse(url)
     if parsed_url.scheme not in {'http', 'https'}:
@@ -598,7 +598,8 @@ def _create_httpjson_handler(site_config, config_prefix):
                             'no data will be sent to the server')
 
     return HTTPJSONHandler(url, extras, ignore_keys, json_formatter,
-                           extra_headers, debug, backoff_intervals, timeout)
+                           extra_headers, debug, backoff_intervals,
+                           retry_timeout)
 
 
 def _record_to_json(record, extras, ignore_keys):
@@ -648,7 +649,7 @@ class HTTPJSONHandler(logging.Handler):
 
     def __init__(self, url, extras=None, ignore_keys=None,
                  json_formatter=None, extra_headers=None,
-                 debug=False, backoff_intervals=(1, 2, 3), timeout=0):
+                 debug=False, backoff_intervals=(1, 2, 3), retry_timeout=0):
         super().__init__()
         self._url = url
         self._extras = extras
@@ -672,7 +673,7 @@ class HTTPJSONHandler(logging.Handler):
             self._headers.update(extra_headers)
 
         self._debug = debug
-        self._timeout = timeout
+        self._timeout = retry_timeout
         self._backoff_intervals = backoff_intervals
 
     def emit(self, record):

--- a/reframe/frontend/executors/__init__.py
+++ b/reframe/frontend/executors/__init__.py
@@ -20,9 +20,10 @@ import reframe.frontend.dependencies as dependencies
 import reframe.utility.jsonext as jsonext
 import reframe.utility.typecheck as typ
 from reframe.core.exceptions import (AbortTaskError,
-                                     JobNotStartedError,
                                      FailureLimitError,
                                      ForceExitError,
+                                     JobNotStartedError,
+                                     LoggingError,
                                      RunSessionTimeout,
                                      SkipTestError,
                                      StatisticsError,
@@ -480,8 +481,13 @@ class RegressionTask:
 
         self._current_stage = 'finalize'
         self._notify_listeners('on_task_success')
-        self._perflogger.log_performance(logging.INFO, self,
-                                         multiline=self._perflog_compat)
+        try:
+            self._perflogger.log_performance(logging.INFO, self,
+                                             multiline=self._perflog_compat)
+        except LoggingError as e:
+            logging.getlogger().warning(
+                f'could not log performance data for {self.testcase}: {e}'
+            )
 
     @logging.time_function
     def cleanup(self, *args, **kwargs):
@@ -491,8 +497,13 @@ class RegressionTask:
         self._failed_stage = self._current_stage
         self._exc_info = exc_info or sys.exc_info()
         self._notify_listeners(callback)
-        self._perflogger.log_performance(logging.INFO, self,
-                                         multiline=self._perflog_compat)
+        try:
+            self._perflogger.log_performance(logging.INFO, self,
+                                             multiline=self._perflog_compat)
+        except LoggingError as e:
+            logging.getlogger().warning(
+                f'could not log performance data for {self.testcase}: {e}'
+            )
 
     def skip(self, exc_info=None):
         self._skipped = True

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -173,7 +173,12 @@
                         },
                         "json_formatter": {},
                         "extra_headers": {"type": "object"},
-                        "debug": {"type": "boolean"}
+                        "debug": {"type": "boolean"},
+                        "sleep_times": {
+                            "type": "array",
+                            "items": {"type": "number"}
+                        },
+                        "timeout": {"type": "number"}
                     },
                     "required": ["url"]
                 }
@@ -632,6 +637,8 @@
         "logging/handlers_perflog/httpjson_json_formatter": null,
         "logging/handlers_perflog/httpjson_extra_headers": {},
         "logging/handlers_perflog/httpjson_debug": false,
+        "logging/handlers_perflog/httpjson_sleep_times": [0.1, 0.2, 0.4, 0.8, 1.6, 3.2],
+        "logging/handlers_perflog/httpjson_timeout": 0,
         "modes/options": [],
         "modes/target_systems": ["*"],
         "storage/enable": false,

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -174,11 +174,11 @@
                         "json_formatter": {},
                         "extra_headers": {"type": "object"},
                         "debug": {"type": "boolean"},
-                        "sleep_intervals": {
+                        "backoff_intervals": {
                             "type": "array",
                             "items": {"type": "number"}
                         },
-                        "timeout": {"type": "number"}
+                        "retry_timeout": {"type": "number"}
                     },
                     "required": ["url"]
                 }
@@ -637,8 +637,8 @@
         "logging/handlers_perflog/httpjson_json_formatter": null,
         "logging/handlers_perflog/httpjson_extra_headers": {},
         "logging/handlers_perflog/httpjson_debug": false,
-        "logging/handlers_perflog/httpjson_sleep_intervals": [0.1, 0.2, 0.4, 0.8, 1.6, 3.2],
-        "logging/handlers_perflog/httpjson_timeout": 0,
+        "logging/handlers_perflog/httpjson_backoff_intervals": [0.1, 0.2, 0.4, 0.8, 1.6, 3.2],
+        "logging/handlers_perflog/httpjson_retry_timeout": 0,
         "modes/options": [],
         "modes/target_systems": ["*"],
         "storage/enable": false,

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -174,7 +174,7 @@
                         "json_formatter": {},
                         "extra_headers": {"type": "object"},
                         "debug": {"type": "boolean"},
-                        "sleep_times": {
+                        "sleep_intervals": {
                             "type": "array",
                             "items": {"type": "number"}
                         },
@@ -637,7 +637,7 @@
         "logging/handlers_perflog/httpjson_json_formatter": null,
         "logging/handlers_perflog/httpjson_extra_headers": {},
         "logging/handlers_perflog/httpjson_debug": false,
-        "logging/handlers_perflog/httpjson_sleep_times": [0.1, 0.2, 0.4, 0.8, 1.6, 3.2],
+        "logging/handlers_perflog/httpjson_sleep_intervals": [0.1, 0.2, 0.4, 0.8, 1.6, 3.2],
         "logging/handlers_perflog/httpjson_timeout": 0,
         "modes/options": [],
         "modes/target_systems": ["*"],


### PR DESCRIPTION
Reopening https://github.com/reframe-hpc/reframe/pull/3354 on a branch based on master.
Fixes https://github.com/reframe-hpc/reframe/issues/3353 .