### PR TITLE
[enhancement] Report all failed performance variables in `FAILURE INFO`

### DIFF
--- a/reframe/frontend/printer.py
+++ b/reframe/frontend/printer.py
@@ -161,7 +161,8 @@ class PrettyPrinter:
 
             self.info(f"  * Reason: {msg}")
             tb = ''.join(traceback.format_exception(
-                *rec['fail_info'].values()))
+                *rec['fail_info'].values())
+            )
             if rec['fail_severe']:
                 self.info(tb)
             else:


### PR DESCRIPTION
In case of a single failing performance variable the output doesn't change. If multiple are failing, this are listed in separate lines as follows:

```
  * Reason: performance error: failed to meet references:
	bw1=92 GB/s, expected 190 (l=180.5, u=199.5)
	bw2=58 GB/s, expected 190 (l=184.3, u=195.7)
	bw3=92 GB/s, expected 190 (l=186.2, u=193.8)
```