### PR TITLE
[bugfix] Treat a node in `PLANNED` Slurm state as available

### DIFF
--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -706,7 +706,8 @@ class _SlurmNode(sched.Node):
             'ALLOCATED',
             'COMPLETING',
             'IDLE',
-            'RESERVED',
+            'PLANNED',
+            'RESERVED'
         }
         return self._states <= available_states
 


### PR DESCRIPTION
A node is put in `PLANNED` state by the backfill plugin. Currently, ReFrame will treat such node as unavailable causing it to cancel a pending job requesting such node if `RFM_IGNORE_REQNODENOTAVAIL` is not set (default).

Related to #303 and #1049.