### PR TITLE
[bugfix] Add missing `topology_prefix` option in the configuration schema

### DIFF
--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -536,6 +536,7 @@
                     "target_systems": {"$ref": "#/defs/system_ref"},
                     "table_format": {"enum": ["csv", "plain", "pretty"]},
                     "timestamp_dirs": {"type": "string"},
+                    "topology_prefix": {"type": "string"},
                     "trap_job_errors": {"type": "boolean"},
                     "unload_modules": {"$ref": "#/defs/modules_list"},
                     "use_login_shell": {"type": "boolean"},


### PR DESCRIPTION
Closes #3363.