### PR TITLE
[bugfix] Fix use of `dump_pipeline_progress` and `RFM_DUMP_PIPELINE_PROGRESS` options

### DIFF
--- a/reframe/frontend/executors/policies.py
+++ b/reframe/frontend/executors/policies.py
@@ -281,7 +281,7 @@ class AsynchronousExecutionPolicy(ExecutionPolicy, TaskEventListener):
             '_rfm_local': rt.runtime().get_option('systems/0/max_local_jobs')
         }
         self._pipeline_statistics = rt.runtime().get_option(
-            'systems/0/dump_pipeline_progress'
+            'general/0/dump_pipeline_progress'
         )
         self.task_listeners.append(self)
 


### PR DESCRIPTION
`dump_pipeline_progress` is in within the `general` part of the configuration