### PR TITLE
[doc] Fix default value for results storage in documentation

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -1686,7 +1686,7 @@ Result storage configuration
 .. py:attribute:: storage.enable
 
    :required: No
-   :default: ``true``
+   :default: ``false``
 
    Enable results storage.
 


### PR DESCRIPTION
Fix default value for results storage

Following #3313 the results storage is now disabled by default.