### PR TITLE
[bugfix] Include test info when skipping tests

### DIFF
--- a/reframe/frontend/executors/policies.py
+++ b/reframe/frontend/executors/policies.py
@@ -183,7 +183,7 @@ class SerialExecutionPolicy(ExecutionPolicy, TaskEventListener):
         pass
 
     def on_task_skip(self, task):
-        msg = str(task.exc_info[1])
+        msg = f'{task.info()} [{task.exc_info[1]}]'
         self.printer.status('SKIP', msg, just='right')
 
     def on_task_abort(self, task):
@@ -605,7 +605,7 @@ class AsynchronousExecutionPolicy(ExecutionPolicy, TaskEventListener):
         self._pollctl.reset_snooze_time()
 
     def on_task_skip(self, task):
-        msg = str(task.exc_info[1])
+        msg = f'{task.info()} [{task.exc_info[1]}]'
         self.printer.status('SKIP', msg, just='right')
 
     def on_task_abort(self, task):


### PR DESCRIPTION
Now output is the following:

```console
[     SKIP ] (1/3) SkipTest /dbb6b33c @generic:default+builtin [unsupported]
[       OK ] (2/3) CompileOnlyHelloTest /ecfc0900 @generic:default+builtin
[     SKIP ] (3/3) HelloTest /2b3e4546 @generic:default+builtin [could not satisfy the minimum task requirement: required 2, found 1]
```

Closes #3351.