### PR TITLE
[bugfix] Properly expand environment variables in execution modes

### DIFF
--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -941,9 +941,12 @@ def main():
                 # We lexically split the mode options, because otherwise spaces
                 # will be treated as part of the option argument;
                 # see GH bug #1554
-                mode_args = list(
-                    itertools.chain.from_iterable(shlex.split(m)
-                                                  for m in mode_args))
+                mode_args = list(itertools.chain.from_iterable(
+                    shlex.split(osext.expandvars(arg)) for arg in mode_args)
+                )
+                printer.debug(f'Expanding execution mode {options.mode!r}: '
+                              f'{" ".join(mode_args)}')
+
                 # Parse the mode's options and reparse the command-line
                 options = argparser.parse_args(mode_args,
                                                suppress_required=True)

--- a/unittests/resources/config/settings.py
+++ b/unittests/resources/config/settings.py
@@ -275,6 +275,11 @@ site_configuration = {
                 '-p builtin',
                 '-S local=1'
             ]
+        },
+        {
+            'name': 'env_vars',
+            'options': ['-n', '${TEST_NAME_PATTERN}',
+                        '-S', '${VAR}=${VAL}']
         }
     ],
     'logging': [

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -542,6 +542,20 @@ def test_execution_modes(run_reframe, run_action):
     assert 'Ran 1/1 test case' in stdout
 
 
+def test_execution_modes_envvar_expansion(run_reframe, monkeypatch):
+    monkeypatch.setenv('TEST_NAME_PATTERN', '^HelloTest$')
+    monkeypatch.setenv('VAR', 'x')
+    monkeypatch.setenv('VAL', '1')
+    returncode, stdout, stderr = run_reframe(
+        mode='env_vars', action='list'
+    )
+    assert returncode == 0
+    assert 'Traceback' not in stdout
+    assert 'Traceback' not in stderr
+    assert "the following variables were not set: 'x'"
+    assert 'Found 1 check(s)' in stdout
+
+
 def test_invalid_mode_error(run_reframe):
     mode = 'invalid'
     returncode, stdout, stderr = run_reframe(

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -552,7 +552,7 @@ def test_execution_modes_envvar_expansion(run_reframe, monkeypatch):
     assert returncode == 0
     assert 'Traceback' not in stdout
     assert 'Traceback' not in stderr
-    assert "the following variables were not set: 'x'"
+    assert "the following variables were not set: 'x'" in stdout
     assert 'Found 1 check(s)' in stdout
 
 

--- a/unittests/test_config.py
+++ b/unittests/test_config.py
@@ -225,7 +225,7 @@ def test_select_subconfig(site_config):
     site_config.select_subconfig('testsys')
     assert len(site_config['systems']) == 1
     assert len(site_config['systems'][0]['partitions']) == 2
-    assert len(site_config['modes']) == 1
+    assert len(site_config['modes']) == 2
     assert site_config.get('systems/0/name') == 'testsys'
     assert site_config.get('systems/0/descr') == 'Fake system for unit tests'
     assert site_config.get('systems/0/hostnames') == ['testsys']


### PR DESCRIPTION
We now expand environment variables once we resolve the execution mode and do not wait for a later expansion during the resolution of the various configuration parameters.

Closes #3306.