### PR TITLE
[bugfix] Do not copy or `git clone` `sourcesdir` if `--dont-restage` is passed

### DIFF
--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -477,6 +477,10 @@ Options controlling ReFrame output
 
    .. versionadded:: 3.1
 
+   .. warning::
+
+      Running a test with :option:`--dont-restage` on a stage directory that was created with a different ReFrame version is undefined behaviour.
+
 .. option:: --keep-stage-files
 
    Keep test stage directories even for tests that finish successfully.

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -2645,7 +2645,7 @@ class RunOnlyRegressionTest(RegressionTest, special=True):
         The resources of the test are copied to the stage directory and the
         rest of execution is delegated to the :func:`RegressionTest.run()`.
         '''
-        if (self.sourcesdir and self._requires_stagedir_contents()):
+        if self.sourcesdir and self._requires_stagedir_contents():
             if osext.is_url(self.sourcesdir):
                 self._clone_to_stagedir(self.sourcesdir)
             else:

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -20,6 +20,7 @@ import itertools
 import numbers
 import os
 import shutil
+from pathlib import Path
 
 import reframe.core.fields as fields
 import reframe.core.hooks as hooks
@@ -1779,6 +1780,21 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
         self._setup_container_platform()
         self._resolve_fixtures()
 
+    def _requires_stagedir_contents(self):
+        '''Return true if the contents of the stagedir need to be generated'''
+
+        # Every time the stage directory is created a fresh mark is created.
+        # Normally, this is wiped out before running the test, unless
+        # `--dont-restage` is passed. In this case, we want to leave the
+        # existing stagedir untouched.
+
+        mark = Path(self.stagedir) / '.rfm_mark'
+        if mark.exists():
+            return False
+        else:
+            mark.touch()
+            return True
+
     def _copy_to_stagedir(self, path):
         self.logger.debug(f'Copying {path} to stage directory')
         self.logger.debug(f'Symlinking files: {self.readonly_files}')
@@ -1832,11 +1848,12 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
                     f'interpreted as relative to it'
                 )
 
-            if osext.is_url(self.sourcesdir):
-                self._clone_to_stagedir(self.sourcesdir)
-            else:
-                self._copy_to_stagedir(os.path.join(self._prefix,
-                                                    self.sourcesdir))
+            if self._requires_stagedir_contents():
+                if osext.is_url(self.sourcesdir):
+                    self._clone_to_stagedir(self.sourcesdir)
+                else:
+                    self._copy_to_stagedir(os.path.join(self._prefix,
+                                                        self.sourcesdir))
 
         # Set executable (only if hasn't been provided)
         if not hasattr(self, 'executable'):
@@ -2628,7 +2645,7 @@ class RunOnlyRegressionTest(RegressionTest, special=True):
         The resources of the test are copied to the stage directory and the
         rest of execution is delegated to the :func:`RegressionTest.run()`.
         '''
-        if self.sourcesdir:
+        if (self.sourcesdir and self._requires_stagedir_contents()):
             if osext.is_url(self.sourcesdir):
                 self._clone_to_stagedir(self.sourcesdir)
             else:


### PR DESCRIPTION
There was a more general problem with `--dont-restage` apart from trying to re-issue a `git clone` command if `sourcesdir` was a url. Even if it wasn't, it would still copy the contents of the `sourcesdir` to stagedir. Now we neither copy nor clone if `--dont-restage` is passed. 

However, since we now disallow a copy if `--dont-restage` is passed, that would mean that `--dont-restage` would cause a test to fail if it was run for the first time with `--dont-restage` as its resources wouldn't be copied. To overcome this, each test now write a mark in the stage directory. Before copying the resources to the stage directory, it checks if the mark exists. If it does, it means that there has been a previous run and that the stagedir contents haven't been wiped out, which means `--dont-restage` was passed. If the mark does not exists, the it's a fresh run (either the first ever run of a test, even with `--dont-restage`, or just a regular rerun without `--dont-restage`).

Fixes #3305.