### PR TITLE
[ci] Fix wheel file pattern in the wheel validation Github action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,7 +151,7 @@ jobs:
           python -m build
       - name: Install Wheel
         run: |
-          python -m pip install dist/ReFrame_HPC*.whl
+          python -m pip install dist/*.whl
       - name: Test Installation
         run: |
           reframe -V


### PR DESCRIPTION
The `dist/ReFrame_HPC*.whl` pattern is no longer valid due to https://github.com/pypa/setuptools/pull/4766 which was incorporated in setuptools 75.8.1.