### PR TITLE
Make ReFrame more resilient to `sacct` temporary errors

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -456,18 +456,20 @@ System Partition Configuration
       No other test would be able to proceed.
 
 
-.. py:attribute:: systems.partitions.sched_options.sacct_retries
+.. py:attribute:: systems.partitions.sched_options.max_sacct_failures
 
    :required: No
    :default: ``3``
 
+   Maximum number of consecutive failures of `sacct` before ReFrame reports a failure.
+
    Some times the ``sacct`` command may be temporarily unavailable.
-   In this case, ReFrame will continue polling until ``sacct_retries`` is reached.
+   In this case, ReFrame will continue polling until ``max_sacct_failures`` is reached.
    Every time the command succeeds, the counter is reset.
 
-   This option is relevant for the Slurm backend only.
+   This option is relevant for the ``slurm`` backend only.
 
-   .. versionadded:: 4.8.0
+   .. versionadded:: 4.8
 
 
 .. py:attribute:: systems.partitions.sched_options.unqualified_hostnames

--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -456,6 +456,20 @@ System Partition Configuration
       No other test would be able to proceed.
 
 
+.. py:attribute:: systems.partitions.sched_options.sacct_retries
+
+   :required: No
+   :default: ``0``
+
+   Some times the ``sacct`` command may be temporarily unavailable.
+   In this case, ReFrame will continue polling until ``sacct_retries`` is reached.
+   Every time the command succeeds, the counter is reset.
+
+   This option is relevant for the Slurm backend only.
+
+   .. versionadded:: 4.8.0
+
+
 .. py:attribute:: systems.partitions.sched_options.unqualified_hostnames
 
    :required: No

--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -459,7 +459,7 @@ System Partition Configuration
 .. py:attribute:: systems.partitions.sched_options.sacct_retries
 
    :required: No
-   :default: ``0``
+   :default: ``3``
 
    Some times the ``sacct`` command may be temporarily unavailable.
    In this case, ReFrame will continue polling until ``sacct_retries`` is reached.

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -12,6 +12,7 @@ import time
 from argparse import ArgumentParser
 from contextlib import suppress
 
+import reframe.core.logging as logging
 import reframe.core.runtime as rt
 import reframe.core.schedulers as sched
 import reframe.utility.osext as osext
@@ -465,8 +466,12 @@ class SlurmJobScheduler(sched.JobScheduler):
                 if self._sacct_retries < self._max_sacct_retries:
                     self._sacct_retries += 1
                     self.log(
-                        f'sacct failed with error: '
-                        f'{e.stderr}: have tried {self._sacct_retries} time(s)'
+                        (
+                            f'sacct failed with error: '
+                            f'{e.stderr}: have tried {self._sacct_retries} '
+                            f'time(s)'
+                        ),
+                        level=logging.WARNING
                     )
                     return
                 else:

--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -142,7 +142,7 @@ class SlurmJobScheduler(sched.JobScheduler):
         self._use_nodes_opt = self.get_option('use_nodes_option')
         self._resubmit_on_errors = self.get_option('resubmit_on_errors')
         self._max_sacct_failures = self.get_option('max_sacct_failures')
-        self._num_failures_sacct = 0
+        self._num_sacct_failures = 0
         self._sched_access_in_submit = self.get_option(
             'sched_access_in_submit'
         )
@@ -461,12 +461,12 @@ class SlurmJobScheduler(sched.JobScheduler):
                     f'-o jobid,state,exitcode,end,nodelist'
                 )
                 # Reset the retry counter if the command succeeds
-                self._num_failures_sacct = 0
+                self._num_sacct_failures = 0
             except SpawnedProcessError as e:
-                self._num_failures_sacct += 1
-                if self._num_failures_sacct > self._max_sacct_failures:
+                self._num_sacct_failures += 1
+                if self._num_sacct_failures > self._max_sacct_failures:
                     self.log(
-                        f'sacct failed ({self._num_failures_sacct}/'
+                        f'sacct failed ({self._num_sacct_failures}/'
                         f'{self._max_sacct_failures}): {e.stderr}',
                         level=logging.WARNING
                     )

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -684,7 +684,7 @@
         "systems*/sched_options/ignore_reqnodenotavail": false,
         "systems*/sched_options/job_submit_timeout": 60,
         "systems*/sched_options/resubmit_on_errors": [],
-        "systems*/sched_options/sacct_retries": 0,
+        "systems*/sched_options/sacct_retries": 3,
         "systems*/sched_options/unqualified_hostnames": false,
         "systems*/sched_options/use_nodes_option": false
     }

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -117,6 +117,7 @@
                     "type": "array",
                     "items": {"type": "string"}
                 },
+                "sacct_retries": {"type": "number"},
                 "unqualified_hostnames": {"type": "boolean"},
                 "use_nodes_option": {"type": "boolean"}
             }
@@ -683,6 +684,7 @@
         "systems*/sched_options/ignore_reqnodenotavail": false,
         "systems*/sched_options/job_submit_timeout": 60,
         "systems*/sched_options/resubmit_on_errors": [],
+        "systems*/sched_options/sacct_retries": 0,
         "systems*/sched_options/unqualified_hostnames": false,
         "systems*/sched_options/use_nodes_option": false
     }

--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -106,18 +106,18 @@
         "sched_options": {
             "type": "object",
             "properties": {
-                "sched_access_in_submit": {"type": "boolean"},
                 "hosts": {
                     "type": "array",
                     "items": {"type": "string"}
                 },
                 "ignore_reqnodenotavail": {"type": "boolean"},
                 "job_submit_timeout": {"type": "number"},
+                "max_sacct_failures": {"type": "number"},
                 "resubmit_on_errors": {
                     "type": "array",
                     "items": {"type": "string"}
                 },
-                "sacct_retries": {"type": "number"},
+                "sched_access_in_submit": {"type": "boolean"},
                 "unqualified_hostnames": {"type": "boolean"},
                 "use_nodes_option": {"type": "boolean"}
             }
@@ -679,12 +679,12 @@
         "systems/partitions/time_limit": null,
         "systems/partitions/devices": [],
         "systems/partitions/extras": {},
-        "systems*/sched_options/sched_access_in_submit": false,
-        "systems*/sched_options/ssh_hosts": [],
         "systems*/sched_options/ignore_reqnodenotavail": false,
         "systems*/sched_options/job_submit_timeout": 60,
+        "systems*/sched_options/max_sacct_failures": 3,
+        "systems*/sched_options/sched_access_in_submit": false,
+        "systems*/sched_options/ssh_hosts": [],
         "systems*/sched_options/resubmit_on_errors": [],
-        "systems*/sched_options/sacct_retries": 3,
         "systems*/sched_options/unqualified_hostnames": false,
         "systems*/sched_options/use_nodes_option": false
     }

--- a/unittests/test_config.py
+++ b/unittests/test_config.py
@@ -327,13 +327,13 @@ def test_select_subconfig(site_config):
     ) == []
     assert site_config.get(
         'systems/0/sched_options/sacct_retries'
-    ) == 0
+    ) == 3
     assert site_config.get(
         'systems/0/partitions/@gpu/sched_options/resubmit_on_errors'
     ) == []
     assert site_config.get(
         'systems/0/partitions/@gpu/sched_options/sacct_retries'
-    ) == 0
+    ) == 3
     assert site_config.get('environments/@PrgEnv-gnu/cc') == 'cc'
     assert site_config.get('environments/1/cxx') == 'CC'
     assert site_config.get('general/0/check_search_path') == ['c:d']

--- a/unittests/test_config.py
+++ b/unittests/test_config.py
@@ -326,8 +326,14 @@ def test_select_subconfig(site_config):
         'systems/0/sched_options/resubmit_on_errors'
     ) == []
     assert site_config.get(
+        'systems/0/sched_options/sacct_retries'
+    ) == 0
+    assert site_config.get(
         'systems/0/partitions/@gpu/sched_options/resubmit_on_errors'
     ) == []
+    assert site_config.get(
+        'systems/0/partitions/@gpu/sched_options/sacct_retries'
+    ) == 0
     assert site_config.get('environments/@PrgEnv-gnu/cc') == 'cc'
     assert site_config.get('environments/1/cxx') == 'CC'
     assert site_config.get('general/0/check_search_path') == ['c:d']

--- a/unittests/test_config.py
+++ b/unittests/test_config.py
@@ -326,13 +326,13 @@ def test_select_subconfig(site_config):
         'systems/0/sched_options/resubmit_on_errors'
     ) == []
     assert site_config.get(
-        'systems/0/sched_options/sacct_retries'
+        'systems/0/sched_options/max_sacct_failures'
     ) == 3
     assert site_config.get(
         'systems/0/partitions/@gpu/sched_options/resubmit_on_errors'
     ) == []
     assert site_config.get(
-        'systems/0/partitions/@gpu/sched_options/sacct_retries'
+        'systems/0/partitions/@gpu/sched_options/max_sacct_failures'
     ) == 3
     assert site_config.get('environments/@PrgEnv-gnu/cc') == 'cc'
     assert site_config.get('environments/1/cxx') == 'CC'


### PR DESCRIPTION
Closes #3415 

For me it's useful to have the failure logged as a warning, so that people would be aware that the system is not stable. Now the output looks like this when it happens:
```
[ RUN      ] PyTorch...
[S] slurm: sacct failed with error: sacct: error: _open_persist_conn: failed to open persistent connection to host:beverin-slurmctl.tds.cscs.ch:6819: Connection timed out
sacct: error: Sending PersistInit msg: Connection timed out
sacct: error: Problem talking to the database: Connection timed out
: have tried 1 time(s)
[       OK ] (27/42) ...
```