### PR TITLE
[bugfix] Disable number parsing when in `--list-stored-sessions`

### DIFF
--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -1015,7 +1015,7 @@ def main():
             if spec == 'all':
                 spec = '19700101T0000+0000:now'
 
-            printer.table(reporting.session_data(spec))
+            printer.table(reporting.session_data(spec), disable_numparse=True)
             sys.exit(0)
 
     if options.list_stored_testcases:


### PR DESCRIPTION
Now output is

```console
┍━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━┯━━━━━━━━━━━━━┯━━━━━━━┯━━━━━━━┑
│ UUID                                 │ Start time           │ End time             │ Num runs   │ Num cases   │ x     │ y     │
┝━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┿━━━━━━━━━━━━━━━━━━━━━━┿━━━━━━━━━━━━━━━━━━━━━━┿━━━━━━━━━━━━┿━━━━━━━━━━━━━┿━━━━━━━┿━━━━━━━┥
│ 6c27c7c0-725a-4f9b-9449-6b91cda3dc91 │ 20250313T221426+0100 │ 20250313T221427+0100 │ 1          │ 1           │ 12.30 │ 12.31 │
┕━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━┷━━━━━━━━━━━━━┷━━━━━━━┷━━━━━━━┙
```

Fixes #3404.