### PR TITLE
[feat] Support selecting A/B column variants in performance comparisons

### DIFF
--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -1474,8 +1474,14 @@ The selection of the final columns of the results table is specified by the same
 
 However, for performance comparisons, ReFrame will generate two columns for every attribute in the subspec that is not also a group-by attribute, suffixed with ``_A`` and ``_B``.
 These columns contain the aggregated values of the corresponding attributes.
-Note that only the aggregation of ``pval`` (i.e. the test case performance)  can be controlled (see :ref:`testcase-grouping`)
+Note that only the aggregation of ``pval`` (i.e. the test case performance)  can be controlled (see :ref:`testcase-grouping`).
 All other attributes are aggregated by joining their unique values.
+
+It possible to select only one of the A/B variants of the extra columns by adding the ``_A`` or ``_B`` suffix to the column name in the ``<cols>`` subspec, e.g., ``+result_A`` will only show the result of the first group of test cases.
+
+.. versionchanged:: 4.8
+
+   Support for selecting A/B column variants in performance comparisons.
 
 Examples
 --------

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -1446,6 +1446,13 @@ def test_performance_compare(run_reframe, table_format, monkeypatch):
         )
     )
 
+    # Select only specific variants of extra cols
+    assert_no_crash(
+        *run_reframe2(
+            action='--performance-compare=now-1m:now/now-1d:now/mean:/+result_A+job_nodelist_B'  # noqa: E501
+        )
+    )
+
     # Check disjoint sets of groups and columns
     assert_no_crash(
         *run_reframe2(


### PR DESCRIPTION
When doing performance comparisons (`--performance-compare` or `--performance-report`), users can now explicitly select the A or B variant for extra columns, e.g., `+result_A` will only list the aggregated results of the first set.

Closes #3341.