### PR TITLE
[bugfix] Disallow command options from execution modes

### DIFF
--- a/docs/config_reference.rst
+++ b/docs/config_reference.rst
@@ -1698,6 +1698,14 @@ The options of an execution mode will be passed to ReFrame as if they were speci
 
    The command-line options associated with this execution mode.
 
+   .. warning::
+      :ref:`Command options <commands>` are *not* allowed in execution modes.
+      These should always be passed explicitly in command line.
+
+   .. versionchanged:: 4.8
+
+      Command options are explicitly disallowed in execution modes.
+
 
 .. py:attribute:: modes.target_systems
 

--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -666,6 +666,14 @@ Options controlling ReFrame execution
    .. versionchanged:: 4.1
       Options that can be specified multiple times are now combined between execution modes and the command line.
 
+   .. versionchanged:: 4.7
+      The :option:`--mode` must always be combined with a :ref:`command option <commands>`.
+      If the mode contains a command option already, the command option that will finally take effect is implementation defined.
+
+   .. versionchanged:: 4.8
+      Command options are disallowed from execution modes.
+
+
 .. option:: --reruns=N
 
    Rerun the whole test session ``N`` times.

--- a/reframe/frontend/argparse.py
+++ b/reframe/frontend/argparse.py
@@ -160,6 +160,10 @@ class _ArgumentHolder:
         # options. Values are tuples of the form (envvar, configvar)
         self._option_map = shared_options if shared_options is not None else {}
 
+        # We store the options (without actions) to quickly decide if an option
+        # is part of specific option group
+        self._options = set()
+
     def __getattr__(self, name):
         # Delegate all unknown public attribute requests to the underlying
         # holder
@@ -176,7 +180,15 @@ class _ArgumentHolder:
         else:
             setattr(self._holder, name, value)
 
+    def has_known_options(self, args):
+        flags = {arg for arg in args if arg.startswith('-')}
+        return flags & self._options
+
     def add_argument(self, *flags, **kwargs):
+        # Store all flags separately
+        for opt in flags:
+            self._options.add(opt)
+
         try:
             opt_name = kwargs['dest']
         except KeyError:

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -947,6 +947,15 @@ def main():
                 printer.debug(f'Expanding execution mode {options.mode!r}: '
                               f'{" ".join(mode_args)}')
 
+                action_opts = action_options.has_known_options(mode_args)
+                if action_opts:
+                    printer.error(
+                        f'Expanding execution mode {options.mode!r} failed: '
+                        'action options are not allowed in modes: '
+                        f'{" ".join(action_opts)}'
+                    )
+                    sys.exit(1)
+
                 # Parse the mode's options and reparse the command-line
                 options = argparser.parse_args(mode_args,
                                                suppress_required=True)

--- a/unittests/test_argparser.py
+++ b/unittests/test_argparser.py
@@ -50,6 +50,10 @@ def test_arguments(argparser, foo_options):
 
     foo_options.add_argument('--foo-bar', action='store_true')
     foo_options.add_argument('--alist', action='append', default=[])
+    assert foo_options.has_known_options(['-f', '-l', '-b'])
+    assert foo_options.has_known_options(['--foobar', '-l', '-b'])
+    assert not foo_options.has_known_options(['-l', '-b'])
+
     options = argparser.parse_args(['--foobar', '--foo-bar'])
     assert options.foobar
     assert options.foo_bar


### PR DESCRIPTION
Execution modes are not allowed to use command/action options. This was never the intent of execution modes and since 4.7, since `--mode` is not a command option, it was required to pass one in the command line. If the mode had already a command option, then which of the two would take effect was implementation defined. This PR disallows completely the use of command options in execution modes to avoid such abmiguities.

Closes #3424.