### PR TITLE
[bugfix] Fix calculation of lower/upper reference bounds when their absolute value reaches zero

### DIFF
--- a/reframe/utility/sanity.py
+++ b/reframe/utility/sanity.py
@@ -8,6 +8,7 @@ import collections.abc
 import contextlib
 import glob as pyglob
 import itertools
+import math
 import os
 import re
 import sys
@@ -576,8 +577,14 @@ def assert_reference(val, ref, lower_thres=None, upper_thres=None, msg=None):
 
         return ref*(1 + thres)
 
-    lower = calc_bound(lower_thres) or float('-inf')
-    upper = calc_bound(upper_thres) or float('inf')
+    lower = calc_bound(lower_thres)
+    if lower is None:
+        lower = -math.inf
+
+    upper = calc_bound(upper_thres)
+    if upper is None:
+        upper = math.inf
+
     try:
         evaluate(assert_bounded(val, lower, upper))
     except SanityError:

--- a/unittests/test_sanity_functions.py
+++ b/unittests/test_sanity_functions.py
@@ -473,6 +473,18 @@ def test_assert_reference():
                              r'\(l=-1\.2, u=-0\.9\)'):
         sn.evaluate(sn.assert_reference(-0.8, -1, -0.2, 0.1))
 
+    # Check that bounds are correctly calculated in case that lower bound
+    # reaches zero (see also GH issue #3430)
+    with pytest.raises(SanityError,
+                       match=r'1 is beyond reference value 0\.1 '
+                             r'\(l=0\.0, u=0\.1\)'):
+        assert sn.assert_reference(1, 0.1, -1.0, 0)
+
+    with pytest.raises(SanityError,
+                       match=r'-1 is beyond reference value -0\.1 '
+                             r'\(l=-0\.1, u=-0\.0\)'):
+        assert sn.assert_reference(-1, -0.1, 0, 1.0)
+
     # Check invalid thresholds
     with pytest.raises(SanityError,
                        match=r'invalid high threshold value: -0\.1'):


### PR DESCRIPTION
Closes #3430.