### PR TITLE
Use of OMP_PROC_BIND in example

### DIFF
--- a/examples/tutorial/stream/stream_parameters.py
+++ b/examples/tutorial/stream/stream_parameters.py
@@ -27,7 +27,7 @@ class stream_test(rfm.RunOnlyRegressionTest):
     valid_prog_environs = ['+openmp']
     stream_binary = fixture(build_stream, scope='environment')
     num_threads = parameter([1, 2, 4, 8])
-    thread_placement = parameter(['close', 'cores', 'spread'])
+    thread_placement = parameter(['true', 'close', 'spread'])
 
     @run_after('setup')
     def set_executable(self):

--- a/examples/tutorial/stream/stream_parameters_fixtures.py
+++ b/examples/tutorial/stream/stream_parameters_fixtures.py
@@ -29,7 +29,7 @@ class stream_test(rfm.RunOnlyRegressionTest):
     valid_prog_environs = ['+openmp']
     stream_binary = fixture(build_stream, scope='environment')
     num_threads = parameter([1, 2, 4, 8])
-    thread_placement = parameter(['close', 'cores', 'spread'])
+    thread_placement = parameter(['true', 'close', 'spread'])
 
     @run_after('setup')
     def set_executable(self):


### PR DESCRIPTION
The example to use Stream seems to use `OMP_PROC_BIND` but sets possible values as `close`, `cores`, `spread`.    This confused me and therefore suggest the following unless I am missing something.

`cores` does seem to be a valid option for `OMP_PROC_BIND` and only for `OMP_PLACES`.

`true` is a valid option and doesnt enforce a method for affinity.  Could also be `false` to allow threads to migrate.

For example see: https://www.openmp.org/spec-html/5.0/openmpse52.html#x291-20580006.4

Is there another reason why it's set to `cores` as part of the learning experience?  I couldn't see any reference to why it would be.