### PR TITLE
[feat] Support discrete testcase filters when comparing performance

### DIFF
--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -187,10 +187,15 @@ Result storage commands
 
    The ``CMPSPEC`` argument specifies how testcases will be selected, aggregated and presented.
    This option can be combined with :option:`--name` and :option:`--filter-expr` to restrict the listed tests.
+   The :option:`--filter-expr` option specifically can be specified twice, in which case the first expression will be used the to filter the first set of test cases, and the second one will filter the second set.
 
    Check the :ref:`querying-past-results` section for the exact syntax of ``CMPSPEC``.
 
    .. versionadded:: 4.7
+
+   .. versionchanged:: 4.8
+
+      The :option:`--filter-expr` can now be passed twice with :option:`--performance-compare`.
 
 Other commands
 ^^^^^^^^^^^^^^

--- a/reframe/frontend/reporting/__init__.py
+++ b/reframe/frontend/reporting/__init__.py
@@ -740,7 +740,8 @@ def compare_testcase_data(base_testcases, target_testcases, base_fn, target_fn,
 
 
 @time_function
-def performance_compare(cmp, report=None, namepatt=None, test_filter=None):
+def performance_compare(cmp, report=None, namepatt=None,
+                        filterA=None, filterB=None):
     with reraise_as(ReframeError, (ValueError,),
                     'could not parse comparison spec'):
         match = parse_cmp_spec(cmp)
@@ -762,9 +763,9 @@ def performance_compare(cmp, report=None, namepatt=None, test_filter=None):
         except IndexError:
             tcs_base = []
     else:
-        tcs_base = backend.fetch_testcases(match.base, namepatt, test_filter)
+        tcs_base = backend.fetch_testcases(match.base, namepatt, filterA)
 
-    tcs_target = backend.fetch_testcases(match.target, namepatt, test_filter)
+    tcs_target = backend.fetch_testcases(match.target, namepatt, filterB)
     return compare_testcase_data(tcs_base, tcs_target, match.aggregator,
                                  match.aggregator, match.groups, match.columns)
 


### PR DESCRIPTION
This PR allows user to specify the `-E` twice when combined with the `--performance-compare` option, in which each of the filter expression will be applied to the corresponding testcase set.

Closes #3437.