### PR TITLE
[enhancement] List parameterized tests in their instantiation order

### DIFF
--- a/reframe/core/decorators.py
+++ b/reframe/core/decorators.py
@@ -9,6 +9,7 @@
 
 __all__ = ['simple_test']
 
+import collections
 import inspect
 import sys
 import traceback
@@ -96,7 +97,7 @@ class TestRegistry:
         # establish their exact dependencies at instantiation time, so the
         # dependency graph grows dynamically.
 
-        leaf_tests = []
+        leaf_tests = collections.deque()
         for test, variants in self._tests.items():
             for args, kwargs in variants:
                 try:
@@ -127,7 +128,7 @@ class TestRegistry:
         while leaf_tests:
             tmp_registry = FixtureRegistry()
             while leaf_tests:
-                c = leaf_tests.pop()
+                c = leaf_tests.popleft()
                 reg = getattr(c, '_rfm_fixture_registry', None)
                 final_tests.append(c)
                 if reg:
@@ -140,7 +141,7 @@ class TestRegistry:
                     _setvars(new_fixtures.uninst_tests(), external_vars)
                 )
 
-            leaf_tests = new_fixtures.instantiate_all()
+            leaf_tests = collections.deque(new_fixtures.instantiate_all())
             fixture_registry.update(new_fixtures)
 
         return final_tests

--- a/unittests/test_testgenerators.py
+++ b/unittests/test_testgenerators.py
@@ -46,7 +46,7 @@ def test_distribute_testcases(sys0_exec_ctx):
     assert count == 2
 
     def sys0p0_nodes():
-        for nodelist in (['n2'], ['n2'], ['n1'], ['n1']):
+        for nodelist in (['n1'], ['n1'], ['n2'], ['n2']):
             yield nodelist
 
     nodelist_iter = sys0p0_nodes()


### PR DESCRIPTION
Although the parameterized tests were instantiated in the order they appear in the test file and in the order of their parameter list, they were listed in reverse order, which was annoying, although technically not a bug (the default listing is implementation-defined).

The problem was that we were iterating over them in reverse order in order to instantiate any fixtures, so the final list of tests was reverted. This is fixed by using a `deque` list and popping from the left side.