### PR TITLE
[bugfix] Update special parameter character in test name

### DIFF
--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -1217,12 +1217,14 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
         '''The name of the test.
 
         This is an alias of :attr:`display_name` but omitting any implicit
-        parameters starting with ``$`` that are inserted by the
+        parameters starting with ``.`` that are inserted by the
         :option:`--repeat`, :option:`--distribute` and other similar options.
 
         .. versionchanged:: 4.7
 
-           The implicit parameters starting with ``$`` are now omitted.
+           The implicit parameters starting with special characters are now
+           omitted.
+
         '''
         if hasattr(self, '_rfm_name'):
             return self._rfm_name

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -673,11 +673,11 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #: the system/partition combinations.
     #: The reference itself is a four-tuple that contains the reference value,
     #: the lower and upper thresholds, and the measurement unit.
-    #: 
+    #:
     #: For non-zero reference values, lower and upper thresholds are
     #: percentages -/+ from the reference value in decimal form.
     #:
-    #: When a reference value of ``0`` is expected, lower and upper 
+    #: When a reference value of ``0`` is expected, lower and upper
     #: thresholds are interpreted as absolute values.
     #:
     #: An example follows:
@@ -1231,7 +1231,7 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
         basename, *params = self.display_name.split(' ')
         name = basename
         for p in params:
-            if not p.startswith('%$'):
+            if not p.startswith('%.'):
                 name += f' {p}'
 
         self._rfm_name = name


### PR DESCRIPTION
The `name` test property was not updated when the special parameter character was changed from `$` to `.` in #3330.