### PR TITLE
[feat] Allow changing the default mount location of stagedir inside containers

### DIFF
--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -34,7 +34,7 @@ import reframe.utility.typecheck as typ
 import reframe.utility.udeps as udeps
 from reframe.core.backends import getlauncher, getscheduler
 from reframe.core.buildsystems import BuildSystemField
-from reframe.core.containers import (ContainerPlatform, ContainerPlatformField)
+from reframe.core.containers import ContainerPlatform
 from reframe.core.deferrable import (_DeferredExpression,
                                      _DeferredPerformanceExpression)
 from reframe.core.environments import Environment
@@ -466,8 +466,8 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #: .. versionchanged:: 3.12.0
     #:    This field is now set automatically from the current partition's
     #:    configuration.
-    container_platform = variable(field=ContainerPlatformField,
-                                  value=_NoRuntime(), loggable=False)
+    container_platform = variable(ContainerPlatform, value=_NoRuntime(),
+                                  loggable=False, allow_implicit=True)
 
     #: .. versionadded:: 3.0
     #:
@@ -673,11 +673,11 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #: the system/partition combinations.
     #: The reference itself is a four-tuple that contains the reference value,
     #: the lower and upper thresholds, and the measurement unit.
-    #: 
+    #:
     #: For non-zero reference values, lower and upper thresholds are
     #: percentages -/+ from the reference value in decimal form.
     #:
-    #: When a reference value of ``0`` is expected, lower and upper 
+    #: When a reference value of ``0`` is expected, lower and upper
     #: thresholds are interpreted as absolute values.
     #:
     #: An example follows:

--- a/unittests/test_containers.py
+++ b/unittests/test_containers.py
@@ -6,6 +6,7 @@
 import pytest
 
 import reframe.core.containers as containers
+from reframe.core.containers import ContainerPlatform
 
 
 @pytest.fixture(params=[
@@ -126,7 +127,6 @@ def expected_cmd_mount_points(container_variant):
         return ('apptainer run -B"/path/one:/one" '
                 '-B"/path/two:/two" -B"/foo:/rfm_workdir" '
                 '--pwd /rfm_workdir image:tag')
-
 
 
 @pytest.fixture
@@ -304,3 +304,14 @@ def test_run_with_workdir(container_platform_with_opts,
     container_platform_with_opts.workdir = 'foodir'
     found_commands = container_platform_with_opts.launch_command('/foo')
     assert found_commands == expected_run_with_workdir
+
+
+@pytest.fixture(params=['Docker', 'Sarus', 'Shifter',
+                        'Singularity', 'Apptainer'])
+def container_platform_name(request):
+    return request.param
+
+
+def test_create_from_str(container_platform_name):
+    cp = ContainerPlatform(container_platform_name)
+    assert type(cp).__name__ == container_platform_name

--- a/unittests/test_containers.py
+++ b/unittests/test_containers.py
@@ -128,6 +128,75 @@ def expected_cmd_mount_points(container_variant):
                 '-B"/path/two:/two" -B"/foo:/rfm_workdir" '
                 '--pwd /rfm_workdir image:tag')
 
+@pytest.fixture
+def expected_cmd_mount_points_no_stagedir(container_variant):
+    if container_variant in {'Docker', 'Docker+nopull'}:
+        return ('docker run --rm -v "/path/one":"/one" '
+                '-v "/path/two":"/two" '
+                '-w /workspace image:tag cmd')
+    elif container_variant == 'Docker+nocommand':
+        return ('docker run --rm -v "/path/one":"/one" '
+                '-v "/path/two":"/two" '
+                '-w /workspace image:tag')
+    elif container_variant in {'Sarus', 'Sarus+nopull'}:
+        return ('sarus run '
+                '--mount=type=bind,source="/path/one",destination="/one" '
+                '--mount=type=bind,source="/path/two",destination="/two" '
+                '-w /workspace image:tag cmd')
+    elif container_variant == 'Sarus+nocommand':
+        return ('sarus run '
+                '--mount=type=bind,source="/path/one",destination="/one" '
+                '--mount=type=bind,source="/path/two",destination="/two" '
+                '-w /workspace image:tag')
+    elif container_variant == 'Sarus+mpi':
+        return ('sarus run '
+                '--mount=type=bind,source="/path/one",destination="/one" '
+                '--mount=type=bind,source="/path/two",destination="/two" '
+                '--mpi -w /workspace image:tag cmd')
+    elif container_variant == 'Sarus+load':
+        return ('sarus run '
+                '--mount=type=bind,source="/path/one",destination="/one" '
+                '--mount=type=bind,source="/path/two",destination="/two" '
+                '-w /workspace load/library/image:tag cmd')
+    elif container_variant in {'Shifter', 'Shifter+nopull'}:
+        return ('shifter run '
+                '--mount=type=bind,source="/path/one",destination="/one" '
+                '--mount=type=bind,source="/path/two",destination="/two" '
+                'image:tag cmd')
+    elif container_variant == 'Shifter+nocommand':
+        return ('shifter run '
+                '--mount=type=bind,source="/path/one",destination="/one" '
+                '--mount=type=bind,source="/path/two",destination="/two" '
+                'image:tag')
+    elif container_variant == 'Shifter+mpi':
+        return ('shifter run '
+                '--mount=type=bind,source="/path/one",destination="/one" '
+                '--mount=type=bind,source="/path/two",destination="/two" '
+                '--mpi image:tag cmd')
+    elif container_variant == 'Shifter+load':
+        return ('shifter run '
+                '--mount=type=bind,source="/path/one",destination="/one" '
+                '--mount=type=bind,source="/path/two",destination="/two" '
+                'load/library/image:tag cmd')
+    elif container_variant == 'Singularity':
+        return ('singularity exec -B"/path/one:/one" '
+                '-B"/path/two:/two" --pwd /workspace image:tag cmd')
+    elif container_variant == 'Singularity+cuda':
+        return ('singularity exec -B"/path/one:/one" '
+                '-B"/path/two:/two" --nv --pwd /workspace image:tag cmd')
+    elif container_variant == 'Singularity+nocommand':
+        return ('singularity run -B"/path/one:/one" '
+                '-B"/path/two:/two" --pwd /workspace image:tag')
+    elif container_variant == 'Apptainer':
+        return ('apptainer exec -B"/path/one:/one" '
+                '-B"/path/two:/two" --pwd /workspace image:tag cmd')
+    elif container_variant == 'Apptainer+cuda':
+        return ('apptainer exec -B"/path/one:/one" '
+                '-B"/path/two:/two" --nv --pwd /workspace image:tag cmd')
+    elif container_variant == 'Apptainer+nocommand':
+        return ('apptainer run -B"/path/one:/one" '
+                '-B"/path/two:/two" --pwd /workspace image:tag')
+
 
 @pytest.fixture
 def expected_cmd_prepare(container_variant):
@@ -219,6 +288,16 @@ def test_mount_points(container_platform, expected_cmd_mount_points):
                                        ('/path/two', '/two')]
     cmd = container_platform.launch_command('/foo')
     assert cmd == expected_cmd_mount_points
+
+
+def test_mount_points_no_stagedir(container_platform,
+                                  expected_cmd_mount_points_no_stagedir):
+    container_platform.mount_points = [('/path/one', '/one'),
+                                       ('/path/two', '/two')]
+    container_platform.mount_stagedir = None
+    container_platform.workdir = '/workspace'
+    cmd = container_platform.launch_command('/foo')
+    assert cmd == expected_cmd_mount_points_no_stagedir
 
 
 def test_prepare_command(container_platform, expected_cmd_prepare):

--- a/unittests/test_pipeline.py
+++ b/unittests/test_pipeline.py
@@ -15,7 +15,6 @@ import reframe.utility.osext as osext
 import reframe.utility.sanity as sn
 import unittests.utility as test_util
 
-from reframe.core.containers import _STAGEDIR_MOUNT
 from reframe.core.exceptions import (BuildError, PipelineError, ReframeError,
                                      PerformanceError, SanityError,
                                      SkipTestError, ReframeSyntaxError)
@@ -1853,14 +1852,14 @@ def container_test(tmp_path):
 
                 self.container_platform.image = image
                 self.container_platform.command = (
-                    f"bash -c 'cd {_STAGEDIR_MOUNT}; pwd; ls; "
-                    f"cat /etc/os-release'"
+                    "bash -c 'cd /rfm_workdir; pwd; ls; "
+                    "cat /etc/os-release'"
                 )
 
             @sanity_function
             def assert_os_release(self):
                 return sn.all([
-                    sn.assert_found(rf'^{_STAGEDIR_MOUNT}', self.stdout),
+                    sn.assert_found(r'^/rfm_workdir', self.stdout),
                     sn.assert_found(r'^foo', self.stdout),
                     sn.assert_found(
                         r'18\.04\.\d+ LTS \(Bionic Beaver\)', self.stdout),


### PR DESCRIPTION
This introduces a new `mount_stagedir` variable that controls the mount point of the stagedir. If `None`, the stagedir will not be mounted.

This PR also refactors the `ContainerPlatform` so as to use the builtin variables instead of the raw fields.

Closes #3367.