### PR TITLE
[bugfix] Fix constraint evaluation for Slurm features starting with numbers

### DIFF
--- a/reframe/core/schedulers/slurm.py
+++ b/reframe/core/schedulers/slurm.py
@@ -741,10 +741,10 @@ class _SlurmNode(sched.Node):
             return False
 
         expr = re.sub(
-            "[\-\w]+",
+            r'[\-\w]+',
             lambda m: str(m.group(0) in self.active_features),
             slurm_constraint
-        ).replace("|", " or ").replace("&", " and ")
+        ).replace('|', ' or ').replace('&', ' and ')
 
         try:
             return eval(expr)


### PR DESCRIPTION
Features starting with a number (e.g. `4xA40`) seem valid to slurm, but are not valid python identifiers. Currently this causes nodes getting filtered out when such feature is used as constraints. ~~This prefixes all variables during eval with underscore to get around it.~~ 

Edit: this now inserts boolean values directly into the constraints to support such Slurm features.