### PR TITLE
[feat] Support list assignment from JSON using the `-S` option

### DIFF
--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -764,7 +764,7 @@ Options controlling ReFrame execution
    - Sequence types: ``-S seqvar=1,2,3,4``
    - Mapping types: ``-S mapvar=a:1,b:2,c:3``
 
-   Nested mapping types can also be converted using JSON syntax.
+   They can also be converted using JSON syntax.
    For example, the :attr:`~reframe.core.pipeline.RegressionTest.extra_resources` complex dictionary could be set with ``-S extra_resources='{"gpu": {"num_gpus_per_node":8}}'``.
 
    Conversions to arbitrary objects are also supported.
@@ -825,6 +825,10 @@ Options controlling ReFrame execution
    .. versionchanged:: 4.4
 
       Allow setting nested mapping types using JSON syntax.
+
+   .. versionchanged:: 4.8
+
+      Allow setting sequence types using JSON syntax.
 
 .. option:: --skip-performance-check
 

--- a/reframe/utility/typecheck.py
+++ b/reframe/utility/typecheck.py
@@ -218,7 +218,15 @@ class _SequenceType(_BuiltinType):
     def __rfm_cast_str__(cls, s):
         container_type = cls._type
         elem_type = cls._elem_type
-        return container_type(elem_type(e) for e in s.split(','))
+        try:
+            items = json.loads(s)
+        except json.JSONDecodeError:
+            items = [elem_type(e) for e in s.split(',')]
+        else:
+            if not isinstance(items, list):
+                items = [items]
+
+        return container_type(items)
 
 
 class _TupleType(_SequenceType):

--- a/unittests/test_typecheck.py
+++ b/unittests/test_typecheck.py
@@ -102,6 +102,10 @@ def test_list_type():
     assert typ.List[int]('1,2') == [1, 2]
     assert typ.List[int]('1') == [1]
 
+    # Conversion from JSON
+    assert typ.List[int]('[1, 2]') == [1, 2]
+    assert typ.List[typ.List[int]]('[[1], [2]]') == [[1], [2]]
+
     with pytest.raises(ValueError):
         typ.List[int]('foo')
 


### PR DESCRIPTION
This solves the issue when the default `,` separator is not sufficient to separate the list elements as well as allows for nested list assignments.

Closes #3264.