### PR TITLE
[feat] Do not emit the `-lselect` option if `num_tasks=None`

### DIFF
--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -569,7 +569,7 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #: - ``local``: not applicable.
     #: - ``lsf``: Neither the ``-nnodes`` nor the ``-n`` will be emitted.
     #: - ``oar``: Resets it to ``1``.
-    #: - ``pbs``: Resets it to ``1``.
+    #: - ``pbs``: The ``-lselect`` option will not be emitted.
     #: - ``sge``: not applicable.
     #: - ``slurm``: Neither the ``--ntasks`` nor the ``--nodes`` option (if the
     #:   :attr:`~config.systems.partitions.sched_options.use_nodes_option` is
@@ -589,6 +589,8 @@ class RegressionTest(RegressionMixin, jsonext.JSONSerializable):
     #:        number of required tasks by the test.
     #:     .. versionchanged:: 4.1
     #:        Allow :attr:`num_tasks` to be :obj:`None`.
+    #:     .. versionchanged:: 4.8
+    #:        ``pbs`` and ``torque`` backends interpret ``num_tasks=None``.
     num_tasks = variable(int, type(None), value=1)
 
     #: Number of tasks per node required by this test.

--- a/unittests/test_schedulers.py
+++ b/unittests/test_schedulers.py
@@ -295,7 +295,12 @@ def _expected_pbs_directives_minimal(job):
     ])
 
 
-_expected_pbs_directives_no_tasks = _expected_pbs_directives_minimal
+def _expected_pbs_directives_no_tasks(job):
+    return set([
+        '#PBS -N testjob',
+        f'#PBS -o {job.stdout}',
+        f'#PBS -e {job.stderr}'
+    ])
 
 
 def _expected_torque_directives(job):
@@ -324,7 +329,7 @@ def _expected_torque_directives_minimal(job):
     ])
 
 
-_expected_torque_directives_no_tasks = _expected_torque_directives_minimal
+_expected_torque_directives_no_tasks = _expected_pbs_directives_no_tasks
 
 
 def _expected_oar_directives(job):


### PR DESCRIPTION
Users can then specify it manually through `self.job.options`.

Closes #3315.