### PR TITLE
[bugfix] Treat correctly `failed_stage=None` in failure stats report

### DIFF
--- a/reframe/frontend/printer.py
+++ b/reframe/frontend/printer.py
@@ -195,6 +195,8 @@ class PrettyPrinter:
                 info += f' @{tc["system"]}:{tc["partition"]}+{tc["environ"]}'
 
                 failed_stage = tc['fail_phase']
+                if not failed_stage:
+                    continue
                 failures.setdefault(failed_stage, [])
                 failures[failed_stage].append(info)
 

--- a/reframe/frontend/printer.py
+++ b/reframe/frontend/printer.py
@@ -197,6 +197,7 @@ class PrettyPrinter:
                 failed_stage = tc['fail_phase']
                 if not failed_stage:
                     continue
+
                 failures.setdefault(failed_stage, [])
                 failures[failed_stage].append(info)
 


### PR DESCRIPTION
This PR tries to address the following error when using the `--failure-stats` command line option
```
ERROR: run session stopped: type error: unsupported format string passed to NoneType.__format__
ERROR: Traceback (most recent call last):
  File "/hpcdc/project/scilib/libsci_acc/csml-libsci-acc-testing/python-libs/x86_64/python3.11/site-packages/reframe/frontend/cli.py", line 1654, in main
    printer.failure_stats(
  File "/hpcdc/project/scilib/libsci_acc/csml-libsci-acc-testing/python-libs/x86_64/python3.11/site-packages/reframe/frontend/printer.py", line 227, in failure_stats
    stats_body.append(row_format.format(p, len(l), l[0]))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: unsupported format string passed to NoneType.__format__
```

The problem is that successful tests are stored with `tc['fail_phase']` as `None` and also got passed to the dictionary `failures`. Then later when ReFrame tries to generate a report, `p` is set to `None` in the following lines
```
for p, l in failures.items():
    stats_body.append(row_format.format(p, len(l), l[0]))
```

You can reproduce the same behavior with
```
$ python -c '"{:<13}".format(None)'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: unsupported format string passed to NoneType.__format__
```