### PR TITLE
[enhancement] Use the `--use-pep517` option in `bootstrap.sh`

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -116,10 +116,10 @@ if [ -n "$PYGELF" ]; then
     sed -e 's/^#+pygelf%//g' requirements.txt > $tmp_requirements
     CMD_M +pygelf $python -m pip install --no-cache-dir -q -r $tmp_requirements --target=$py_pkg_prefix/ --upgrade $PIPOPTS && rm $tmp_requirements
 else
-    CMD $python -m pip install --no-cache-dir -q -r requirements.txt --target=$py_pkg_prefix/ --upgrade $PIPOPTS
+    CMD $python -m pip install --use-pep517 --no-cache-dir -q -r requirements.txt --target=$py_pkg_prefix/ --upgrade $PIPOPTS
 fi
 
 if [ -n "$MAKEDOCS" ]; then
-    CMD_M +docs $python -m pip install --no-cache-dir -q -r docs/requirements.txt --target=$py_pkg_prefix/ --upgrade $PIPOPTS
+    CMD_M +docs $python -m pip install --use-pep517 --no-cache-dir -q -r docs/requirements.txt --target=$py_pkg_prefix/ --upgrade $PIPOPTS
     make -C docs PYTHON=$python
 fi


### PR DESCRIPTION
This is to avoid deprecation warnings from dependencies that are not yet updated (see ClusterShell):

```
  DEPRECATION: Building 'ClusterShell' using the legacy setup.py bdist_wheel mechanism, which will be removed in a future version. pip 25.3 will enforce this behaviour change. A possible replacement is to use the standardized build interface by setting the `--use-pep517` option, (possibly combined with `--no-build-isolation`), or adding a `pyproject.toml` file to the source tree of 'ClusterShell'. Discussion can be found at https://github.com/pypa/pip/issues/6334
```

This is a follow up from #3470.