### PR TITLE
[feat] Add support for marking tests as expected failures

### DIFF
--- a/docs/regression_test_api.rst
+++ b/docs/regression_test_api.rst
@@ -27,6 +27,8 @@ Test Decorators
 
 .. autodecorator:: reframe.core.decorators.simple_test
 
+.. autodecorator:: reframe.core.decorators.xfail
+
 
 .. _builtins:
 
@@ -86,6 +88,7 @@ The use of this module is required only when creating new tests programmatically
 
 .. autofunction:: reframe.core.builtins.variable
 
+.. autofunction:: reframe.core.builtins.xfail
 
 .. _pipeline-hooks:
 

--- a/examples/tutorial/stream/stream_runonly_xfail.py
+++ b/examples/tutorial/stream/stream_runonly_xfail.py
@@ -1,0 +1,26 @@
+# Copyright 2016-2025 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# ReFrame Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+import reframe as rfm
+import reframe.utility.sanity as sn
+
+
+@rfm.simple_test
+@rfm.xfail('demo failure')
+class stream_test(rfm.RunOnlyRegressionTest):
+    valid_systems = ['*']
+    valid_prog_environs = ['*']
+    executable = 'stream.x'
+
+    @sanity_function
+    def validate(self):
+        return sn.assert_found(r'Slution Validates', self.stdout)
+
+    @performance_function('MB/s')
+    def copy_bw(self):
+        return sn.extractsingle(r'Copy:\s+(\S+)', self.stdout, 1, float)
+
+    @performance_function('MB/s')
+    def triad_bw(self):
+        return sn.extractsingle(r'Triad:\s+(\S+)', self.stdout, 1, float)

--- a/examples/tutorial/stream/stream_runonly_xfail_cond.py
+++ b/examples/tutorial/stream/stream_runonly_xfail_cond.py
@@ -1,0 +1,30 @@
+# Copyright 2016-2025 Swiss National Supercomputing Centre (CSCS/ETH Zurich)
+# ReFrame Project Developers. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+import reframe as rfm
+import reframe.utility.sanity as sn
+
+
+@rfm.simple_test
+@rfm.xfail('demo failure', lambda test: test.x <= 2)
+class stream_test(rfm.RunOnlyRegressionTest):
+    valid_systems = ['*']
+    valid_prog_environs = ['*']
+    executable = 'stream.x'
+    x = variable(int, value=1)
+
+    @sanity_function
+    def validate(self):
+        if self.x < 2 or self.x > 2:
+            return sn.assert_found(r'Slution Validates', self.stdout)
+        elif self.x == 2:
+            return sn.assert_found(r'Solution Validates', self.stdout)
+
+    @performance_function('MB/s')
+    def copy_bw(self):
+        return sn.extractsingle(r'Copy:\s+(\S+)', self.stdout, 1, float)
+
+    @performance_function('MB/s')
+    def triad_bw(self):
+        return sn.extractsingle(r'Triad:\s+(\S+)', self.stdout, 1, float)

--- a/reframe/core/builtins.py
+++ b/reframe/core/builtins.py
@@ -8,6 +8,8 @@
 #
 
 import functools
+from collections import namedtuple
+
 import reframe.core.parameters as parameters
 import reframe.core.variables as variables
 import reframe.core.fixtures as fixtures
@@ -19,7 +21,7 @@ from reframe.core.deferrable import deferrable, _DeferredPerformanceExpression
 __all__ = ['deferrable', 'deprecate', 'final', 'fixture', 'loggable',
            'loggable_as', 'parameter', 'performance_function', 'required',
            'require_deps', 'run_before', 'run_after', 'sanity_function',
-           'variable']
+           'variable', 'xfail']
 
 parameter = parameters.TestParam
 variable = variables.TestVar
@@ -221,3 +223,18 @@ def loggable_as(name):
 
 loggable = loggable_as(None)
 loggable.__doc__ = '''Equivalent to :func:`loggable_as(None) <loggable_as>`.'''
+
+_XFailReference = namedtuple('XFailReference', ['message', 'data'])
+
+
+def xfail(message, reference):
+    '''Mark a test :attr:`~reframe.core.pipeline.RegressionTest.reference` as
+    an expected failure.
+
+    :arg message: The message to issue when this expected failure is
+        encountered.
+    :arg reference: The original reference tuple.
+
+    .. versionadded:: 4.9
+    '''
+    return _XFailReference(message=message, data=reference)

--- a/reframe/core/exceptions.py
+++ b/reframe/core/exceptions.py
@@ -285,6 +285,14 @@ class SkipTestError(ReframeError):
     '''Raised when a test needs to be skipped.'''
 
 
+class ExpectedFailureError(ReframeError):
+    '''Raised when a test failure is expected'''
+
+
+class UnexpectedSuccessError(ReframeError):
+    '''Raised when a test unexpectedly passes'''
+
+
 def user_frame(exc_type, exc_value, tb):
     '''Return a user frame from the exception's traceback.
 

--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -13,7 +13,6 @@ __all__ = [
 ]
 
 
-import functools
 import glob
 import hashlib
 import inspect

--- a/reframe/frontend/executors/__init__.py
+++ b/reframe/frontend/executors/__init__.py
@@ -20,6 +20,7 @@ import reframe.frontend.dependencies as dependencies
 import reframe.utility.jsonext as jsonext
 import reframe.utility.typecheck as typ
 from reframe.core.exceptions import (AbortTaskError,
+                                     ExpectedFailureError,
                                      FailureLimitError,
                                      ForceExitError,
                                      JobNotStartedError,
@@ -27,7 +28,8 @@ from reframe.core.exceptions import (AbortTaskError,
                                      RunSessionTimeout,
                                      SkipTestError,
                                      StatisticsError,
-                                     TaskExit)
+                                     TaskExit,
+                                     UnexpectedSuccessError)
 from reframe.core.schedulers.local import LocalJobScheduler
 from reframe.frontend.printer import PrettyPrinter
 
@@ -64,6 +66,12 @@ class TestStats:
 
     def failed(self, run=-1):
         return [t for t in self.tasks(run) if t.failed]
+
+    def xfailed(self, run=-1):
+        return [t for t in self.tasks(run) if t.xfailed]
+
+    def xpassed(self, run=-1):
+        return [t for t in self.tasks(run) if t.xpassed]
 
     def skipped(self, run=-1):
         return [t for t in self.tasks(run) if t.skipped]
@@ -203,6 +211,9 @@ class RegressionTask:
         self._exc_info = (None, None, None)
         self._listeners = listeners or []
         self._skipped = False
+        self._xfailed = False
+        self._xpassed = False
+        self._aborted = False
 
         # Reference count for dependent tests; safe to cleanup the test only
         # if it is zero
@@ -213,8 +224,6 @@ class RegressionTask:
 
         # Timestamps for the start and finish phases of the pipeline
         self._timestamps = {}
-
-        self._aborted = False
 
         # Performance logging
         self._perflogger = logging.null_logger
@@ -291,12 +300,18 @@ class RegressionTask:
     @property
     def failed(self):
         return (self._failed_stage is not None and
-                not self._aborted and not self._skipped)
+                not self._aborted and not self._skipped and not self._xfailed)
 
     @property
     def state(self):
         if self.failed:
             return 'fail'
+
+        if self.xfailed:
+            return 'xfail'
+
+        if self.xpassed:
+            return 'xpass'
 
         if self.skipped:
             return 'skip'
@@ -324,7 +339,7 @@ class RegressionTask:
 
     @property
     def completed(self):
-        return self.failed or self.succeeded
+        return self.failed or self.succeeded or self.xfailed
 
     @property
     def aborted(self):
@@ -335,11 +350,23 @@ class RegressionTask:
         return self._skipped
 
     @property
+    def xfailed(self):
+        return self._xfailed
+
+    @property
+    def xpassed(self):
+        return self._xpassed
+
+    @property
     def result(self):
         if self.succeeded:
             return 'pass'
         elif self.failed:
             return 'fail'
+        elif self.xfailed:
+            return 'xfail'
+        elif self.xpassed:
+            return 'xpass'
         elif self.aborted:
             return 'abort'
         elif self.skipped:
@@ -387,6 +414,12 @@ class RegressionTask:
                 # This practically ignores skipping during the cleanup phase
                 self.skip()
                 raise TaskExit from e
+        except ExpectedFailureError as e:
+            self.xfail()
+            raise TaskExit from e
+        except UnexpectedSuccessError as e:
+            self.xpass()
+            raise TaskExit from e
         except ABORT_REASONS:
             self.fail()
             raise
@@ -511,6 +544,18 @@ class RegressionTask:
         self._exc_info = exc_info or sys.exc_info()
         self._notify_listeners('on_task_skip')
 
+    def xfail(self, exc_info=None):
+        self._xfailed = True
+        self._failed_stage = self._current_stage
+        self._exc_info = exc_info or sys.exc_info()
+        self._notify_listeners('on_task_xfailure')
+
+    def xpass(self, exc_info=None):
+        self._xpassed = True
+        self._failed_stage = self._current_stage
+        self._exc_info = exc_info or sys.exc_info()
+        self._notify_listeners('on_task_xsuccess')
+
     def abort(self, cause=None):
         if self.failed or self._aborted:
             return
@@ -567,6 +612,14 @@ class TaskEventListener(abc.ABC):
     @abc.abstractmethod
     def on_task_failure(self, task):
         '''Called when a RegressionTask has failed.'''
+
+    @abc.abstractmethod
+    def on_task_xfailure(self, task):
+        '''Called when a RegressionTask had an expected failure.'''
+
+    @abc.abstractmethod
+    def on_task_xsuccess(self, task):
+        '''Called when a RegressionTask had succeeded unexpectedly.'''
 
     @abc.abstractmethod
     def on_task_abort(self, task):
@@ -674,11 +727,14 @@ class Runner:
             total_run = self._stats.num_cases(runid)
             total_completed = len(self._stats.completed(runid))
             total_skipped = len(self._stats.skipped(runid))
+            total_xfailed = len(self._stats.xfailed(runid))
             self._printer.status(
                 status,
                 f'Ran {total_completed}/{total_run}'
                 f' test case(s) from {num_checks} check(s) '
-                f'({num_failures} failure(s), {total_skipped} skipped, '
+                f'({num_failures} failure(s), '
+                f'{total_xfailed} expected failure(s), '
+                f'{total_skipped} skipped, '
                 f'{num_aborted} aborted)',
                 just='center'
             )

--- a/reframe/frontend/executors/policies.py
+++ b/reframe/frontend/executors/policies.py
@@ -10,6 +10,7 @@ import time
 
 import reframe.core.runtime as rt
 import reframe.utility as util
+import reframe.utility.color as color
 from reframe.core.exceptions import (FailureLimitError,
                                      RunSessionTimeout,
                                      SkipTestError,
@@ -48,10 +49,25 @@ def _print_perf(task):
         rt.runtime().get_option('general/0/perf_info_level')
     )
     for key, info in perfvars.items():
+        val, ref, lower, upper, unit, result = info
         name = key.split(':')[-1]
-        getlogger().log(level,
-                        f'P: {name}: {info[0]} {info[4]} '
-                        f'(r:{info[1]}, l:{info[2]}, u:{info[3]})')
+        msg = f'P: {name}: {val} {unit} (r:{ref}, l:{lower}, u:{upper})'
+        if result == 'xfail':
+            msg = color.colorize(msg, color.MAGENTA)
+        elif result == 'fail' or result == 'xpass':
+            msg = color.colorize(msg, color.RED)
+
+        getlogger().log(level, msg)
+
+
+def _print_pipeline_timings(task):
+    timings = task.pipeline_timings(['setup',
+                                     'compile_complete',
+                                     'run_complete',
+                                     'sanity',
+                                     'performance',
+                                     'total'])
+    getlogger().verbose(f'==> {timings}')
 
 
 class _PollController:
@@ -84,7 +100,85 @@ class _PollController:
         )
 
 
-class SerialExecutionPolicy(ExecutionPolicy, TaskEventListener):
+class _PolicyEventListener(TaskEventListener):
+    def on_task_setup(self, task):
+        pass
+
+    def on_task_run(self, task):
+        pass
+
+    def on_task_compile(self, task):
+        pass
+
+    def on_task_exit(self, task):
+        pass
+
+    def on_task_compile_exit(self, task):
+        pass
+
+    def on_task_skip(self, task):
+        msg = f'{task.info()} [{task.exc_info[1]}]'
+        self.printer.status('SKIP', msg, just='right')
+
+    def on_task_abort(self, task):
+        msg = f'{task.info()}'
+        self.printer.status('ABORT', msg, just='right')
+
+    def on_task_xfailure(self, task):
+        msg = f'{task.info()} [{task.exc_info[1]}]'
+        self.printer.status('XFAIL', msg, just='right')
+        _print_perf(task)
+        if task.failed_stage == 'sanity':
+            # Dry-run the performance stage to trigger performance logging
+            task.performance(dry_run=True)
+
+        _print_pipeline_timings(task)
+
+    def on_task_failure(self, task):
+        self._num_failed_tasks += 1
+        msg = f'{task.info()}'
+        if task.failed_stage == 'cleanup':
+            self.printer.status('ERROR', msg, just='right')
+        else:
+            self.printer.status('FAIL', msg, just='right')
+
+        _print_perf(task)
+        if task.failed_stage == 'sanity':
+            # Dry-run the performance stage to trigger performance logging
+            task.performance(dry_run=True)
+
+        getlogger().info(f'==> test failed during {task.failed_stage!r}: '
+                         f'test staged in {task.check.stagedir!r}')
+        _print_pipeline_timings(task)
+        if self._num_failed_tasks >= self.max_failures:
+            raise FailureLimitError(
+                f'maximum number of failures ({self.max_failures}) reached'
+            )
+
+    def on_task_xsuccess(self, task):
+        msg = f'{task.info()}'
+        self.printer.status('XPASS', msg, just='right')
+        _print_perf(task)
+        if task.failed_stage == 'sanity':
+            # Dry-run the performance stage to trigger performance logging
+            task.performance(dry_run=True)
+
+        _print_pipeline_timings(task)
+
+    def on_task_success(self, task):
+        msg = f'{task.info()}'
+        self.printer.status('OK', msg, just='right')
+        _print_perf(task)
+        _print_pipeline_timings(task)
+
+        # Update reference count of dependencies
+        for c in task.testcase.deps:
+            # NOTE: Restored dependencies are not in the task_index
+            if c in self._task_index:
+                self._task_index[c].ref_count -= 1
+
+
+class SerialExecutionPolicy(ExecutionPolicy, _PolicyEventListener):
     def __init__(self):
         super().__init__()
 
@@ -167,78 +261,14 @@ class SerialExecutionPolicy(ExecutionPolicy, TaskEventListener):
         except BaseException:
             task.fail(sys.exc_info())
 
-    def on_task_setup(self, task):
-        pass
-
-    def on_task_run(self, task):
-        pass
-
-    def on_task_compile(self, task):
-        pass
-
-    def on_task_exit(self, task):
-        pass
-
-    def on_task_compile_exit(self, task):
-        pass
-
-    def on_task_skip(self, task):
-        msg = f'{task.info()} [{task.exc_info[1]}]'
-        self.printer.status('SKIP', msg, just='right')
-
-    def on_task_abort(self, task):
-        msg = f'{task.info()}'
-        self.printer.status('ABORT', msg, just='right')
-
-    def on_task_failure(self, task):
-        self._num_failed_tasks += 1
-        msg = f'{task.info()}'
-        if task.failed_stage == 'cleanup':
-            self.printer.status('ERROR', msg, just='right')
-        else:
-            self.printer.status('FAIL', msg, just='right')
-
-        _print_perf(task)
-        if task.failed_stage == 'sanity':
-            # Dry-run the performance stage to trigger performance logging
-            task.performance(dry_run=True)
-
-        timings = task.pipeline_timings(['setup',
-                                         'compile_complete',
-                                         'run_complete',
-                                         'sanity',
-                                         'performance',
-                                         'total'])
-        getlogger().info(f'==> test failed during {task.failed_stage!r}: '
-                         f'test staged in {task.check.stagedir!r}')
-        getlogger().verbose(f'==> {timings}')
-        if self._num_failed_tasks >= self.max_failures:
-            raise FailureLimitError(
-                f'maximum number of failures ({self.max_failures}) reached'
-            )
-
+    def on_task_success(self, task):
+        super().on_task_success(task)
+        _cleanup_all(self._retired_tasks, not self.keep_stage_files)
         if self.timeout_expired():
             raise RunSessionTimeout('maximum session duration exceeded')
 
-    def on_task_success(self, task):
-        msg = f'{task.info()}'
-        self.printer.status('OK', msg, just='right')
-        _print_perf(task)
-        timings = task.pipeline_timings(['setup',
-                                         'compile_complete',
-                                         'run_complete',
-                                         'sanity',
-                                         'performance',
-                                         'total'])
-        getlogger().verbose(f'==> {timings}')
-
-        # Update reference count of dependencies
-        for c in task.testcase.deps:
-            # NOTE: Restored dependencies are not in the task_index
-            if c in self._task_index:
-                self._task_index[c].ref_count -= 1
-
-        _cleanup_all(self._retired_tasks, not self.keep_stage_files)
+    def on_task_failure(self, task):
+        super().on_task_failure(task)
         if self.timeout_expired():
             raise RunSessionTimeout('maximum session duration exceeded')
 
@@ -247,7 +277,7 @@ class SerialExecutionPolicy(ExecutionPolicy, TaskEventListener):
         _cleanup_all(self._retired_tasks, not self.keep_stage_files)
 
 
-class AsynchronousExecutionPolicy(ExecutionPolicy, TaskEventListener):
+class AsynchronousExecutionPolicy(ExecutionPolicy, _PolicyEventListener):
     '''The asynchronous execution policy.'''
 
     def __init__(self):
@@ -451,7 +481,7 @@ class AsynchronousExecutionPolicy(ExecutionPolicy, TaskEventListener):
         if self.deps_skipped(task):
             try:
                 raise SkipTestError('skipped due to skipped dependencies')
-            except SkipTestError as e:
+            except SkipTestError:
                 task.skip()
                 self._current_tasks.remove(task)
                 return 1
@@ -587,70 +617,8 @@ class AsynchronousExecutionPolicy(ExecutionPolicy, TaskEventListener):
             with contextlib.suppress(FailureLimitError):
                 task.abort(cause)
 
-    # These function can be useful for tracking statistics of the framework,
-    # such as number of tests that have finished setup etc.
-    def on_task_setup(self, task):
-        pass
-
-    def on_task_run(self, task):
-        pass
-
-    def on_task_compile(self, task):
-        pass
-
     def on_task_exit(self, task):
         self._pollctl.reset_snooze_time()
 
     def on_task_compile_exit(self, task):
         self._pollctl.reset_snooze_time()
-
-    def on_task_skip(self, task):
-        msg = f'{task.info()} [{task.exc_info[1]}]'
-        self.printer.status('SKIP', msg, just='right')
-
-    def on_task_abort(self, task):
-        msg = f'{task.info()}'
-        self.printer.status('ABORT', msg, just='right')
-
-    def on_task_failure(self, task):
-        self._num_failed_tasks += 1
-        msg = f'{task.info()}'
-        if task.failed_stage == 'cleanup':
-            self.printer.status('ERROR', msg, just='right')
-        else:
-            self.printer.status('FAIL', msg, just='right')
-
-        _print_perf(task)
-        if task.failed_stage == 'sanity':
-            # Dry-run the performance stage to trigger performance logging
-            task.performance(dry_run=True)
-
-        timings = task.pipeline_timings(['setup',
-                                         'compile_complete',
-                                         'run_complete',
-                                         'sanity',
-                                         'performance',
-                                         'total'])
-        getlogger().info(f'==> test failed during {task.failed_stage!r}: '
-                         f'test staged in {task.check.stagedir!r}')
-        getlogger().verbose(f'==> {timings}')
-        if self._num_failed_tasks >= self.max_failures:
-            raise FailureLimitError(
-                f'maximum number of failures ({self.max_failures}) reached'
-            )
-
-    def on_task_success(self, task):
-        msg = f'{task.info()}'
-        self.printer.status('OK', msg, just='right')
-        _print_perf(task)
-        timings = task.pipeline_timings(['setup',
-                                         'compile_complete',
-                                         'run_complete',
-                                         'sanity',
-                                         'performance',
-                                         'total'])
-        getlogger().verbose(f'==> {timings}')
-        for c in task.testcase.deps:
-            # NOTE: Restored dependencies are not in the task_index
-            if c in self._task_index:
-                self._task_index[c].ref_count -= 1

--- a/reframe/frontend/printer.py
+++ b/reframe/frontend/printer.py
@@ -62,8 +62,10 @@ class PrettyPrinter:
         if self.colorize:
             if status_stripped in ('ABORT', 'ABORTED', 'DRY', 'SKIP'):
                 status = color.colorize(status, color.YELLOW)
-            elif status_stripped in ('FAIL', 'FAILED', 'ERROR'):
+            elif status_stripped in ('FAIL', 'FAILED', 'ERROR', 'XPASS'):
                 status = color.colorize(status, color.RED)
+            elif status_stripped == 'XFAIL':
+                status = color.colorize(status, color.MAGENTA)
             else:
                 status = color.colorize(status, color.GREEN)
 

--- a/reframe/utility/typecheck.py
+++ b/reframe/utility/typecheck.py
@@ -165,10 +165,11 @@ class _BuiltinType(ConvertibleType):
 
     def __instancecheck__(cls, inst):
         if hasattr(cls, '_types'):
-            return any(issubclass(type(inst), t) for t in cls._types)
+            return isinstance(inst, cls._types)
+            # return any(issubclass(type(inst), t) for t in cls._types)
 
         if hasattr(cls, '_xtype'):
-            return not issubclass(type(inst), cls._xtype)
+            return not isinstance(inst, cls._xtype)
 
         return issubclass(type(inst), cls)
 
@@ -236,6 +237,9 @@ class _TupleType(_SequenceType):
     '''
 
     def __instancecheck__(cls, inst):
+        if not super().__instancecheck__(inst):
+            return False
+
         if not issubclass(type(inst), cls):
             return False
 
@@ -295,6 +299,9 @@ class _MappingType(_BuiltinType):
         cls._namespace = namespace
 
     def __instancecheck__(cls, inst):
+        if not super().__instancecheck__(inst):
+            return False
+
         if not issubclass(type(inst), cls):
             return False
 

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -982,7 +982,8 @@ def test_maxfail_option(run_reframe):
     assert 'Traceback' not in stdout
     assert 'Traceback' not in stderr
     assert ('Ran 2/2 test case(s) from 2 check(s) '
-            '(0 failure(s), 0 skipped, 0 aborted)') in stdout
+            '(0 failure(s), 0 expected failure(s), '
+            '0 skipped, 0 aborted)') in stdout
     assert returncode == 0
 
 
@@ -1031,7 +1032,8 @@ def test_repeat_option(run_reframe, run_action):
     assert 'Traceback' not in stdout
     assert 'Traceback' not in stderr
     assert ('Ran 2/2 test case(s) from 2 check(s) '
-            '(0 failure(s), 0 skipped, 0 aborted)') in stdout
+            '(0 failure(s), 0 expected failure(s), '
+            '0 skipped, 0 aborted)') in stdout
     assert returncode == 0
 
 

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -423,6 +423,12 @@ class _TaskEventMonitor(executors.TaskEventListener):
     def on_task_success(self, task):
         pass
 
+    def on_task_xsuccess(self, task):
+        pass
+
+    def on_task_xfailure(self, task):
+        pass
+
     def on_task_failure(self, task):
         pass
 

--- a/unittests/test_sanity_functions.py
+++ b/unittests/test_sanity_functions.py
@@ -494,24 +494,24 @@ def test_assert_reference():
         assert sn.assert_reference(-1, -0.1, 0, 1.0)
 
     # Check invalid thresholds
-    with pytest.raises(SanityError,
+    with pytest.raises(ValueError,
                        match=r'invalid high threshold value: -0\.1'):
         sn.evaluate(sn.assert_reference(0.9, 1, -0.2, -0.1))
 
-    with pytest.raises(SanityError,
+    with pytest.raises(ValueError,
                        match=r'invalid low threshold value: 0\.2'):
         sn.evaluate(sn.assert_reference(0.9, 1, 0.2, 0.1))
 
-    with pytest.raises(SanityError,
+    with pytest.raises(ValueError,
                        match=r'invalid low threshold value: 1\.2'):
         sn.evaluate(sn.assert_reference(0.9, 1, 1.2, 0.1))
 
     # check invalid thresholds greater than 1
-    with pytest.raises(SanityError,
+    with pytest.raises(ValueError,
                        match=r'invalid low threshold value: -2\.0'):
         sn.evaluate(sn.assert_reference(0.9, 1, -2.0, 0.1))
 
-    with pytest.raises(SanityError,
+    with pytest.raises(ValueError,
                        match=r'invalid high threshold value: 1\.5'):
         sn.evaluate(sn.assert_reference(-1.5, -1, -0.5, 1.5))
 

--- a/unittests/test_typecheck.py
+++ b/unittests/test_typecheck.py
@@ -357,8 +357,8 @@ def test_composition_of_types():
     for t in composite_types:
         assert isinstance({1: 1}, t)
         assert isinstance({'1': 1}, t)
-        assert isinstance({1: [1]}, t)
-        assert isinstance({'1': 1.2}, t)
+        assert not isinstance({1: [1]}, t)
+        assert not isinstance({'1': 1.2}, t)
 
     # Test custom types
 


### PR DESCRIPTION
The main elements introduced by this PR are:

1. The `@xfail` decorator to mark a test as an expected sanity failure.
2. The `xfail()` builtin to mark reference tuples as expected performance failures.

Two new test states are introduced which are also logged: `XFAIL` for expected failures and `XPASS` for unexpected passes.

Design-wise the concept is the same as the one explained in [#2378](https://github.com/reframe-hpc/reframe/issues/2378#issuecomment-2770777765).

Implementation-wise there are two major changes:

1. The execution policies code is refactored by eliminating code duplication between the serial and asynchronous policies.
2. A new utility function `reference_bounds()` is introduced which is used to validate and calculate the absolute lower/upper bounds. This used to be internal to `assert_reference()` and now it's made public (maybe the docs there need a slight reorganization).
3. The treatment of performance failures is rewritten as now we have to handle much more complex cases, were the performance variables of a test can simultaneously be `pass`, `fail`, `xpass` or `xfail`.

For more details on how feature works macroscopically check the tutorial and the reference docs.

Closes #2378.