### PR TITLE
[bugfix] Include (again) partition name in test failure info

### DIFF
--- a/reframe/frontend/printer.py
+++ b/reframe/frontend/printer.py
@@ -122,7 +122,8 @@ class PrettyPrinter:
             self.info(f"FAILURE INFO for {rec['display_name']} "
                       f"(run: {runid}/{total_runs})")
             self.info(f"  * Description: {rec['descr']}")
-            self.info(f"  * System partition: {rec['system']}")
+            self.info("  * System partition: "
+                      f"{rec['system']}:{rec['partition']}")
             self.info(f"  * Environment: {rec['environ']}")
             self.info(f"  * Test file: {rec['filename']}")
             self.info(f"  * Stage directory: {rec['stagedir']}")


### PR DESCRIPTION
Closes #3485.

This was introduced in #3227.