### PR TITLE
[bugfix] Return `Job.jobid` as string always

### DIFF
--- a/reframe/core/schedulers/__init__.py
+++ b/reframe/core/schedulers/__init__.py
@@ -480,7 +480,7 @@ class Job(jsonext.JSONSerializable, metaclass=JobMeta):
 
         :type: :class:`str` or :class:`None`
         '''
-        return self._jobid
+        return str(self._jobid) if self._jobid is not None else None
 
     @property
     def exitcode(self):

--- a/reframe/core/schedulers/local.py
+++ b/reframe/core/schedulers/local.py
@@ -94,7 +94,7 @@ class LocalJobScheduler(sched.JobScheduler):
     def _kill_all(self, job):
         '''Send SIGKILL to all the processes of the spawned job.'''
         try:
-            os.killpg(job.jobid, signal.SIGKILL)
+            os.killpg(job._jobid, signal.SIGKILL)
             job._signal = signal.SIGKILL
         except (ProcessLookupError, PermissionError):
             # The process group may already be dead or assigned to a different
@@ -109,7 +109,7 @@ class LocalJobScheduler(sched.JobScheduler):
     def _term_all(self, job):
         '''Send SIGTERM to all the processes of the spawned job.'''
         try:
-            os.killpg(job.jobid, signal.SIGTERM)
+            os.killpg(job._jobid, signal.SIGTERM)
             job._signal = signal.SIGTERM
         except (ProcessLookupError, PermissionError):
             # Job has finished already, close file handles
@@ -160,11 +160,11 @@ class LocalJobScheduler(sched.JobScheduler):
             self._poll_job(job)
 
     def _poll_job(self, job):
-        if job is None or job.jobid is None:
+        if job is None or job._jobid is None:
             return
 
         try:
-            pid, status = os.waitpid(job.jobid, os.WNOHANG)
+            pid, status = os.waitpid(job._jobid, os.WNOHANG)
         except OSError as e:
             if e.errno == errno.ECHILD:
                 # No unwaited children


### PR DESCRIPTION
The `local` and `ssh` scheduler were returning it as an integer which is not according to the intended type of the `jobid` property: http://localhost:8000/regression_test_api.html#reframe.core.schedulers.Job.jobid

Closes #3482.