### PR TITLE
[enhancement] Skip tests if their dependencies fail

### DIFF
--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -1633,6 +1633,13 @@ The following list summarizes the schema changes (version numbers refer to schem
 
       Every reference tuple of ``.[].runs[].testcases[].perfvalues`` has now an additional element at the end, denoting the result (``pass`` or ``fail``) for the corresponding performance variable.
 
+   .. admonition:: 4.2
+
+      A new test ``result`` is introduced: ``fail_deps``, for when the dependencies of a test fail and the test is skipped.
+
+      Since ReFrame 4.9, if a test's dependencies fail, the test is skipped and is put in the ``fail_deps`` state.
+      Previously, it was treated as a normal failure.
+
 
 Environment
 ===========

--- a/reframe/core/exceptions.py
+++ b/reframe/core/exceptions.py
@@ -94,12 +94,6 @@ class TaskExit(ReframeError):
     '''Raised when a regression task must exit the pipeline prematurely.'''
 
 
-class TaskDependencyError(ReframeError):
-    '''Raised inside a regression task by the runtime when one of its
-    dependencies has failed.
-    '''
-
-
 class FailureLimitError(ReframeError):
     '''Raised when the limit of test failures has been reached.'''
 

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -1352,7 +1352,7 @@ def main():
                 if not rec:
                     return False
 
-                return rec['result'] == 'fail' or rec['result'] == 'abort'
+                return rec['result'] in {'fail', 'fail_deps', 'abort'}
 
             testcases = list(filter(_case_failed, testcases))
             printer.verbose(

--- a/reframe/frontend/printer.py
+++ b/reframe/frontend/printer.py
@@ -176,7 +176,7 @@ class PrettyPrinter:
                 continue
 
             for r in run_info['testcases']:
-                if r['result'] in {'pass', 'abort', 'skip'}:
+                if r['result'] in {'pass', 'abort', 'skip', 'fail_deps'}:
                     continue
 
                 _print_failure_info(r, run_no, len(report['runs']))
@@ -248,6 +248,10 @@ class PrettyPrinter:
         for run in reversed(report['runs'][1:]):
             runidx = run['run_index']
             for tc in run['testcases']:
+                if tc['result'] == 'fail_deps':
+                    # Ignore tests that were skipped due to failed deps
+                    continue
+
                 # Overwrite entry from previous run if available
                 tc_info = format_testcase_from_json(tc)
                 if tc_info not in retried_tc:

--- a/reframe/frontend/reporting/__init__.py
+++ b/reframe/frontend/reporting/__init__.py
@@ -32,7 +32,7 @@ from .utility import Aggregator, parse_cmp_spec, parse_query_spec
 # The schema data version
 # Major version bumps are expected to break the validation of previous schemas
 
-DATA_VERSION = '4.1'
+DATA_VERSION = '4.2'
 _SCHEMA = None
 _RESERVED_SESSION_INFO_KEYS = None
 _DATETIME_FMT = r'%Y%m%dT%H%M%S%z'

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -172,7 +172,7 @@ def test_check_restore_session_failed(run_reframe, tmp_path):
     )
     assert set(report.slice('name', when=('fail_phase', 'sanity'))) == {'T2'}
     assert set(report.slice('name',
-                            when=('fail_phase', 'startup'))) == {'T7', 'T9'}
+                            when=('result', 'fail_deps'))) == {'T7', 'T9'}
     assert set(report.slice('name', when=('fail_phase', 'setup'))) == {'T8'}
     assert report['runs'][-1]['num_cases'] == 4
 

--- a/unittests/test_policies.py
+++ b/unittests/test_policies.py
@@ -18,8 +18,7 @@ import unittests.utility as test_util
 from reframe.core.exceptions import (AbortTaskError,
                                      FailureLimitError,
                                      ForceExitError,
-                                     RunSessionTimeout,
-                                     TaskDependencyError)
+                                     RunSessionTimeout)
 from unittests.resources.checks.hellocheck import HelloTest
 from unittests.resources.checks.frontend_checks import (
     BadSetupCheck,
@@ -353,17 +352,13 @@ def assert_dependency_run(runner):
     assert_runall(runner)
     stats = runner.stats
     assert 10 == stats.num_cases(0)
-    assert 4  == len(stats.failed())
-    for tf in stats.failed():
-        check = tf.testcase.check
-        _, exc_value, _ = tf.exc_info
-        if check.name == 'T7' or check.name == 'T9':
-            assert isinstance(exc_value, TaskDependencyError)
+    assert 2  == len(stats.failed())
+    assert 2  == len(stats.skipped())
 
     # Check that cleanup is executed properly for successful tests as well
     for t in stats.tasks():
         check = t.testcase.check
-        if t.failed:
+        if t.failed or t.skipped:
             continue
 
         if t.ref_count == 0:
@@ -499,7 +494,7 @@ def test_concurrency_unlimited(make_async_runner, make_cases,
     #     assert begin_stamps[-1] <= end_stamps[0]
     #
     if begin_stamps[-1] > end_stamps[0]:
-        pytest.skip('the system seems too much loaded.')
+        pytest.skip('the system seems too loaded')
 
 
 def test_concurrency_limited(make_async_runner, make_cases,
@@ -543,7 +538,7 @@ def test_concurrency_limited(make_async_runner, make_cases,
     # corresponding strict check would be:
     # self.assertTrue(self.begin_stamps[max_jobs-1] <= self.end_stamps[0])
     if begin_stamps[max_jobs-1] > end_stamps[0]:
-        pytest.skip('the system seems too loaded.')
+        pytest.skip('the system seems too loaded')
 
 
 def test_concurrency_none(make_async_runner, make_cases,


### PR DESCRIPTION
When a test's dependencies fail, the test is now simply skipped and is put in a special state `fail_deps`. This is needed to be able to differentiate the tests that have been skipped due to failed dependencies in order to retry them in case of `--max-retries` or restore them with `--restore-session --failed`.

Closes #3480.