### PR TITLE
Improve logging of test case generation

### DIFF
--- a/reframe/frontend/executors/__init__.py
+++ b/reframe/frontend/executors/__init__.py
@@ -28,6 +28,7 @@ from reframe.core.exceptions import (AbortTaskError,
                                      SkipTestError,
                                      StatisticsError,
                                      TaskExit)
+from reframe.core.logging import getlogger
 from reframe.core.schedulers.local import LocalJobScheduler
 from reframe.frontend.printer import PrettyPrinter
 
@@ -174,11 +175,17 @@ def generate_testcases(checks, prepare=False):
 
     cases = []
     for c in checks:
+        getlogger().debug(
+            f'Resolving systems/environments for {c.display_name!r} with:'
+        )
+        getlogger().debug(f'  > valid_systems: {c.valid_systems}')
+        getlogger().debug(f'  > valid_prog_environs: {c.valid_prog_environs}')
         valid_comb = runtime.valid_sysenv_comb(c.valid_systems,
                                                c.valid_prog_environs)
         for part, environs in valid_comb.items():
             for env in environs:
                 case = TestCase(c, part, env)
+                getlogger().debug(f'  Generated test case: {case}')
                 if prepare:
                     case.prepare()
 
@@ -475,7 +482,7 @@ class RegressionTask:
             with open(jsonfile, 'w') as fp:
                 jsonext.dump(self.check, fp, indent=2)
         except OSError as e:
-            logging.getlogger().warning(
+            getlogger().warning(
                 f'could not dump test case {self.testcase}: {e}'
             )
 
@@ -485,7 +492,7 @@ class RegressionTask:
             self._perflogger.log_performance(logging.INFO, self,
                                              multiline=self._perflog_compat)
         except LoggingError as e:
-            logging.getlogger().warning(
+            getlogger().warning(
                 f'could not log performance data for {self.testcase}: {e}'
             )
 
@@ -501,7 +508,7 @@ class RegressionTask:
             self._perflogger.log_performance(logging.INFO, self,
                                              multiline=self._perflog_compat)
         except LoggingError as e:
-            logging.getlogger().warning(
+            getlogger().warning(
                 f'could not log performance data for {self.testcase}: {e}'
             )
 
@@ -515,7 +522,7 @@ class RegressionTask:
         if self.failed or self._aborted:
             return
 
-        logging.getlogger().debug2(f'Aborting test case: {self.testcase!r}')
+        getlogger().debug2(f'Aborting test case: {self.testcase!r}')
         exc = AbortTaskError()
         exc.__cause__ = cause
         self._aborted = True


### PR DESCRIPTION
Although we log the filtering of test cases by the various criteria, we don't log their generation and this can render difficult debugging errors in `valid_systems` and/or `valid_prog_environs`, where no test cases are generated. This PR logs this test case generation in more detail, so that debugging of such scenarios can be facilitated.