### PR TITLE
[bugfix] Disable file logging when emitting DB records

### DIFF
--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -971,6 +971,19 @@ class LoggerAdapter(logging.LoggerAdapter):
 
             h.setLevel(new_level)
 
+    def set_handler_level(self, level, filter=None):
+        '''Set handler level for handlers attached to this logger.
+
+        :arg level: The new level.
+        :arg filter: A callable accepting a single argument, which is the
+            handler type as declared in ReFrame's configuration. If the filter
+            is :obj:`None` then the level applies to all handlers, otherwise
+            it will apply to all handlers that the filter return :obj:`True`.
+        '''
+        for h in self.logger.handlers:
+            if filter is None or filter(h._rfm_type):
+                h.setLevel(level)
+
 
 # A logger that doesn't log anything
 null_logger = LoggerAdapter()

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -1040,6 +1040,8 @@ def main():
     if options.describe_stored_sessions:
         # Restore logging level
         printer.setLevel(logging.INFO)
+        printer.set_handler_level(logging.WARNING,
+                                  lambda htype: htype != 'stream')
         with exit_gracefully_on_error('failed to retrieve session data',
                                       printer):
             printer.info(jsonext.dumps(reporting.session_info(
@@ -1050,6 +1052,8 @@ def main():
     if options.describe_stored_testcases:
         # Restore logging level
         printer.setLevel(logging.INFO)
+        printer.set_handler_level(logging.WARNING,
+                                  lambda htype: htype != 'stream')
         namepatt = '|'.join(n.replace('%', ' %') for n in options.names)
         with exit_gracefully_on_error('failed to retrieve test case data',
                                       printer):

--- a/reframe/frontend/reporting/storage.py
+++ b/reframe/frontend/reporting/storage.py
@@ -228,6 +228,7 @@ class _SqliteStorage(StorageBackend):
 
         return session_uuid
 
+    @time_function
     def store(self, report, report_file=None):
         with self._db_lock():
             with self._db_connect(self._db_file()) as conn:


### PR DESCRIPTION
We essentially increase the log level to WARNING for all non-stream handlers while printing DB records.

Closes #3519.