### PR TITLE
[enhancement] Show more test attributes with `--describe`

### DIFF
--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -28,6 +28,7 @@ import reframe.utility as util
 import reframe.utility.jsonext as jsonext
 import reframe.utility.osext as osext
 import reframe.utility.typecheck as typ
+from reframe.core.warnings import suppress_deprecations
 from reframe.frontend.testgenerators import (distribute_tests,
                                              getallnodes, repeat_tests,
                                              parameterize_tests)
@@ -149,13 +150,18 @@ def describe_checks(testcases, printer):
             #
             # 1. Add other fields that are relevant for users
             # 2. Remove all private fields
-            rec['name'] = tc.check.name
-            rec['unique_name'] = tc.check.unique_name
-            rec['display_name'] = tc.check.display_name
+            cls = type(tc.check)
+            if hasattr(cls, 'loggable_attrs'):
+                for name, alt_name in cls.loggable_attrs():
+                    key = alt_name if alt_name else name
+                    try:
+                        with suppress_deprecations():
+                            rec.setdefault(key, getattr(tc.check, name))
+                    except AttributeError:
+                        rec.setdefault(key, '<undefined>')
+
             rec['pipeline_hooks'] = {}
             rec['perf_variables'] = list(rec['perf_variables'].keys())
-            rec['prefix'] = tc.check.prefix
-            rec['variant_num'] = tc.check.variant_num
             for stage, hooks in tc.check.pipeline_hooks().items():
                 for hk in hooks:
                     if hk.__name__ not in tc.check.disabled_hooks:


### PR DESCRIPTION
Currently, all the loggable properties are skipped. This PR fixes this by showing all loggable attributes and therefore any loggable properties. This is the same information that is also logged in the report.