### PR TITLE
[feat] Add new `--param-values-delim` option

### DIFF
--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -1083,6 +1083,14 @@ The way the tests are generated and how they interact with the test filtering op
 
    .. versionadded:: 4.3
 
+.. option:: --param-values-delim=<delim>
+
+   Use the given delimiter to separate the parameter values passed with :option:`--parameterize`.
+
+   Default delimiter is ``,``.
+
+   .. versionadded:: 4.9
+
 .. option:: --repeat=N
 
    Repeat the selected tests ``N`` times.

--- a/reframe/frontend/cli.py
+++ b/reframe/frontend/cli.py
@@ -623,6 +623,10 @@ def main():
         default=[], help='Parameterize a test on a set of variables'
     )
     testgen_options.add_argument(
+        '--param-values-delim', action='store', default=',',
+        help='Parameter value delimiter'
+    )
+    testgen_options.add_argument(
         '--repeat', action='store', metavar='N',
         help='Repeat selected tests N times'
     )
@@ -1382,7 +1386,7 @@ def main():
                         f'invalid parameter spec: {param_spec}'
                     ) from None
                 else:
-                    params[var] = values_spec.split(',')
+                    params[var] = values_spec.split(options.param_values_delim)
 
             testcases_all = parameterize_tests(testcases, params)
             testcases = testcases_all

--- a/unittests/test_cli.py
+++ b/unittests/test_cli.py
@@ -1086,6 +1086,20 @@ def test_parameterize_tests(run_reframe):
     assert descr == ['msg=hello1', 'msg=hello2']
 
 
+def test_parameterize_values_delim(run_reframe):
+    returncode, stdout, _ = run_reframe(
+        more_options=['-P', 'descr=hello1,hello2/hello3',
+                      '--param-values-delim=/', '-n', '^HelloTest'],
+        checkpath=['unittests/resources/checks/hellocheck.py'],
+        action='describe'
+    )
+    assert returncode == 0
+
+    test_json = json.loads(stdout)
+    descr = [t['descr'] for t in test_json]
+    assert descr == ['hello1,hello2', 'hello3']
+
+
 def test_parameterize_tests_invalid_params(run_reframe):
     returncode, stdout, stderr = run_reframe(
         more_options=['-P', 'num_tasks', '-n', '^HelloTest'],


### PR DESCRIPTION
This will allow users to customize the delimiter for parameter values passed with the `-P` option.

Closes #3264.