### PR TITLE
[bugfix] Fix config error when `authorization_header` is not set in the `httpjson` handler

### DIFF
--- a/reframe/core/logging.py
+++ b/reframe/core/logging.py
@@ -716,7 +716,8 @@ class HTTPJSONHandler(logging.Handler):
                 "it must be 'json_formatter(record, extras, ignore_keys)'"
             )
 
-        if not is_trivially_callable(authorization_header):
+        if (authorization_header is not None and
+            not is_trivially_callable(authorization_header)):
             raise ConfigError(
                 "httpjson: 'authorization_header' has the wrong signature: "
                 "it must be 'authorization_header()'"


### PR DESCRIPTION
Reframe would raise a config error when `authorization_header` is not set in the `httpjson` handler.
```
ERROR: failed to load configuration: httpjson: 'authorization_header' has the wrong signature: it must be 'authorization_header()'
```