### PR TITLE
[bugfix] Fix reporting of failing performance variables when test defines multiple figures of merit

### DIFF
--- a/reframe/core/pipeline.py
+++ b/reframe/core/pipeline.py
@@ -3180,6 +3180,7 @@ class RegressionTest(RegressionTestPlugin, jsonext.JSONSerializable):
         # Check the performance variables against their references.
         errors = _PerfErrorBuilder()
         for key, values in self._perfvalues.items():
+            tag = key.split(':')[-1]
             val, ref, low_thres, high_thres, unit, _ = values
 
             # Verify that val is a number

--- a/unittests/test_pipeline.py
+++ b/unittests/test_pipeline.py
@@ -2348,7 +2348,17 @@ def test_perf_expected_failures(perftest, sanity_file, perf_file,
     if exctype is None:
         _run_sanity(perftest, *local_exec_ctx)
     else:
-        with pytest.raises(exctype):
+        def _validate_exc(err):
+            if value2_status == 'pass':
+                print(err)
+                return 'value2' not in err.args[0]
+            if value1_status == 'pass':
+                print(err)
+                return 'value1' not in err.args[0]
+
+            return True
+
+        with pytest.raises(exctype, check=_validate_exc):
             _run_sanity(perftest, *local_exec_ctx)
 
 


### PR DESCRIPTION
This also adapts the existing unit tests to catch the original error.

Closes #3712.