### PR TITLE
[bugfix] Fix possible DB deadlock when creating indexes

### DIFF
--- a/reframe/frontend/reporting/storage.py
+++ b/reframe/frontend/reporting/storage.py
@@ -171,7 +171,7 @@ class _SqliteStorage(StorageBackend):
     def _db_create_indexes(self):
         clsname = type(self).__name__
         getlogger().debug(f'{clsname}: creating database indexes if needed')
-        with self._db_connect(self.__db_file) as conn:
+        with self._db_write(self.__db_file) as conn:
             conn.execute('CREATE INDEX IF NOT EXISTS index_testcases_time '
                          'on testcases(job_completion_time_unix)')
             conn.execute('CREATE TABLE IF NOT EXISTS metadata('


### PR DESCRIPTION
When creating the DB indexes upon every DB file connection, ReFrame did not acquire the write lock as it ought to. This could lead to deadlocks in cases of contentions.

This was introduced in #3546.