### PR TITLE
[bugfix] More robust configuration check before attempting to load it

### DIFF
--- a/reframe/core/config.py
+++ b/reframe/core/config.py
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+import ast
 import contextlib
 import copy
 import fnmatch
@@ -71,6 +72,21 @@ def _normalize_syntax(conv):
         return _get
 
     return _do_normalize
+
+
+class PythonConfigValidator(ast.NodeVisitor):
+    def __init__(self):
+        self._has_site_config = False
+
+    @property
+    def valid(self):
+        return self._has_site_config
+
+    def visit_Assign(self, node):
+        for target in node.targets:
+            if (isinstance(target, ast.Name) and
+                target.id == 'site_configuration'):
+                self._has_site_config = True
 
 
 class _SiteConfig:
@@ -341,7 +357,19 @@ class _SiteConfig:
     def subconfig_system(self):
         return self._local_system
 
+    def _validate_config_python(self, filename):
+        with open(filename) as fp:
+            source_tree = ast.parse(fp.read(), filename=filename)
+
+        validator = PythonConfigValidator()
+        validator.visit(source_tree)
+        if not validator.valid:
+            raise ConfigError(
+                f"'{filename}' is not a valid Python configuration file"
+            )
+
     def load_config_python(self, filename):
+        self._validate_config_python(filename)
         try:
             mod = util.import_module_from_file(filename, load_parents=True)
         except ImportError as e:

--- a/unittests/test_config.py
+++ b/unittests/test_config.py
@@ -78,6 +78,14 @@ def test_load_config_python():
     assert len(site.sources) == 2
 
 
+def test_load_config_python_invalid():
+    # Try to load a test file as a configuration file, which is a common
+    # mistake that the static configuration validation should catch.
+    with pytest.raises(ConfigError,
+                       match=r'not a valid Python configuration file'):
+        config.load_config('unittests/resources/checks/hellocheck.py')
+
+
 def test_load_multiple_configs(generate_partial_configs):
     site = config.load_config(*generate_partial_configs)
     assert len(site.sources) == 4
@@ -93,14 +101,6 @@ def test_load_config_nouser(monkeypatch):
     monkeypatch.delenv('LNAME', raising=False)
     monkeypatch.delenv('USERNAME', raising=False)
     config.load_config()
-
-
-def test_load_config_python_invalid(tmp_path):
-    pyfile = tmp_path / 'settings.py'
-    pyfile.write_text('x = 1\n')
-    with pytest.raises(ConfigError,
-                       match=r'not a valid Python configuration file'):
-        config.load_config(pyfile)
 
 
 def test_load_config_json(tmp_path):
@@ -122,14 +122,6 @@ def test_load_config_json_invalid_syntax(tmp_path):
 def test_load_config_unknown_file(tmp_path):
     with pytest.raises(OSError):
         config.load_config(tmp_path / 'foo.json')
-
-
-def test_load_config_import_error():
-    # If the configuration file is relative to ReFrame and ImportError is
-    # raised, which should be wrapped inside ConfigError
-    with pytest.raises(ConfigError,
-                       match=r'could not load Python configuration file'):
-        config.load_config('reframe/core/foo.py')
 
 
 def test_load_config_unknown_filetype(tmp_path):


### PR DESCRIPTION
Now we statically check the configuration file by looking for the top-level `site_configuration` assignment before attempting to load it. Unit tests were adapted.

Closes #3708.