### PR TITLE
[feat] Support version-like environment names

### DIFF
--- a/reframe/schemas/config.json
+++ b/reframe/schemas/config.json
@@ -11,6 +11,10 @@
             "type": "string",
             "pattern": "^[a-zA-Z_](?:[a-zA-Z0-9_-])*$"
         },
+        "alphanum_ext_vers_string": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_](?:[a-zA-Z0-9_.-])*$"
+        },
         "system_ref": {
             "type": "array",
             "items": {"type": "string"}
@@ -389,7 +393,7 @@
             "items": {
                 "type": "object",
                 "properties": {
-                    "name": {"$ref": "#/defs/alphanum_ext_string"},
+                    "name": {"$ref": "#/defs/alphanum_ext_vers_string"},
                     "modules": {"$ref": "#/defs/modules_list"},
                     "env_vars": {"$ref": "#/defs/envvar_list"},
                     "variables": {"$ref": "#/defs/envvar_list"},


### PR DESCRIPTION
This relaxes the validation schema for environment names to allow, for instance, `foo-1.0.0`, `2026.09.0`.

Fixes #3645.